### PR TITLE
AECP messages are now unicast to the end station MAC

### DIFF
--- a/controller/lib/src/aecp.cpp
+++ b/controller/lib/src/aecp.cpp
@@ -27,6 +27,7 @@
  * AVDECC Enumeration and Control Protocol implementation
  */
 
+#include "net_interface_imp.h"
 #include "enumeration.h"
 #include "log.h"
 #include "util.h"
@@ -55,7 +56,7 @@ namespace avdecc_lib
 		free(aecp_frame);
 	}
 
-	int aecp::ether_frame_init(adp *adp_ref, struct jdksavdecc_frame *ether_frame)
+	int aecp::ether_frame_init(end_station *end_station, struct jdksavdecc_frame *ether_frame)
 	{
 		/*** Offset to write the field to ***/
 		size_t ether_frame_pos = 0x0;
@@ -63,8 +64,8 @@ namespace avdecc_lib
 
 		/***************************** Ethernet Frame ****************************/
 		ether_frame->ethertype = JDKSAVDECC_AVTP_ETHERTYPE;
-		ether_frame->src_address = adp_ref->get_src_mac_addr();
-		ether_frame->dest_address = adp_ref->get_dest_addr();
+		convert_uint64_to_eui48(net_interface_ref->get_mac(), ether_frame->src_address.value);
+		convert_uint64_to_eui48(end_station->get_end_station_mac(), ether_frame->dest_address.value);
 		ether_frame->length = AECP_FRAME_LEN; // Length of AECP packet is 64 bytes
 
 		/*********************** Fill frame payload with Ethernet frame information ********************/

--- a/controller/lib/src/aecp.h
+++ b/controller/lib/src/aecp.h
@@ -33,6 +33,7 @@
 
 #include "jdksavdecc_aecp_aem.h"
 #include "jdksavdecc_aem_command.h"
+#include "end_station.h"
 
 namespace avdecc_lib
 {
@@ -73,7 +74,7 @@ namespace avdecc_lib
 		/**
 		 * Initialize and fill Ethernet frame payload with Ethernet frame information for AEM commands.
 		 */
-		static int ether_frame_init(adp *adp_ref, struct jdksavdecc_frame *ether_frame);
+		static int ether_frame_init(end_station *end_station, struct jdksavdecc_frame *ether_frame);
 
 		/**
 		 * Initialize and fill Ethernet frame payload with 1722 AECP Header information.

--- a/controller/lib/src/audio_unit_descriptor_imp.cpp
+++ b/controller/lib/src/audio_unit_descriptor_imp.cpp
@@ -321,7 +321,7 @@ namespace avdecc_lib
 		aem_cmd_get_sampling_rate.descriptor_index = desc_index;
 
 		/******************************** Fill frame payload with AECP data and send the frame ***************************/
-		aecp::ether_frame_init(base_end_station_imp_ref->get_adp(), ether_frame);
+		aecp::ether_frame_init(base_end_station_imp_ref, ether_frame);
 		aem_cmd_get_sampling_rate_returned = jdksavdecc_aem_command_get_sampling_rate_write(&aem_cmd_get_sampling_rate,
 		                                                                                    ether_frame->payload,
 		                                                                                    aecp::CMD_POS,

--- a/controller/lib/src/end_station_imp.cpp
+++ b/controller/lib/src/end_station_imp.cpp
@@ -137,7 +137,7 @@ namespace avdecc_lib
 		aem_command_read_desc.descriptor_index = desc_index;
 
 		/******************************* Fill frame payload with AECP data and send the frame ****************************/
-		aecp::ether_frame_init(adp_ref, ether_frame);
+		aecp::ether_frame_init(this, ether_frame);
 		aem_command_read_desc_returned = jdksavdecc_aem_command_read_descriptor_write(&aem_command_read_desc,
 		                                                                              ether_frame->payload,
 		                                                                              aecp::CMD_POS,

--- a/controller/lib/src/stream_input_descriptor_imp.cpp
+++ b/controller/lib/src/stream_input_descriptor_imp.cpp
@@ -247,7 +247,7 @@ namespace avdecc_lib
 		aem_cmd_set_stream_format.stream_format = jdksavdecc_eui64_get(&new_stream_format, 0);
 
 		/******************************** Fill frame payload with AECP data and send the frame ***************************/
-		aecp::ether_frame_init(base_end_station_imp_ref->get_adp(), ether_frame);
+		aecp::ether_frame_init(base_end_station_imp_ref, ether_frame);
 		aem_cmd_set_stream_format_returned = jdksavdecc_aem_command_set_stream_format_write(&aem_cmd_set_stream_format,
 		                                                                                    ether_frame->payload,
 		                                                                                    aecp::CMD_POS,
@@ -319,7 +319,7 @@ namespace avdecc_lib
 		aem_cmd_get_stream_format.descriptor_index = desc_index;
 
 		/******************************** Fill frame payload with AECP data and send the frame ***************************/
-		aecp::ether_frame_init(base_end_station_imp_ref->get_adp(), ether_frame);
+		aecp::ether_frame_init(base_end_station_imp_ref, ether_frame);
 		aem_cmd_get_stream_format_returned = jdksavdecc_aem_command_get_stream_format_write(&aem_cmd_get_stream_format,
 		                                                                                    ether_frame->payload,
 		                                                                                    aecp::CMD_POS,
@@ -408,7 +408,7 @@ namespace avdecc_lib
 		}*/
 
 		/************************** Fill frame payload with AECP data and send the frame *****************************/
-		aecp::ether_frame_init(base_end_station_imp_ref->get_adp(), ether_frame);
+		aecp::ether_frame_init(base_end_station_imp_ref, ether_frame);
 		aem_cmd_set_stream_info_returned = jdksavdecc_aem_command_set_stream_info_write(&aem_cmd_set_stream_info,
 		                                                                                ether_frame->payload,
 		                                                                                aecp::CMD_POS,
@@ -479,7 +479,7 @@ namespace avdecc_lib
 		aem_cmd_get_stream_info.descriptor_index = desc_index;
 
 		/************************** Fill frame payload with AECP data and send the frame *****************************/
-		aecp::ether_frame_init(base_end_station_imp_ref->get_adp(), ether_frame);
+		aecp::ether_frame_init(base_end_station_imp_ref, ether_frame);
 		aem_cmd_get_stream_info_returned = jdksavdecc_aem_command_get_stream_info_write(&aem_cmd_get_stream_info,
 		                                                                                ether_frame->payload,
 		                                                                                aecp::CMD_POS,

--- a/controller/lib/src/stream_output_descriptor_imp.cpp
+++ b/controller/lib/src/stream_output_descriptor_imp.cpp
@@ -244,7 +244,7 @@ namespace avdecc_lib
 		aem_cmd_set_stream_format.stream_format = jdksavdecc_eui64_get(&new_stream_format, 0);
 
 		/******************************** Fill frame payload with AECP data and send the frame ***************************/
-		aecp::ether_frame_init(base_end_station_imp_ref->get_adp(), ether_frame);
+		aecp::ether_frame_init(base_end_station_imp_ref, ether_frame);
 		aem_cmd_set_stream_format_returned = jdksavdecc_aem_command_set_stream_format_write(&aem_cmd_set_stream_format,
 		                                                                                    ether_frame->payload,
 		                                                                                    aecp::CMD_POS,
@@ -315,7 +315,7 @@ namespace avdecc_lib
 		aem_cmd_get_stream_format.descriptor_index = desc_index;
 
 		/******************************** Fill frame payload with AECP data and send the frame ***************************/
-		aecp::ether_frame_init(base_end_station_imp_ref->get_adp(), ether_frame);
+		aecp::ether_frame_init(base_end_station_imp_ref, ether_frame);
 		aem_cmd_get_stream_format_returned = jdksavdecc_aem_command_get_stream_format_write(&aem_cmd_get_stream_format,
 		                                                                                    ether_frame->payload,
 		                                                                                    aecp::CMD_POS,
@@ -403,7 +403,7 @@ namespace avdecc_lib
 		}*/
 
 		/************************** Fill frame payload with AECP data and send the frame *****************************/
-		aecp::ether_frame_init(base_end_station_imp_ref->get_adp(), ether_frame);
+		aecp::ether_frame_init(base_end_station_imp_ref, ether_frame);
 		aem_cmd_set_stream_info_returned = jdksavdecc_aem_command_set_stream_info_write(&aem_cmd_set_stream_info,
 		                                                                                ether_frame->payload,
 		                                                                                aecp::CMD_POS,
@@ -473,7 +473,7 @@ namespace avdecc_lib
 		aem_cmd_get_stream_info.descriptor_index = desc_index;
 
 		/************************** Fill frame payload with AECP data and send the frame *****************************/
-		aecp::ether_frame_init(base_end_station_imp_ref->get_adp(), ether_frame);
+		aecp::ether_frame_init(base_end_station_imp_ref, ether_frame);
 		aem_cmd_get_stream_info_returned = jdksavdecc_aem_command_get_stream_info_write(&aem_cmd_get_stream_info,
 		                                                                                ether_frame->payload,
 		                                                                                aecp::CMD_POS,


### PR DESCRIPTION
Previously they were being incorrectly sent to the ADP multicast destination address.
