### PR TITLE
Removing AudioScience specific include paths

### DIFF
--- a/controller/app/build/msvc/avdecc_controller_cmd_line_main/avdecc_controller_cmd_line_main/avdecc_controller_cmd_line_main.vcxproj
+++ b/controller/app/build/msvc/avdecc_controller_cmd_line_main/avdecc_controller_cmd_line_main/avdecc_controller_cmd_line_main.vcxproj
@@ -56,12 +56,12 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>\asi\sw\avdecc-lib\controller\app\cmdline\src;\asi\sw\avdecc-lib\controller\lib\include;\asi\sw\avdecc-lib\controller\lib\src\msvc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\..\..\..\cmdline\src;$(ProjectDir)\..\..\..\..\..\lib\include;$(ProjectDir)\..\..\..\..\..\lib\src\msvc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>\asi\sw\avdecc-lib\controller\lib\bin\avdecc_controller_lib32_debug\avdecc_controller_lib32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(ProjectDir)\..\..\..\..\..\lib\bin\avdecc_controller_lib32_debug\avdecc_controller_lib32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">

--- a/controller/lib/build/msvc/avdecc_controller_lib32/avdecc_controller_lib32.vcxproj
+++ b/controller/lib/build/msvc/avdecc_controller_lib32/avdecc_controller_lib32.vcxproj
@@ -40,7 +40,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>false</LinkIncremental>
     <OutDir>..\..\..\bin\avdecc_controller_lib32_debug\</OutDir>
-    <IncludePath>$(JDKSAVDECC_DIR)\include;$(WPCAP_DIR)\Include;$(IncludePath)</IncludePath>
+    <IncludePath>$(JDKSAVDECC_DIR)\include;$(WPCAP_DIR)\Include;$(ProjectDir)\..\..\..\include;$(ProjectDir)\..\..\..\src;$(ProjectDir)\..\..\..\src\msvc;$(IncludePath)</IncludePath>
     <LibraryPath>$(WPCAP_DIR)\Lib;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -56,7 +56,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;AVDECC_CONTROLLER_LIB32_EXPORTS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>\asi\sw\avdecc-lib\controller\lib\include;\asi\sw\avdecc-lib\controller\lib\src;\asi\sw\avdecc-lib\controller\lib\src\msvc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
Now uses paths relative to the project dir
