### PR TITLE
Preventing recursive destructor call causing segfault (mac/linux).

### DIFF
--- a/controller/lib/src/linux/system_layer2_multithreaded_callback.cpp
+++ b/controller/lib/src/linux/system_layer2_multithreaded_callback.cpp
@@ -114,6 +114,9 @@ namespace avdecc_lib
 
     void STDCALL system_layer2_multithreaded_callback::destroy()
     {
+        if (this == local_system)
+          local_system = NULL;
+
         delete this;
     }
 

--- a/controller/lib/src/osx/system_layer2_multithreaded_callback.cpp
+++ b/controller/lib/src/osx/system_layer2_multithreaded_callback.cpp
@@ -119,6 +119,9 @@ namespace avdecc_lib
 
     void STDCALL system_layer2_multithreaded_callback::destroy()
     {
+        if (this == local_system)
+          local_system = NULL;
+
         delete this;
     }
 


### PR DESCRIPTION
local_system is deleted by calling destroy(), but this caused a segfault (stack overflow) as the destructor was called recursively.
