### PR TITLE
include cinttypes instead of inttypes.h to fix linux x64 build error whe...

### DIFF
--- a/controller/app/cmdline/src/cli_argument.cpp
+++ b/controller/app/cmdline/src/cli_argument.cpp
@@ -29,6 +29,7 @@
  */
 
 #include <assert.h>
+#include <cinttypes>
 
 #include "controller.h"
 #include "end_station.h"
@@ -217,7 +218,7 @@ void cli_argument_end_station::get_completion_options(std::set<std::string> &opt
     {
         char entity_id_str[20];
         avdecc_lib::end_station *end_station = controller->get_end_station_by_index(i);
-        sprintf(entity_id_str, "0x%llx", end_station->entity_id());
+        sprintf(entity_id_str, "0x%"  PRIx64, end_station->entity_id());
         options.insert(std::string(entity_id_str));
     }
 }

--- a/controller/app/cmdline/src/cmd_line_main.cpp
+++ b/controller/app/cmdline/src/cmd_line_main.cpp
@@ -34,7 +34,7 @@
 #include <string>
 #include <vector>
 #include <cstdint>
-#include <inttypes.h>
+#include <cinttypes>
 
 #include <stdexcept>
 #include "cmd_line.h"


### PR DESCRIPTION
...n parsing PRIx64
