### PR TITLE
Ensure that notifications actually cause a wait.

### DIFF
--- a/controller/lib/src/cmd_wait_mgr.cpp
+++ b/controller/lib/src/cmd_wait_mgr.cpp
@@ -45,6 +45,7 @@ namespace avdecc_lib
             return -1;
         else
         {
+            notify_id = id;
             state = wait_primed;
             return 0;
         }


### PR DESCRIPTION
I found that running the our automated tests with the latest controller there was a failure in that 'show connections' printed nothing on the first time and then did after that. Digging a bit deeper it showed that the waiting for command completion was not working any more. I think this is the fix that is required.
