### PR TITLE
lib: controller: function end_station_imp *at(size_t i) now uses lock_guard

### DIFF
--- a/controller/lib/src/controller_imp.cpp
+++ b/controller/lib/src/controller_imp.cpp
@@ -80,9 +80,8 @@ namespace avdecc_lib
         end_station_imp *at(size_t i)
         {
             end_station_imp * ep;
-            locker.lock();
+            std::lock_guard<std::mutex> guard(locker);
             ep = end_station_vec.at(i);
-            locker.unlock();
             return ep;
         };
         void push_back(end_station_imp *ep)


### PR DESCRIPTION
Previous implementation used a plain mutex, which could be left in a locked state
if the .at(i) operation caused an exception.
