### PR TITLE
lib: controller: add mutex around endpoint vector lookup

### DIFF
--- a/controller/lib/src/controller_imp.h
+++ b/controller/lib/src/controller_imp.h
@@ -33,10 +33,12 @@
 
 namespace avdecc_lib
 {
+    class end_stations;
+
     class controller_imp : public virtual controller
     {
     private:
-        std::vector<end_station_imp *> end_station_vec; // Store a list of End Station objects
+        end_stations *end_station_array;
 
         /**
          * Find an end station that matches the entity and controller IDs


### PR DESCRIPTION
In previous version of the code the discovery thread could add an endpoint,
causing the endpoint vector to be re-allocated at the exact time a foreground
thread was looking up an endpoint. This version gets around this possible issue
by using a mutex in the lookup process. Note, actual endpoint class accesses are
fine because they use a pointer to the endpoint class and the endpoint class itself
is never moved in memory.
