### PR TITLE
Descriptor issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,18 @@ To read the name of the first input jack, one would go:
 
 	controller->end_station(0)->entity(0)->configuration(0)->input_stream(0)->get_name(name)
 
+Release 0.6 update:
+
+To avoid the possible issue of an asynchronous response thread updating a descriptor value while it is being read
+in the cmdline, a new AEM descriptor read process has been implemented.  All the methods required to read each descriptor
+are separated into response classes, which read the descriptor values from a stored response frame. 
+
+To read the current sampling rate from an audio unit descriptor:
+    
+    avdecc_lib::audio_unit_descriptor_response *audio_unit_resp_ref = audio_unit_desc_ref->get_audio_unit_response();
+    audio_unit_resp_ref->current_sampling_rate();
+    delete audio_unit_resp_ref;
+
 AVDECC AEM commands
 -------------------
 
@@ -234,6 +246,19 @@ sequence is to wait for the callback to complete in-line, ie:
 
 The above examples place an uint32_t notify_id in a "void *" container. If the application writer is careful about
 object creation and destruction, they may choose to place a C++ (or other language) object in the notify_id field.
+
+Release 0.6 update:
+
+Similar to descriptors, AVDECC command response processing has been altered to account for the possibility of an
+asynchronous response writing to a memory location while it is being read in the cmdline.  So far, GET_ commands 
+that return a value (e.g. get_counters) have been updated to return their response in a response class.
+
+To read the locked counter from clock domain counters:
+
+    avdecc_lib::clock_domain_counters_response *clock_domain_counters_resp = clock_domain_desc_ref->get_clock_domain_counters_response();
+    if(clock_domain_counters_resp->get_counter_valid(avdecc_lib::CLOCK_DOMAIN_LOCKED))
+        atomic_cout << "Locked Counter: " << clock_domain_counters_resp->get_counter_by_name(avdecc_lib::CLOCK_DOMAIN_LOCKED) << std::endl;
+    delete clock_domain_counters_resp;
 
 Callbacks
 ---------

--- a/controller/app/cmdline/src/cmd_line.cpp
+++ b/controller/app/cmdline/src/cmd_line.cpp
@@ -949,7 +949,7 @@ int cmd_line::cmd_list(int total_matched, std::vector<cli_argument*> args)
                             << std::setw(16) << std::hex << std::setfill('0') << end_station_entity_id << "  |  "
                             << std::setw(16) << std::hex << std::setfill(' ') << (ent_desc_resp ? fw_ver : "UNKNOWN") << "  |  "
                             << std::setw(12) << std::hex << std::setfill('0') << end_station_mac).rdbuf() << std::endl;
-            free(ent_desc_resp);
+            delete(ent_desc_resp);
         }
     }
 
@@ -993,7 +993,7 @@ int cmd_line::cmd_view_media_clock(int total_matched, std::vector<cli_argument*>
                                     << "  " << std::setw(18) << avdecc_lib::utility::aem_desc_value_to_name(desc_type_value)
                                     << "  " << std::setw(16) << std::dec << desc_index << std::endl;
                     }
-                free(stream_input_resp_ref);
+                delete(stream_input_resp_ref);
                 }
             }
 
@@ -1006,7 +1006,7 @@ int cmd_line::cmd_view_media_clock(int total_matched, std::vector<cli_argument*>
                     is_clock_sync_source_set = stream_output_resp_ref->stream_flags_clock_sync_source();
                     if(is_clock_sync_source_set)
                     {
-                        desc_obj_name = stream_output_desc->object_name();
+                        desc_obj_name = stream_output_resp_ref->object_name();
                         desc_type_value = stream_output_desc->descriptor_type();
                         desc_index = stream_output_desc->descriptor_index();
 
@@ -1014,7 +1014,7 @@ int cmd_line::cmd_view_media_clock(int total_matched, std::vector<cli_argument*>
                                     << "  " << std::setw(18) << std::hex << avdecc_lib::utility::aem_desc_value_to_name(desc_type_value)
                                     << "  " << std::setw(16) << std::dec << desc_index << std::endl;
                     }
-                    free(stream_output_resp_ref);
+                    delete(stream_output_resp_ref);
                 }
             }
         }
@@ -1184,9 +1184,11 @@ int cmd_line::cmd_view_all(int total_matched, std::vector<cli_argument*> args)
         {
             case avdecc_lib::AEM_DESC_ENTITY:
                 {
+                    avdecc_lib::entity_descriptor_response *entity_resp = entity->get_entity_response();
                     atomic_cout << std::setw(20) << std::hex << avdecc_lib::utility::aem_desc_value_to_name(entity->descriptor_type())
                                 << "   " << std::setw(16) << std::dec << entity->descriptor_index()
-                                << "   " << std::setw(20) << std::hex << entity->get_entity_response()->entity_name() << std::endl;
+                                << "   " << std::setw(20) << std::hex << entity_resp->entity_name() << std::endl;
+                    delete entity_resp;
                 }
 
             case avdecc_lib::AEM_DESC_CONFIGURATION:
@@ -1201,85 +1203,99 @@ int cmd_line::cmd_view_all(int total_matched, std::vector<cli_argument*> args)
                 for(unsigned int j = 0; j < configuration->audio_unit_desc_count(); j++)
                 {
                     avdecc_lib::audio_unit_descriptor *audio_unit_desc_ref = configuration->get_audio_unit_desc_by_index(j);
+                    avdecc_lib::audio_unit_descriptor_response *audio_unit_resp_ref = audio_unit_desc_ref->get_audio_unit_response();
                     print_desc_type_index_name_row(*audio_unit_desc_ref,
-                                                   configuration->get_strings_desc_string_by_reference(audio_unit_desc_ref->get_audio_unit_response()->localized_description()),
+                                                   configuration->get_strings_desc_string_by_reference(audio_unit_resp_ref->localized_description()),
                                                    *locale);
+                    delete audio_unit_resp_ref;
                 }
 
             case avdecc_lib::AEM_DESC_STREAM_INPUT:
                 for(unsigned int j = 0; j < configuration->stream_input_desc_count(); j++)
                 {
                     avdecc_lib::stream_input_descriptor *stream_input_desc_ref = configuration->get_stream_input_desc_by_index(j);
+                    avdecc_lib::stream_input_descriptor_response *stream_input_resp_ref = stream_input_desc_ref->get_stream_input_response();
                     print_desc_type_index_name_row(*stream_input_desc_ref,
-                                                   configuration->get_strings_desc_string_by_reference(stream_input_desc_ref->localized_description()),
+                                                   configuration->get_strings_desc_string_by_reference(stream_input_resp_ref->localized_description()),
                                                    *locale);
+                    delete stream_input_resp_ref;
                 }
 
             case avdecc_lib::AEM_DESC_STREAM_OUTPUT:
                 for(unsigned int j = 0; j < configuration->stream_output_desc_count(); j++)
                 {
                     avdecc_lib::stream_output_descriptor *stream_output_desc_ref = configuration->get_stream_output_desc_by_index(j);
+                    avdecc_lib::stream_output_descriptor_response *stream_output_resp_ref = stream_output_desc_ref->get_stream_output_response();
                     print_desc_type_index_name_row(*stream_output_desc_ref,
-                                                   configuration->get_strings_desc_string_by_reference(stream_output_desc_ref->localized_description()),
+                                                   configuration->get_strings_desc_string_by_reference(stream_output_resp_ref->localized_description()),
                                                    *locale);
+                    delete stream_output_resp_ref;
                 }
 
             case avdecc_lib::AEM_DESC_JACK_INPUT:
                 for(unsigned int j = 0; j < configuration->jack_input_desc_count(); j++)
                 {
                     avdecc_lib::jack_input_descriptor *jack_input_desc_ref = configuration->get_jack_input_desc_by_index(j);
+                    avdecc_lib::jack_input_descriptor_response *jack_input_resp_ref = jack_input_desc_ref->get_jack_input_response();
                     print_desc_type_index_name_row(*jack_input_desc_ref,
-                                                   configuration->get_strings_desc_string_by_reference(jack_input_desc_ref->localized_description()),
+                                                   configuration->get_strings_desc_string_by_reference(jack_input_resp_ref->localized_description()),
                                                    *locale);
+                    delete jack_input_resp_ref;
                 }
 
             case avdecc_lib::AEM_DESC_JACK_OUTPUT:
                 for(unsigned int j = 0; j < configuration->jack_output_desc_count(); j++)
                 {
                     avdecc_lib::jack_output_descriptor *jack_output_desc_ref = configuration->get_jack_output_desc_by_index(j);
+                    avdecc_lib::jack_output_descriptor_response *jack_output_resp_ref = jack_output_desc_ref->get_jack_output_response();
                     print_desc_type_index_name_row(*jack_output_desc_ref,
-                                                   configuration->get_strings_desc_string_by_reference(jack_output_desc_ref->localized_description()),
+                                                   configuration->get_strings_desc_string_by_reference(jack_output_resp_ref->localized_description()),
                                                    *locale);
+                    delete jack_output_resp_ref;
                 }
 
             case avdecc_lib::AEM_DESC_AVB_INTERFACE:
                 for(unsigned int j = 0; j < configuration->avb_interface_desc_count(); j++)
                 {
                     avdecc_lib::avb_interface_descriptor *avb_interface_desc_ref = configuration->get_avb_interface_desc_by_index(j);
-                    avdecc_lib::avb_interface_descriptor_response *avb_interface_desc_resp_ref = avb_interface_desc_ref->get_avb_interface_response();
+                    avdecc_lib::avb_interface_descriptor_response *avb_interface_resp_ref = avb_interface_desc_ref->get_avb_interface_response();
                     print_desc_type_index_name_row(*avb_interface_desc_ref,
-                                                   configuration->get_strings_desc_string_by_reference(avb_interface_desc_resp_ref->localized_description()),
+                                                   configuration->get_strings_desc_string_by_reference(avb_interface_resp_ref->localized_description()),
                                                    *locale);
-                    free(avb_interface_desc_resp_ref);
+                    delete avb_interface_resp_ref;
                 }
 
             case avdecc_lib::AEM_DESC_CLOCK_SOURCE:
                 for(unsigned int j = 0; j < configuration->clock_source_desc_count(); j++)
                 {
                     avdecc_lib::clock_source_descriptor *clk_src_desc_ref = configuration->get_clock_source_desc_by_index(j);
+                    avdecc_lib::clock_source_descriptor_response *clk_src_resp_ref = clk_src_desc_ref->get_clock_source_response();
                     print_desc_type_index_name_row(*clk_src_desc_ref,
-                                                   configuration->get_strings_desc_string_by_reference(clk_src_desc_ref->localized_description()),
+                                                   configuration->get_strings_desc_string_by_reference(clk_src_resp_ref->localized_description()),
                                                    *locale);
+                    delete clk_src_resp_ref;
                 }
 
             case avdecc_lib::AEM_DESC_MEMORY_OBJECT:
                 for(unsigned int j = 0; j < configuration->memory_object_desc_count(); j++)
                 {
                     avdecc_lib::memory_object_descriptor *mem_obj_desc_ref = configuration->get_memory_object_desc_by_index(j);
+                    avdecc_lib::memory_object_descriptor_response *mem_obj_resp_ref = mem_obj_desc_ref->get_memory_object_response();
                     print_desc_type_index_name_row(*mem_obj_desc_ref,
-                                                   configuration->get_strings_desc_string_by_reference(mem_obj_desc_ref->localized_description()),
+                                                   configuration->get_strings_desc_string_by_reference(mem_obj_resp_ref->localized_description()),
                                                    *locale);
+                    delete mem_obj_resp_ref;
                 }
 
             case avdecc_lib::AEM_DESC_LOCALE:
                 for(unsigned int j = 0; j < configuration->locale_desc_count(); j++)
                 {
                     avdecc_lib::locale_descriptor *locale_def_ref = configuration->get_locale_desc_by_index(j);
-                    avdecc_lib::locale_descriptor_response *locale_resp = locale_def_ref->get_locale_response();
+                    avdecc_lib::locale_descriptor_response *locale_resp_ref = locale_def_ref->get_locale_response();
                     atomic_cout << std::setw(20) << avdecc_lib::utility::aem_desc_value_to_name(locale_def_ref->descriptor_type())
-                                << "   "<<  std::setw(16) << std::hex << locale_resp->descriptor_index()
-                                << "   " << std::setw(20) << std::hex << locale_resp->locale_identifier() << std::endl;
-                    free(locale_resp);
+                                << "   "<<  std::setw(16) << std::hex << locale_def_ref->descriptor_index()
+                                << "   " << std::setw(20) << std::hex << locale_resp_ref->locale_identifier() << std::endl;
+                    delete locale_resp_ref;
                 }
 
 //            case avdecc_lib::AEM_DESC_STRINGS:
@@ -1347,17 +1363,21 @@ int cmd_line::cmd_view_all(int total_matched, std::vector<cli_argument*> args)
                 for(unsigned int j = 0; j < configuration->clock_domain_desc_count(); j++)
                 {
                     avdecc_lib::clock_domain_descriptor *clk_domain_desc_ref = configuration->get_clock_domain_desc_by_index(j);
+                    avdecc_lib::clock_domain_descriptor_response *clk_domain_resp_ref = clk_domain_desc_ref->get_clock_domain_response();
                     print_desc_type_index_name_row(*clk_domain_desc_ref,
-                                                   configuration->get_strings_desc_string_by_reference(clk_domain_desc_ref->localized_description()),
+                                                   configuration->get_strings_desc_string_by_reference(clk_domain_resp_ref->localized_description()),
                                                    *locale);
+                    delete clk_domain_resp_ref;
                 }
             case avdecc_lib::AEM_DESC_CONTROL:
                 for(unsigned int j = 0; j < configuration->control_desc_count(); j++)
                 {
                     avdecc_lib::control_descriptor *control_desc_ref = configuration->get_control_desc_by_index(j);
+                    avdecc_lib::control_descriptor_response *control_resp_ref = control_desc_ref->get_control_response();
                     print_desc_type_index_name_row(*control_desc_ref,
-                                                   configuration->get_strings_desc_string_by_reference(control_desc_ref->localized_description()),
+                                                   configuration->get_strings_desc_string_by_reference(control_resp_ref->localized_description()),
                                                    *locale);
+                    delete control_resp_ref;
                 }
             break;
         }
@@ -1376,13 +1396,13 @@ int cmd_line::cmd_view_details(int total_matched, std::vector<cli_argument*> arg
     
     if (get_current_entity_and_descriptor(end_station, &entity, &configuration))
         return 0;
-    
     avdecc_lib::entity_descriptor_response *entity_resp_ref = entity->get_entity_response();
 
     atomic_cout << "\nEnd Station: " << " (" << entity_resp_ref->entity_name() << ")" << std::endl;
     atomic_cout << "Entity Index: " << end_station->get_current_entity_index() << "  Entity ID: 0x" << std::hex <<entity_resp_ref->entity_id() << std::endl;
     atomic_cout << "Configuration: " << end_station->get_current_config_index() << std::endl;
     atomic_cout << "------------------------------------------------------------------------------" << std::endl;
+    delete entity_resp_ref;
 
     switch(0)
     {
@@ -1618,7 +1638,7 @@ int cmd_line::do_view_descriptor(std::string desc_name, uint16_t desc_index)
     avdecc_lib::entity_descriptor *entity;
     avdecc_lib::configuration_descriptor *configuration;
     get_current_entity_and_descriptor(end_station, &entity, &configuration);
-    
+
     // test field output
     if (desc_type_value == avdecc_lib::AEM_DESC_EXTERNAL_PORT_INPUT)
     {
@@ -1658,7 +1678,7 @@ int cmd_line::do_view_descriptor(std::string desc_name, uint16_t desc_index)
                     atomic_cout << "\nUNHANDLED FIELD TYPE";
             }
         }
-        free(desc);
+        delete desc;
         return 0;
     }
 
@@ -1688,7 +1708,7 @@ int cmd_line::do_view_descriptor(std::string desc_name, uint16_t desc_index)
                     atomic_cout << "\nserial_number = " << std::dec << entity_desc_resp->serial_number();
                     atomic_cout << "\nconfigurations_count = " << std::dec << entity_desc_resp->configurations_count();
                     atomic_cout << "\ncurrent_configuration = " << std::dec << entity_desc_resp->current_configuration() << std::endl;
-                    free(entity_desc_resp);
+                    delete(entity_desc_resp);
                 }
             }
             break;
@@ -1774,7 +1794,7 @@ int cmd_line::do_view_descriptor(std::string desc_name, uint16_t desc_index)
                     {
                         atomic_cout << "sampling_rate_" << i << " = " << std::dec << audio_unit_resp_ref->get_sampling_rate_by_index(i) << std::endl;
                     }
-                    free(audio_unit_resp_ref);
+                    delete(audio_unit_resp_ref);
                 }
             }
             break;
@@ -1814,7 +1834,7 @@ int cmd_line::do_view_descriptor(std::string desc_name, uint16_t desc_index)
                     atomic_cout << "\nbackedup_talker_unique = " << std::dec << stream_input_resp_ref->backedup_talker_unique();
                     atomic_cout << "\navb_interface_index = " << std::dec << stream_input_resp_ref->avb_interface_index();
                     atomic_cout << "\nbuffer_length = " << std::dec << stream_input_resp_ref->buffer_length() << std::endl;
-                    free(stream_input_resp_ref);
+                    delete(stream_input_resp_ref);
                 }
             }
             break;
@@ -1854,7 +1874,7 @@ int cmd_line::do_view_descriptor(std::string desc_name, uint16_t desc_index)
                     atomic_cout << "\nbackedup_talker_unique = " << std::dec << stream_output_resp_ref->backedup_talker_unique();
                     atomic_cout << "\navb_interface_index = " << std::dec << stream_output_resp_ref->avb_interface_index();
                     atomic_cout << "\nbuffer_length = " << std::dec << stream_output_resp_ref->buffer_length() << std::endl;
-                    free(stream_output_resp_ref);
+                    delete(stream_output_resp_ref);
                 }
             }
             break;
@@ -1875,7 +1895,7 @@ int cmd_line::do_view_descriptor(std::string desc_name, uint16_t desc_index)
                     atomic_cout << "\n\tcaptive_flag = 0x" << std::hex << jack_input_resp_ref->jack_flag_captive();
                     atomic_cout << "\nnumber_of_controls = " << std::dec << jack_input_resp_ref->number_of_controls();
                     atomic_cout << "\nbase_control = " << std::dec << jack_input_resp_ref->base_control() << std::endl;
-                    free(jack_input_resp_ref);
+                    delete(jack_input_resp_ref);
                 }
             }
             break;
@@ -1897,7 +1917,7 @@ int cmd_line::do_view_descriptor(std::string desc_name, uint16_t desc_index)
                     atomic_cout << "\njack_type = 0x" << std::hex << jack_output_resp_ref->jack_type();
                     atomic_cout << "\nnumber_of_controls = " << std::dec << jack_output_resp_ref->number_of_controls();
                     atomic_cout << "\nbase_control = " << std::dec << jack_output_resp_ref->base_control() << std::endl;
-                    free(jack_output_resp_ref);
+                    delete(jack_output_resp_ref);
                 }
             }
             break;
@@ -1926,7 +1946,7 @@ int cmd_line::do_view_descriptor(std::string desc_name, uint16_t desc_index)
                     atomic_cout << "\nlog_announce_interval = " << std::dec << (unsigned int)avb_interface_desc_resp->log_announce_interval();
                     atomic_cout << "\nlog_pdelay_interval = " << std::dec << (unsigned int)avb_interface_desc_resp->log_pdelay_interval();
                     atomic_cout << "\nport_number = " << std::dec << avb_interface_desc_resp->port_number() << std::endl;
-                    free(avb_interface_desc_resp);
+                    delete(avb_interface_desc_resp);
                 }
             }
             break;
@@ -1947,7 +1967,7 @@ int cmd_line::do_view_descriptor(std::string desc_name, uint16_t desc_index)
                     atomic_cout << "\nclock_source_identifier = 0x" << std::hex << clk_src_resp_ref->clock_source_identifier();
                     atomic_cout << "\nclock_source_location_type = 0x" << std::hex << clk_src_resp_ref->clock_source_location_type();
                     atomic_cout << "\nclock_source_location_index = " << std::dec << clk_src_resp_ref->clock_source_location_index() << std::endl;
-                    free(clk_src_resp_ref);
+                    delete(clk_src_resp_ref);
                 }
             }
             break;
@@ -1969,7 +1989,7 @@ int cmd_line::do_view_descriptor(std::string desc_name, uint16_t desc_index)
                     atomic_cout << "\nstart_address = 0x" << std::hex << mem_obj_resp_ref->start_address();
                     atomic_cout << "\nmaximum_length = " << std::dec << mem_obj_resp_ref->maximum_length() << " bytes";;
                     atomic_cout << "\nlength = " << std::dec << mem_obj_resp_ref->length() << " bytes" << std::endl;
-                    free(mem_obj_resp_ref);
+                    delete(mem_obj_resp_ref);
                 }
             }
             break;
@@ -1986,7 +2006,7 @@ int cmd_line::do_view_descriptor(std::string desc_name, uint16_t desc_index)
                     atomic_cout << "\nlocale_identifier = " << std::dec << locale_resp->locale_identifier();
                     atomic_cout << "\nnumber_of_strings = " << std::dec << locale_resp->number_of_strings();
                     atomic_cout << "\nbase_strings = " << std::dec << locale_resp->base_strings() << std::endl;
-                    free(locale_resp);
+                    delete(locale_resp);
                 }
             }
             break;
@@ -2007,7 +2027,7 @@ int cmd_line::do_view_descriptor(std::string desc_name, uint16_t desc_index)
                     atomic_cout << "\nstring_4 = " << std::hex << strings_resp_ref->get_string_by_index(4);
                     atomic_cout << "\nstring_5 = " << std::hex << strings_resp_ref->get_string_by_index(5);
                     atomic_cout << "\nstring_6 = " << std::hex << strings_resp_ref->get_string_by_index(6) << std::endl;
-                    free(strings_resp_ref);
+                    delete(strings_resp_ref);
                 }
             }
             break;
@@ -2029,7 +2049,7 @@ int cmd_line::do_view_descriptor(std::string desc_name, uint16_t desc_index)
                     atomic_cout << "\nbase_cluster = " << std::dec << stream_port_input_resp_ref->base_cluster();
                     atomic_cout << "\nnumber_of_maps = " << std::dec << stream_port_input_resp_ref->number_of_maps();
                     atomic_cout << "\nbase_map = " << std::dec << stream_port_input_resp_ref->base_map() << std::endl;
-                    free(stream_port_input_resp_ref);
+                    delete(stream_port_input_resp_ref);
                 }
             }
             break;
@@ -2051,7 +2071,7 @@ int cmd_line::do_view_descriptor(std::string desc_name, uint16_t desc_index)
                     atomic_cout << "\nbase_cluster = " << std::dec << stream_port_output_resp_ref->base_cluster();
                     atomic_cout << "\nnumber_of_maps = " << std::dec << stream_port_output_resp_ref->number_of_maps();
                     atomic_cout << "\nbase_map = " << std::dec << stream_port_output_resp_ref->base_map() << std::endl;
-                    free(stream_port_output_resp_ref);
+                    delete(stream_port_output_resp_ref);
                 }
             }
             break;
@@ -2074,7 +2094,7 @@ int cmd_line::do_view_descriptor(std::string desc_name, uint16_t desc_index)
                     atomic_cout << "\nblock_latency = " << std::dec << audio_cluster_resp_ref->block_latency();
                     atomic_cout << "\nchannel_count = " << std::dec << audio_cluster_resp_ref->channel_count();
                     atomic_cout << "\nformat = 0x" << std::hex << (unsigned int)audio_cluster_resp_ref->format() << std::endl;
-                    free(audio_cluster_resp_ref);
+                    delete(audio_cluster_resp_ref);
                 }
             }
             break;
@@ -2105,7 +2125,7 @@ int cmd_line::do_view_descriptor(std::string desc_name, uint16_t desc_index)
                             atomic_cout << "map[" << i << "].cluster_channel = " << std::dec << map.cluster_channel << std::endl;
                         }
                     }
-                    free(audio_map_resp_ref);
+                    delete(audio_map_resp_ref);
                 }
             }
             break;
@@ -2128,11 +2148,11 @@ int cmd_line::do_view_descriptor(std::string desc_name, uint16_t desc_index)
                     {
                         atomic_cout << "\tclock_sources = " << std::dec << clk_domain_resp_ref->get_clock_source_by_index(i) << std::endl;
                     }
-                    free(clk_domain_resp_ref);
+                    delete(clk_domain_resp_ref);
                 }
             }
             break;
-            
+
         case avdecc_lib::AEM_DESC_EXTERNAL_PORT_INPUT:
             {
                 if (!configuration)
@@ -2151,7 +2171,7 @@ int cmd_line::do_view_descriptor(std::string desc_name, uint16_t desc_index)
                     atomic_cout << "\nsignal_output = " << std::dec << external_port_input_resp_ref->signal_output();
                     atomic_cout << "\nblock_latency = " << std::dec << external_port_input_resp_ref->block_latency();
                     atomic_cout << "\njack_index = " << std::dec << external_port_input_resp_ref->jack_index();
-                    free(external_port_input_resp_ref);
+                    delete(external_port_input_resp_ref);
                 }
             }
             break;
@@ -2174,7 +2194,7 @@ int cmd_line::do_view_descriptor(std::string desc_name, uint16_t desc_index)
                     atomic_cout << "\nsignal_output = " << std::dec << external_port_output_resp_ref->signal_output();
                     atomic_cout << "\nblock_latency = " << std::dec << external_port_output_resp_ref->block_latency();
                     atomic_cout << "\njack_index = " << std::dec << external_port_output_resp_ref->jack_index();
-                    free(external_port_output_resp_ref);
+                    delete(external_port_output_resp_ref);
                 }
             }
             break;
@@ -2276,7 +2296,7 @@ int cmd_line::cmd_connect(int total_matched, std::vector<cli_argument*> args)
                         << avdecc_lib::utility::end_station_mac_to_string(end_station_mac) << "   "
                         << std::setw(3) << j << std::setw(19) << desc_desc_name << "   "
                         << std::setw(14) << format << std::endl;
-            free(stream_input_resp_ref);
+            delete(stream_input_resp_ref);
         }
     }
 
@@ -2306,7 +2326,7 @@ int cmd_line::cmd_connect(int total_matched, std::vector<cli_argument*> args)
                         << avdecc_lib::utility::end_station_mac_to_string(end_station_mac) << "   "
                         << std::setw(3) << j << std::setw(19) << src_desc_name << "   "
                         << std::setw(15) << format << std::endl;
-            free(stream_output_resp_ref);
+            delete(stream_output_resp_ref);
         }
     }
 
@@ -2359,7 +2379,7 @@ int cmd_line::cmd_connect_dst(int total_matched, std::vector<cli_argument*> args
                                 << avdecc_lib::utility::end_station_mac_to_string(end_station_mac)
                                 << "   " << std::setw(2) << j << std::setw(19) << src_desc_name
                                 << "   " << std::setw(10) << format << std::endl;
-                    free(stream_output_resp_ref);
+                    delete(stream_output_resp_ref);
                 }
             }
         }
@@ -2451,11 +2471,11 @@ int cmd_line::cmd_connect_rx(int total_matched, std::vector<cli_argument*> args)
         uint16_t outstream_current_entity = outstream_end_station->get_current_entity_index();
         avdecc_lib::entity_descriptor_response *entity_resp_ref = outstream_end_station->get_entity_desc_by_index(outstream_current_entity)->get_entity_response();
         talker_entity_id = entity_resp_ref->entity_id();
-        free(entity_resp_ref);
+        delete(entity_resp_ref);
         instream->send_connect_rx_cmd((void *)cmd_notification_id, talker_entity_id, outstream_desc_index, connection_flags);
         sys->get_last_resp_status();
-        
-        free(stream_input_resp_ref);
+
+        delete(stream_input_resp_ref);
     }
     else
     {
@@ -2494,7 +2514,7 @@ int cmd_line::cmd_disconnect_rx(int total_matched, std::vector<cli_argument*> ar
         uint16_t current_entity = outstream_end_station->get_current_entity_index();
         avdecc_lib::entity_descriptor_response *entity_resp_ref = outstream_end_station->get_entity_desc_by_index(current_entity)->get_entity_response();
         talker_entity_id = entity_resp_ref->entity_id();
-        free(entity_resp_ref);
+        delete(entity_resp_ref);
 
         instream->send_disconnect_rx_cmd((void *)cmd_notification_id, talker_entity_id, outstream_desc_index);
         sys->get_last_resp_status();
@@ -2582,9 +2602,9 @@ int cmd_line::cmd_show_connections(int total_matched, std::vector<cli_argument*>
                                 << "[" << in_stream_index << "] -> "
                                 << "0x" << std::setw(16) << std::hex << std::setfill('0') << in_end_station->entity_id()
                                 << "[" << out_stream_index << "]" << std::endl;
-                    
-                    free(stream_input_resp_ref);
-                    free(stream_output_resp_ref);
+
+                    delete(stream_input_resp_ref);
+                    delete(stream_output_resp_ref);
                 }
             }
         }
@@ -2616,7 +2636,7 @@ int cmd_line::cmd_get_tx_state(int total_matched, std::vector<cli_argument*> arg
             atomic_cout << "\nstream_dest_mac = 0x" << std::hex << stream_output_resp_ref->get_tx_state_stream_dest_mac();
             atomic_cout << "\nconnection_count = " << std::dec << stream_output_resp_ref->get_tx_state_connection_count();
             atomic_cout << "\nstream_vlan_id = " << std::dec << stream_output_resp_ref->get_tx_state_stream_vlan_id() << std::endl;
-            free(stream_output_resp_ref);
+            delete(stream_output_resp_ref);
         }
     }
     else
@@ -2655,7 +2675,7 @@ int cmd_line::cmd_get_rx_state(int total_matched, std::vector<cli_argument*> arg
             atomic_cout << "\nconnection_count = " << std::dec << stream_input_resp_ref->get_rx_state_connection_count();
             atomic_cout << "\nflags = " << std::dec << stream_input_resp_ref->get_rx_state_flags();
             atomic_cout << "\nstream_vlan_id = " << std::dec << stream_input_resp_ref->get_rx_state_stream_vlan_id() << std::endl;
-            free(stream_input_resp_ref);
+            delete(stream_input_resp_ref);
         }
     }
     else
@@ -2692,7 +2712,7 @@ int cmd_line::cmd_get_tx_connection(int total_matched, std::vector<cli_argument*
             atomic_cout << "\nstream_dest_mac = 0x" << std::hex << stream_output_resp_ref->get_tx_connection_stream_dest_mac();
             atomic_cout << "\nconnection_count = " << std::dec << stream_output_resp_ref->get_tx_connection_connection_count();
             atomic_cout << "\nstream_vlan_id = " << std::dec << stream_output_resp_ref->get_tx_connection_stream_vlan_id() << std::endl;
-            free(stream_output_resp_ref);
+            delete(stream_output_resp_ref);
         }
     }
     else
@@ -3228,7 +3248,7 @@ int cmd_line::cmd_get_sampling_rate(int total_matched, std::vector<cli_argument*
         {
             avdecc_lib::audio_unit_get_sampling_rate_response *audio_unit_resp_ref = audio_unit_desc_ref->get_audio_unit_get_sampling_rate_response();
             atomic_cout << "Sampling rate: " << std::dec << audio_unit_resp_ref->get_sampling_rate_sampling_rate();
-            free(audio_unit_resp_ref);
+            delete audio_unit_resp_ref;
         }
     }
     else if(desc_type_value == avdecc_lib::AEM_DESC_VIDEO_CLUSTER)
@@ -3297,7 +3317,7 @@ int cmd_line::cmd_get_counters(int total_matched, std::vector<cli_argument*> arg
                     atomic_cout << "GPTP GM Changed Counter: " << avb_interface_counters_resp->
                     get_counter_by_name(avdecc_lib::AVB_GPTP_GM_CHANGED)
                         << std::endl;
-                free(avb_interface_counters_resp);
+                delete avb_interface_counters_resp;
             }
         }
     }
@@ -3319,7 +3339,7 @@ int cmd_line::cmd_get_counters(int total_matched, std::vector<cli_argument*> arg
                     atomic_cout << "Locked Counter: " << clock_domain_counters_resp->get_counter_by_name(avdecc_lib::CLOCK_DOMAIN_LOCKED) << std::endl;
                 if(clock_domain_counters_resp->get_counter_valid(avdecc_lib::CLOCK_DOMAIN_UNLOCKED))
                     atomic_cout << "Unlocked Counter: " << clock_domain_counters_resp->get_counter_by_name(avdecc_lib::CLOCK_DOMAIN_UNLOCKED) << std::endl;
-                free(clock_domain_counters_resp);
+                delete clock_domain_counters_resp;
             }
         }
     }
@@ -3362,7 +3382,7 @@ int cmd_line::cmd_get_counters(int total_matched, std::vector<cli_argument*> arg
                     atomic_cout << "Frames RX Counter: " << stream_input_counters_resp->get_counter_by_name(avdecc_lib::STREAM_INPUT_FRAMES_RX) << std::endl;
                 if(stream_input_counters_resp->get_counter_valid(avdecc_lib::STREAM_INPUT_FRAMES_TX))
                     atomic_cout << "Frames TX Counter: " << stream_input_counters_resp->get_counter_by_name(avdecc_lib::STREAM_INPUT_FRAMES_TX) << std::endl;
-                free(stream_input_counters_resp);
+                delete stream_input_counters_resp;
             }
         }
     }
@@ -3392,6 +3412,13 @@ int cmd_line::cmd_set_clock_source(int total_matched, std::vector<cli_argument*>
         return 0;
 
     clk_domain_desc_ref->send_set_clock_source_cmd((void *)cmd_notification_id, new_clk_src_index);
+    int status = sys->get_last_resp_status();
+
+    if(status == avdecc_lib::AEM_STATUS_SUCCESS)
+    {   /*
+        atomic_cout << "Clock source index : " << std::dec << clk_domain_desc_ref->set_clock_source_clock_source_index() << std::endl;
+        */
+    }
 
     return 0;
 }
@@ -3433,8 +3460,8 @@ int cmd_line::cmd_get_clock_source(int total_matched, std::vector<cli_argument*>
         atomic_cout << "Clock source index : " << std::dec << clk_domain_desc_resp->get_clock_source_by_index(clk_src_index) << std::endl;
     }
 
-    free(clk_domain_desc_resp);
-    free(clk_domain_stream_resp_ref);
+    delete clk_domain_desc_resp;
+    delete clk_domain_stream_resp_ref;
     return 0;
 }
 

--- a/controller/app/cmdline/src/cmd_line.cpp
+++ b/controller/app/cmdline/src/cmd_line.cpp
@@ -737,7 +737,7 @@ void cmd_line::cmd_line_commands_init()
     get_cmd->add_sub_command("clock_source", get_clock_source_cmd);
 
     cli_command_format *get_clock_source_fmt = new cli_command_format(
-        "Send a SET_CLOCK_SOURCE command to change the clock source of a clock domain.",
+        "Send a GET_CLOCK_SOURCE command to change the clock source of a clock domain.",
         &cmd_line::cmd_get_clock_source);
     get_clock_source_fmt->add_argument(new cli_argument_string(this, "d_t", "the descriptor type",
                                                                "Valid descriptor type is CLOCK_DOMAIN."));
@@ -2578,6 +2578,7 @@ int cmd_line::cmd_show_connections(int total_matched, std::vector<cli_argument*>
             avdecc_lib::stream_input_get_rx_state_response *stream_input_resp_ref = instream->get_stream_input_get_rx_state_response();
             if (!stream_input_resp_ref->get_rx_state_connection_count())
                 continue;
+            delete stream_input_resp_ref;
 
             for(uint32_t out_index = 0; out_index < controller_obj->get_end_station_count(); out_index++)
             {
@@ -2590,6 +2591,7 @@ int cmd_line::cmd_show_connections(int total_matched, std::vector<cli_argument*>
                 size_t stream_output_desc_count = out_descriptor->stream_output_desc_count();
                 for(uint32_t out_stream_index = 0; out_stream_index < stream_output_desc_count; out_stream_index++)
                 {
+                    avdecc_lib::stream_input_get_rx_state_response *stream_input_resp_ref = instream->get_stream_input_get_rx_state_response();
                     avdecc_lib::stream_output_descriptor *outstream = out_descriptor->get_stream_output_desc_by_index(out_stream_index);
                     avdecc_lib::stream_output_get_tx_state_response *stream_output_resp_ref = outstream->get_stream_output_get_tx_state_response();
                     if (!stream_output_resp_ref->get_tx_state_connection_count() ||
@@ -3447,20 +3449,20 @@ int cmd_line::cmd_get_clock_source(int total_matched, std::vector<cli_argument*>
 
     if (!clk_domain_desc_ref)
         return 0;
-
+    
+    avdecc_lib::clock_domain_descriptor_response *clk_domain_resp_ref = clk_domain_desc_ref->get_clock_domain_response();
     clk_domain_desc_ref->send_get_clock_source_cmd((void *)cmd_notification_id);
     int status = sys->get_last_resp_status();
-    avdecc_lib::clock_domain_descriptor_response *clk_domain_desc_resp = clk_domain_desc_ref->get_clock_domain_response();
-    avdecc_lib::clock_domain_get_clock_source_response *clk_domain_stream_resp_ref = clk_domain_desc_ref->get_clock_domain_get_clock_source_response();
     
+    avdecc_lib::clock_domain_get_clock_source_response *clk_domain_stream_resp_ref = clk_domain_desc_ref->get_clock_domain_get_clock_source_response();
     clk_src_index = clk_domain_stream_resp_ref->get_clock_source_clock_source_index();
 
     if(status == avdecc_lib::AEM_STATUS_SUCCESS)
     {
-        atomic_cout << "Clock source index : " << std::dec << clk_domain_desc_resp->get_clock_source_by_index(clk_src_index) << std::endl;
+        atomic_cout << "Clock source index : " << std::dec << clk_domain_resp_ref->get_clock_source_by_index(clk_src_index) << std::endl;
     }
 
-    delete clk_domain_desc_resp;
+    delete clk_domain_resp_ref;
     delete clk_domain_stream_resp_ref;
     return 0;
 }

--- a/controller/app/cmdline/src/cmd_line.cpp
+++ b/controller/app/cmdline/src/cmd_line.cpp
@@ -36,6 +36,7 @@
 #include <fstream>
 #include <limits.h>
 #include <string.h>
+
 #include "end_station.h"
 #include "entity_descriptor.h"
 #include "configuration_descriptor.h"

--- a/controller/lib/include/audio_cluster_descriptor.h
+++ b/controller/lib/include/audio_cluster_descriptor.h
@@ -35,6 +35,7 @@
 #include <stdint.h>
 #include "build.h"
 #include "descriptor_base.h"
+#include "audio_cluster_descriptor_response.h"
 
 namespace avdecc_lib
 {
@@ -42,54 +43,8 @@ namespace avdecc_lib
     {
     public:
         /**
-         * \return The descriptor type for the signal source of the cluster.
+         * \return the audio_cluster descriptor response class.
          */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL signal_type() = 0;
-
-        /**
-         * \return The descriptor index for the signal source of the cluster.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL signal_index() = 0;
-
-        /**
-         * \return The index of the output of the signal source of the cluster. For a signal type of
-         *	       Signal Splitter or Signal Demultiplexer, this is which output of the object it is
-         *	       being source from, for a signal type of Matrix, this is the column the signal is
-         *	       from and for any other signal type this is 0.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL signal_output() = 0;
-
-        /**
-         * \return The latency in nanoseconds between the timing reference plane and the opposite end
-         *	       of the currently selected signal path. This does not include any latency added by a
-         *	       delay control. The path latency is used to inform smart Controllers of the extra
-         *	       latency to get the samples to the output, so that output across multiple entries
-         *	       can be sample aligned.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL path_latency() = 0;
-
-        /**
-         * \return The block latency of the Audio Cluster. For an Aduio Cluster attached to a Stream Port Input,
-         *	       this is the latency in nanoseconds between the reference plane and the output of the cluster. For
-         *	       an Audio Cluster attached to a Stream Port Output, this is the latency in nanoseconds between the
-         *	       output of the previous block's output and the reference plane. The previous block is the object
-         *	       identified by the signal type and signal index fields.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL block_latency() = 0;
-
-        /**
-         * \return The number of channels within the cluster.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL channel_count() = 0;
-
-        /**
-         * The format for each channel of this cluster, all channels within the cluster have the same format.
-         *
-         * \return 0x00 (IEC 60958) for IEC 60958 encoded Audio Cluster. \n
-         *	       0x40 (MBLA) for Multi-bit Linear Audio. \n
-         *	       0x80 (MIDI) for MIDI data. \n
-         *	       0x88 (SMPTE) for SMPTE data.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint8_t STDCALL format() = 0;
+        AVDECC_CONTROLLER_LIB32_API virtual audio_cluster_descriptor_response * STDCALL get_audio_cluster_response() = 0;
     };
 }

--- a/controller/lib/include/audio_cluster_descriptor_response.h
+++ b/controller/lib/include/audio_cluster_descriptor_response.h
@@ -1,0 +1,95 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * audio_cluster_descriptor_response.h
+ *
+ * Public Audio Cluster descriptor response interface class
+ * The Audio Cluster descriptor describes groups of audio channels in a stream.
+ * An Audio Cluster could represent a stereo IEC 60958 encoded signal, a one or
+ * more channel multibit linear audio signal, a MIDI signal or a SMPTE signal.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "build.h"
+#include "descriptor_base.h"
+
+namespace avdecc_lib
+{
+    class audio_cluster_descriptor_response : public virtual descriptor_base
+    {
+    public:
+        /**
+         * \return The descriptor type for the signal source of the cluster.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL signal_type() = 0;
+        
+        /**
+         * \return The descriptor index for the signal source of the cluster.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL signal_index() = 0;
+        
+        /**
+         * \return The index of the output of the signal source of the cluster. For a signal type of
+         *	       Signal Splitter or Signal Demultiplexer, this is which output of the object it is
+         *	       being source from, for a signal type of Matrix, this is the column the signal is
+         *	       from and for any other signal type this is 0.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL signal_output() = 0;
+        
+        /**
+         * \return The latency in nanoseconds between the timing reference plane and the opposite end
+         *	       of the currently selected signal path. This does not include any latency added by a
+         *	       delay control. The path latency is used to inform smart Controllers of the extra
+         *	       latency to get the samples to the output, so that output across multiple entries
+         *	       can be sample aligned.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL path_latency() = 0;
+        
+        /**
+         * \return The block latency of the Audio Cluster. For an Aduio Cluster attached to a Stream Port Input,
+         *	       this is the latency in nanoseconds between the reference plane and the output of the cluster. For
+         *	       an Audio Cluster attached to a Stream Port Output, this is the latency in nanoseconds between the
+         *	       output of the previous block's output and the reference plane. The previous block is the object
+         *	       identified by the signal type and signal index fields.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL block_latency() = 0;
+        
+        /**
+         * \return The number of channels within the cluster.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL channel_count() = 0;
+        
+        /**
+         * The format for each channel of this cluster, all channels within the cluster have the same format.
+         *
+         * \return 0x00 (IEC 60958) for IEC 60958 encoded Audio Cluster. \n
+         *	       0x40 (MBLA) for Multi-bit Linear Audio. \n
+         *	       0x80 (MIDI) for MIDI data. \n
+         *	       0x88 (SMPTE) for SMPTE data.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint8_t STDCALL format() = 0;
+    };
+}

--- a/controller/lib/include/audio_cluster_descriptor_response.h
+++ b/controller/lib/include/audio_cluster_descriptor_response.h
@@ -34,13 +34,27 @@
 
 #include <stdint.h>
 #include "build.h"
-#include "descriptor_base.h"
 
 namespace avdecc_lib
 {
-    class audio_cluster_descriptor_response : public virtual descriptor_base
+    class audio_cluster_descriptor_response
     {
     public:
+        virtual ~audio_cluster_descriptor_response(){};
+        /**
+         * \return The name of the descriptor object. This may be user set through the use of a SET_NAME command.
+         *	   The object name should be left blank (all zeros) by the manufacturer, with the manufacturer
+         *	   defined value being provided in a localized form via the localized descripton field. By leaving
+         *	   this field blank an AVDECC Controller can determine if the user has overridden the name and can
+         *	   use this name rather than the localized name.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint8_t * STDCALL object_name() = 0;
+        
+        /**
+         * \return The localized string reference pointing to the localized descriptor name.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL localized_description() = 0;
+
         /**
          * \return The descriptor type for the signal source of the cluster.
          */

--- a/controller/lib/include/audio_map_descriptor.h
+++ b/controller/lib/include/audio_map_descriptor.h
@@ -37,31 +37,16 @@
 #include <stdint.h>
 #include "build.h"
 #include "descriptor_base.h"
+#include "audio_map_descriptor_response.h"
 
 namespace avdecc_lib
 {
-    struct audio_map_mapping {
-        uint16_t stream_index;
-        uint16_t stream_channel;
-        uint16_t cluster_offset;
-        uint16_t cluster_channel;
-    };
-
     class audio_map_descriptor : public virtual descriptor_base
     {
     public:
         /**
-         * \return The number of channel mappings within the Audio Map. The maximum value
-         *	       of this field is 62 for this version of AEM.
+         * \return the audio_map descriptor response class.
          */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_mappings() = 0;
-        /**
-         * \param index The index of the mapping to return.
-         * \param mapping The mapping structure that is filled in by this funtion.
-         * \return Returns 0 on success.
-        */
-        AVDECC_CONTROLLER_LIB32_API virtual int STDCALL mapping(size_t index, struct audio_map_mapping &mapping) = 0;
+        AVDECC_CONTROLLER_LIB32_API virtual audio_map_descriptor_response * STDCALL get_audio_map_response() = 0;
     };
 }
-
-

--- a/controller/lib/include/audio_map_descriptor_response.h
+++ b/controller/lib/include/audio_map_descriptor_response.h
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * audio_map_descriptor_response.h
+ *
+ * Public Audio Map descriptor response interface class
+ * The Audio Map descriptor describes a static mapping between an audio stream's channels
+ * and an audio cluster's channels for streams and stream ports which are located in the
+ * same clock domain. An AVDECC Entity which supports dynamic mappings, that is mappings
+ * which can be changed at runtime by an AVDECC Controller, does not use Audio Map
+ * descriptors, but instead provides their mappings via the GET_AUDIO_MAP command.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "build.h"
+#include "descriptor_base.h"
+
+namespace avdecc_lib
+{
+    struct audio_map_mapping {
+        uint16_t stream_index;
+        uint16_t stream_channel;
+        uint16_t cluster_offset;
+        uint16_t cluster_channel;
+    };
+    
+    class audio_map_descriptor_response : public virtual descriptor_base
+    {
+    public:
+        /**
+         * \return The number of channel mappings within the Audio Map. The maximum value
+         *	       of this field is 62 for this version of AEM.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_mappings() = 0;
+        /**
+         * \param index The index of the mapping to return.
+         * \param mapping The mapping structure that is filled in by this funtion.
+         * \return Returns 0 on success.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual int STDCALL mapping(size_t index, struct audio_map_mapping &mapping) = 0;
+    };
+}

--- a/controller/lib/include/audio_map_descriptor_response.h
+++ b/controller/lib/include/audio_map_descriptor_response.h
@@ -36,7 +36,6 @@
 
 #include <stdint.h>
 #include "build.h"
-#include "descriptor_base.h"
 
 namespace avdecc_lib
 {
@@ -47,9 +46,10 @@ namespace avdecc_lib
         uint16_t cluster_channel;
     };
     
-    class audio_map_descriptor_response : public virtual descriptor_base
+    class audio_map_descriptor_response
     {
     public:
+        virtual ~audio_map_descriptor_response(){};
         /**
          * \return The number of channel mappings within the Audio Map. The maximum value
          *	       of this field is 62 for this version of AEM.
@@ -60,6 +60,6 @@ namespace avdecc_lib
          * \param mapping The mapping structure that is filled in by this funtion.
          * \return Returns 0 on success.
          */
-        AVDECC_CONTROLLER_LIB32_API virtual int STDCALL mapping(size_t index, struct audio_map_mapping &mapping) = 0;
+        AVDECC_CONTROLLER_LIB32_API virtual int const STDCALL mapping(size_t index, struct audio_map_mapping &mapping) = 0;
     };
 }

--- a/controller/lib/include/audio_unit_descriptor.h
+++ b/controller/lib/include/audio_unit_descriptor.h
@@ -43,12 +43,12 @@ namespace avdecc_lib
     {
     public:
         /**
-         * \return the avb_interface descriptor response class.
+         * \return the audio_unit descriptor response class.
          */
         AVDECC_CONTROLLER_LIB32_API virtual audio_unit_descriptor_response * STDCALL get_audio_unit_response() = 0;
         
         /**
-         * \return the avb_interface get_sampling_rate response class.
+         * \return the audio_unit get_sampling_rate response class.
          */
         AVDECC_CONTROLLER_LIB32_API virtual audio_unit_get_sampling_rate_response * STDCALL get_audio_unit_get_sampling_rate_response() = 0;
         

--- a/controller/lib/include/audio_unit_descriptor.h
+++ b/controller/lib/include/audio_unit_descriptor.h
@@ -34,6 +34,8 @@
 #include <stdint.h>
 #include "build.h"
 #include "descriptor_base.h"
+#include "audio_unit_descriptor_response.h"
+#include "audio_unit_get_sampling_rate_response.h"
 
 namespace avdecc_lib
 {
@@ -41,197 +43,15 @@ namespace avdecc_lib
     {
     public:
         /**
-         * \return The descriptor index of the Clock Domain descriptor describing the clock domain for the Audio Unit.
+         * \return the avb_interface descriptor response class.
          */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL clock_domain_index() = 0;
-
+        AVDECC_CONTROLLER_LIB32_API virtual audio_unit_descriptor_response * STDCALL get_audio_unit_response() = 0;
+        
         /**
-         * \return The number of Input Stream Ports used by this Audio Unit.
+         * \return the avb_interface get_sampling_rate response class.
          */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_stream_input_ports() = 0;
-
-        /**
-         * \return The index of the first Stream Port Input descriptor.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_stream_input_port() = 0;
-
-        /**
-         * \return The number of Output Stream Ports used by this Audio Unit.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_stream_output_ports() = 0;
-
-        /**
-         * \return The index of the first Stream Port Output descriptor.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_stream_output_port() = 0;
-
-        /**
-         * \return The number of external Input Ports used by this Audio Unit.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_external_input_ports() = 0;
-
-        /**
-         * \return The index of the first External Port Input descriptor.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_external_input_port() = 0;
-
-        /**
-         * \return The number of external Output Ports used by this Audio Unit.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_external_output_ports() = 0;
-
-        /**
-         * \return The index of the first External Port Output descriptor.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_external_output_port() = 0;
-
-        /**
-         * \return The number of internal Input Ports used by this Audio Unit.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_internal_input_ports() = 0;
-
-        /**
-         * \return The index of the first input Internal JACK INPUT and Internal Port Input descriptors.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_internal_input_port() = 0;
-
-        /**
-         * \return The number of internal Output Ports used by this Audio Unit.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_internal_output_ports() = 0;
-
-        /**
-         * \return The index of the first output Internal JACK OUTPUT and Internal Port Output descriptors.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_internal_output_port() = 0;
-
-        /**
-         * \return The number of controls within this Audio Unit.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_controls() = 0;
-
-        /**
-         * \return The index of the first Control descriptor.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_control() = 0;
-
-        /**
-         * \return The number of signal selectors within this Audio Unit.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_signal_selectors() = 0;
-
-        /**
-         * \return The index of the first Signal Selector descriptor.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_signal_selector() = 0;
-
-        /**
-         * \return The number of mixers within this Audio Unit.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_mixers() = 0;
-
-        /**
-         * \return The index of the first Mixer descriptor.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_mixer() = 0;
-
-        /**
-         * \return The number of matrices within this Audio Unit.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_matrices() = 0;
-
-        /**
-         * \return The index of the first Matrix descriptor.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_matrix() = 0;
-
-        /**
-         * \return The number of splitters within this Audio Unit.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_splitters() = 0;
-
-        /**
-         * \return The index of the first Signal Splitter descriptor.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_splitter() = 0;
-
-        /**
-         * \return The number of combiners within this Audio Unit.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_combiners() = 0;
-
-        /**
-         * \return index of the first Signal Combiner descriptor.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_combiner() = 0;
-
-        /**
-         * \return The number of demultiplexers within this Audio Unit.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_demultiplexers() = 0;
-
-        /**
-         * \return The index of the first Signal Demultiplexer descriptor.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_demultiplexer() = 0;
-
-        /**
-         * \return The number of multiplexers within this Audio Unit.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_multiplexers() = 0;
-
-        /**
-         * \return The index of the first Multiplexer descriptor..
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_multiplexer() = 0;
-
-        /**
-         * \return The number of transcoders within this Audio Unit.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_transcoders() = 0;
-
-        /**
-         * \return The index of the first Signal Transcoder descriptor.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_transcoder() = 0;
-
-        /**
-         * \return The number of control blocks within this Audio Unit.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_control_blocks() = 0;
-
-        /**
-         * \return The index of the first Control Block descriptor.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_control_block() = 0;
-
-        /**
-         * \return The current sampling rate of this Audio Unit.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL current_sampling_rate() = 0;
-
-        /**
-         * \return The corresponding sampling rate by index of this Audio Unit.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_sampling_rate_by_index(size_t sampling_rate_index) = 0;
-
-        /**
-         * \return The number of sample rates. The maximum value is 91 for this version of AEM.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL sampling_rates_count() = 0;
-
-        /**
-         * \return The sampling rate of a port or unit after sending a SET_SAMPLING_RATE command and
-         *	       receiving a response back for the command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL set_sampling_rate_sampling_rate() = 0;
-
-        /**
-         * \return The sampling rate of a port or unit after sending a GET_SAMPLING_RATE command and
-         *	       receiving a response back for the command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_sampling_rate_sampling_rate() = 0;
-
+        AVDECC_CONTROLLER_LIB32_API virtual audio_unit_get_sampling_rate_response * STDCALL get_audio_unit_get_sampling_rate_response() = 0;
+        
         /**
          * Send a SET_SAMPLING_RATE command to change the sampling rate of a port or unit.
          *

--- a/controller/lib/include/audio_unit_descriptor_response.h
+++ b/controller/lib/include/audio_unit_descriptor_response.h
@@ -1,0 +1,223 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * audio_unit_descriptor_response.h
+ *
+ * Public AUDIO_UNIT descriptor response interface class
+ * The AUDIO UNIT descriptor describes an AUDIO UNIT within the AVDECC Entity. An Audio Unit
+ * represents a single audio clock domain.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "build.h"
+#include "descriptor_base.h"
+
+namespace avdecc_lib
+{
+    class audio_unit_descriptor_response : public virtual descriptor_base
+    {
+    public:
+        /**
+         * \return The descriptor index of the Clock Domain descriptor describing the clock domain for the Audio Unit.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL clock_domain_index() = 0;
+        
+        /**
+         * \return The number of Input Stream Ports used by this Audio Unit.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_stream_input_ports() = 0;
+        
+        /**
+         * \return The index of the first Stream Port Input descriptor.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_stream_input_port() = 0;
+        
+        /**
+         * \return The number of Output Stream Ports used by this Audio Unit.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_stream_output_ports() = 0;
+        
+        /**
+         * \return The index of the first Stream Port Output descriptor.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_stream_output_port() = 0;
+        
+        /**
+         * \return The number of external Input Ports used by this Audio Unit.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_external_input_ports() = 0;
+        
+        /**
+         * \return The index of the first External Port Input descriptor.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_external_input_port() = 0;
+        
+        /**
+         * \return The number of external Output Ports used by this Audio Unit.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_external_output_ports() = 0;
+        
+        /**
+         * \return The index of the first External Port Output descriptor.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_external_output_port() = 0;
+        
+        /**
+         * \return The number of internal Input Ports used by this Audio Unit.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_internal_input_ports() = 0;
+        
+        /**
+         * \return The index of the first input Internal JACK INPUT and Internal Port Input descriptors.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_internal_input_port() = 0;
+        
+        /**
+         * \return The number of internal Output Ports used by this Audio Unit.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_internal_output_ports() = 0;
+        
+        /**
+         * \return The index of the first output Internal JACK OUTPUT and Internal Port Output descriptors.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_internal_output_port() = 0;
+        
+        /**
+         * \return The number of controls within this Audio Unit.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_controls() = 0;
+        
+        /**
+         * \return The index of the first Control descriptor.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_control() = 0;
+        
+        /**
+         * \return The number of signal selectors within this Audio Unit.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_signal_selectors() = 0;
+        
+        /**
+         * \return The index of the first Signal Selector descriptor.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_signal_selector() = 0;
+        
+        /**
+         * \return The number of mixers within this Audio Unit.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_mixers() = 0;
+        
+        /**
+         * \return The index of the first Mixer descriptor.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_mixer() = 0;
+        
+        /**
+         * \return The number of matrices within this Audio Unit.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_matrices() = 0;
+        
+        /**
+         * \return The index of the first Matrix descriptor.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_matrix() = 0;
+        
+        /**
+         * \return The number of splitters within this Audio Unit.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_splitters() = 0;
+        
+        /**
+         * \return The index of the first Signal Splitter descriptor.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_splitter() = 0;
+        
+        /**
+         * \return The number of combiners within this Audio Unit.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_combiners() = 0;
+        
+        /**
+         * \return index of the first Signal Combiner descriptor.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_combiner() = 0;
+        
+        /**
+         * \return The number of demultiplexers within this Audio Unit.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_demultiplexers() = 0;
+        
+        /**
+         * \return The index of the first Signal Demultiplexer descriptor.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_demultiplexer() = 0;
+        
+        /**
+         * \return The number of multiplexers within this Audio Unit.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_multiplexers() = 0;
+        
+        /**
+         * \return The index of the first Multiplexer descriptor..
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_multiplexer() = 0;
+        
+        /**
+         * \return The number of transcoders within this Audio Unit.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_transcoders() = 0;
+        
+        /**
+         * \return The index of the first Signal Transcoder descriptor.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_transcoder() = 0;
+        
+        /**
+         * \return The number of control blocks within this Audio Unit.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_control_blocks() = 0;
+        
+        /**
+         * \return The index of the first Control Block descriptor.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_control_block() = 0;
+        
+        /**
+         * \return The current sampling rate of this Audio Unit.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL current_sampling_rate() = 0;
+        
+        /**
+         * \return The corresponding sampling rate by index of this Audio Unit.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_sampling_rate_by_index(size_t sampling_rate_index) = 0;
+        
+        /**
+         * \return The number of sample rates. The maximum value is 91 for this version of AEM.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL sampling_rates_count() = 0;
+    };
+}

--- a/controller/lib/include/audio_unit_descriptor_response.h
+++ b/controller/lib/include/audio_unit_descriptor_response.h
@@ -33,13 +33,27 @@
 
 #include <stdint.h>
 #include "build.h"
-#include "descriptor_base.h"
 
 namespace avdecc_lib
 {
-    class audio_unit_descriptor_response : public virtual descriptor_base
+    class audio_unit_descriptor_response
     {
     public:
+        virtual ~audio_unit_descriptor_response(){};
+        /**
+         * \return The name of the descriptor object. This may be user set through the use of a SET_NAME command.
+         *	   The object name should be left blank (all zeros) by the manufacturer, with the manufacturer
+         *	   defined value being provided in a localized form via the localized descripton field. By leaving
+         *	   this field blank an AVDECC Controller can determine if the user has overridden the name and can
+         *	   use this name rather than the localized name.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint8_t * STDCALL object_name() = 0;
+        
+        /**
+         * \return The localized string reference pointing to the localized descriptor name.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL localized_description() = 0;
+
         /**
          * \return The descriptor index of the Clock Domain descriptor describing the clock domain for the Audio Unit.
          */

--- a/controller/lib/include/audio_unit_get_sampling_rate_response.h
+++ b/controller/lib/include/audio_unit_get_sampling_rate_response.h
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * audio_unit_get_sampling_rate_response.h
+ *
+ * Audio Unit get sampling rate response base class
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "build.h"
+
+namespace avdecc_lib
+{
+    class audio_unit_get_sampling_rate_response
+    {
+    public:
+        /**
+         * \return The sampling rate of a port or unit after sending a GET_SAMPLING_RATE command and
+         *	       receiving a response back for the command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_sampling_rate_sampling_rate() = 0;
+    };
+}

--- a/controller/lib/include/audio_unit_get_sampling_rate_response.h
+++ b/controller/lib/include/audio_unit_get_sampling_rate_response.h
@@ -37,6 +37,7 @@ namespace avdecc_lib
     class audio_unit_get_sampling_rate_response
     {
     public:
+        virtual ~audio_unit_get_sampling_rate_response(){};
         /**
          * \return The sampling rate of a port or unit after sending a GET_SAMPLING_RATE command and
          *	       receiving a response back for the command.

--- a/controller/lib/include/avb_counters_response.h
+++ b/controller/lib/include/avb_counters_response.h
@@ -24,7 +24,7 @@
 /**
  * avb_counters_response.h
  *
- * AVB counters response base class
+ * AVB INTERFACE counters response base class
  */
 
 #pragma once
@@ -37,6 +37,7 @@ namespace avdecc_lib
     class avb_counters_response
     {
     public:
+        virtual ~avb_counters_response(){};
         /**
          * \param name avdecc_lib::counter_labels
          *

--- a/controller/lib/include/avb_counters_response.h
+++ b/controller/lib/include/avb_counters_response.h
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * avb_counters_response.h
+ *
+ * AVB counters response base class
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "build.h"
+
+namespace avdecc_lib
+{
+    class avb_counters_response
+    {
+    public:
+        /**
+         * \param name avdecc_lib::counter_labels
+         *
+         * \return the avb counter valid after the GET_COUNTERS command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_counter_valid(int name) = 0;
+        
+        /**
+         * \param name avdecc_lib::counter_labels
+         *
+         * \return the avb counter by name after the GET_COUNTERS command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_counter_by_name(int name) = 0;
+    };
+}

--- a/controller/lib/include/avb_interface_descriptor.h
+++ b/controller/lib/include/avb_interface_descriptor.h
@@ -50,7 +50,7 @@ namespace avdecc_lib
         AVDECC_CONTROLLER_LIB32_API virtual avb_interface_descriptor_response * STDCALL get_avb_interface_response() = 0;
         
         /**
-         * \return the avb_interface descriptor counters.
+         * \return the avb_interface descriptor counters response class.
          */
         AVDECC_CONTROLLER_LIB32_API virtual avb_counters_response * STDCALL get_avb_interface_counters_response() = 0;
         

--- a/controller/lib/include/avb_interface_descriptor.h
+++ b/controller/lib/include/avb_interface_descriptor.h
@@ -36,6 +36,8 @@
 #include <stdint.h>
 #include "build.h"
 #include "descriptor_base.h"
+#include "avb_interface_descriptor_response.h"
+#include "avb_counters_response.h"
 
 namespace avdecc_lib
 {
@@ -43,94 +45,18 @@ namespace avdecc_lib
     {
     public:
         /**
-         * \return The MAC address of the interface.
+         * \return the avb_interface descriptor response class.
          */
-        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL mac_addr() = 0;
-
-        /**
-         * The flags describing the features of the interface.
-         *
-         * \return 1 (GPTP Grandmaster Supported) if the interface supports the grandmaster functionality.
-         * \return 2 (GPTP Supported) if the interface supports the functionality.
-         * \return 4 (SRP Supported) if the interface supports the "Stream Reservation Protocol (SRP)" functionality.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL interface_flags() = 0;
-
-        /**
-         * \return The clock identity of the interface.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL clock_identity() = 0;
-
-        /**
-         * \return The priority1 field of the grandmaster functionality of the AVB INTERFACE if supported, 0xff otherwise.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint8_t STDCALL priority1() = 0;
-
-        /**
-         * \return The clock class field of the grandmaster functionality of the AVB INTERFACE if supported, 0xff otherwise.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint8_t STDCALL clock_class() = 0;
-
-        /**
-         * \return The offset scaled log variance field of the grandmaster functionality of the AVB INTERFACE if supported, 0 otherwise.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL offset_scaled_log_variance() = 0;
-
-        /**
-         * \return The clock accuracy field of the grandmaster functionality of the AVB INTERFACE if supported, 0xff otherwise.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint8_t STDCALL clock_accuracy() = 0;
-
-        /**
-         * \return The priority2 field of the grandmaster functionality of the AVB INTERFACE if supported, 0xff otherwise.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint8_t STDCALL priority2() = 0;
-
-        /**
-         * \return The domain number field of the grandmaster functionality of the AVB INTERFACE if supported, 0 otherwise.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint8_t STDCALL domain_number() = 0;
-
-        /**
-         * \return The current log sync interval field of the grandmaster functionality of the AVB INTERFACE if supported, 0 otherwise.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint8_t STDCALL log_sync_interval() = 0;
-
-        /**
-         * \return The current log announce interval field of the grandmaster functionality of the AVB INTERFACE if supported, 0 otherwise.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint8_t STDCALL log_announce_interval() = 0;
-
-        /**
-         * \return The current log pdelay interval field of the grandmaster functionality of the AVB INTERFACE if supported, 0 otherwise.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint8_t STDCALL log_pdelay_interval() = 0;
-
-        /**
-         * \return The port number field as used by the functionality of the AVB INTERFACE if supported, 0 otherwise.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL port_number() = 0;
+        AVDECC_CONTROLLER_LIB32_API virtual avb_interface_descriptor_response * STDCALL get_avb_interface_response() = 0;
         
         /**
-         * Send a GET_COUNTERS command to get the counters of the AVDECC Entity.
+         * \return the avb_interface descriptor counters.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual avb_counters_response * STDCALL get_avb_interface_counters_response() = 0;
+        
+        /**
+         * Send a GET_COUNTERS command to get the avb_interface counters of the AVDECC Entity.
          */
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_get_counters_cmd(void *notification_id) = 0;
-        
-        /**
-         * \param name avdecc_lib::counter_labels
-         *
-         * \return the avb counter valid after the GET_COUNTERS command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_counter_valid(int name) = 0;
-        
-        /**
-         * \param name avdecc_lib::counter_labels
-         *
-         * \return the avb counter by name after the GET_COUNTERS command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_counter_by_name(int name) = 0;
-        
-
     };
 }
-

--- a/controller/lib/include/avb_interface_descriptor_response.h
+++ b/controller/lib/include/avb_interface_descriptor_response.h
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * avb_interface_descriptor_response.h
+ *
+ * Public AVB INTERFACE descriptor response interface class
+ * The AVB INTERFACE descriptor describes an interface implementing AVB functionality.
+ * This may be a wired jack, wireless interface, or other interface providing AVB
+ * services.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "build.h"
+#include "descriptor_base.h"
+
+namespace avdecc_lib
+{
+    class avb_interface_descriptor_response : public virtual descriptor_base
+    {
+    public:
+        /**
+         * \return The MAC address of the interface.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL mac_addr() = 0;
+        
+        /**
+         * The flags describing the features of the interface.
+         *
+         * \return 1 (GPTP Grandmaster Supported) if the interface supports the grandmaster functionality.
+         * \return 2 (GPTP Supported) if the interface supports the functionality.
+         * \return 4 (SRP Supported) if the interface supports the "Stream Reservation Protocol (SRP)" functionality.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL interface_flags() = 0;
+        
+        /**
+         * \return The clock identity of the interface.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL clock_identity() = 0;
+        
+        /**
+         * \return The priority1 field of the grandmaster functionality of the AVB INTERFACE if supported, 0xff otherwise.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint8_t STDCALL priority1() = 0;
+        
+        /**
+         * \return The clock class field of the grandmaster functionality of the AVB INTERFACE if supported, 0xff otherwise.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint8_t STDCALL clock_class() = 0;
+        
+        /**
+         * \return The offset scaled log variance field of the grandmaster functionality of the AVB INTERFACE if supported, 0 otherwise.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL offset_scaled_log_variance() = 0;
+        
+        /**
+         * \return The clock accuracy field of the grandmaster functionality of the AVB INTERFACE if supported, 0xff otherwise.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint8_t STDCALL clock_accuracy() = 0;
+        
+        /**
+         * \return The priority2 field of the grandmaster functionality of the AVB INTERFACE if supported, 0xff otherwise.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint8_t STDCALL priority2() = 0;
+        
+        /**
+         * \return The domain number field of the grandmaster functionality of the AVB INTERFACE if supported, 0 otherwise.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint8_t STDCALL domain_number() = 0;
+        
+        /**
+         * \return The current log sync interval field of the grandmaster functionality of the AVB INTERFACE if supported, 0 otherwise.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint8_t STDCALL log_sync_interval() = 0;
+        
+        /**
+         * \return The current log announce interval field of the grandmaster functionality of the AVB INTERFACE if supported, 0 otherwise.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint8_t STDCALL log_announce_interval() = 0;
+        
+        /**
+         * \return The current log pdelay interval field of the grandmaster functionality of the AVB INTERFACE if supported, 0 otherwise.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint8_t STDCALL log_pdelay_interval() = 0;
+        
+        /**
+         * \return The port number field as used by the functionality of the AVB INTERFACE if supported, 0 otherwise.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL port_number() = 0;
+    };
+}

--- a/controller/lib/include/avb_interface_descriptor_response.h
+++ b/controller/lib/include/avb_interface_descriptor_response.h
@@ -34,13 +34,27 @@
 
 #include <stdint.h>
 #include "build.h"
-#include "descriptor_base.h"
 
 namespace avdecc_lib
 {
-    class avb_interface_descriptor_response : public virtual descriptor_base
+    class avb_interface_descriptor_response
     {
     public:
+        virtual ~avb_interface_descriptor_response(){};
+        /**
+         * \return The name of the descriptor object. This may be user set through the use of a SET_NAME command.
+         *	   The object name should be left blank (all zeros) by the manufacturer, with the manufacturer
+         *	   defined value being provided in a localized form via the localized descripton field. By leaving
+         *	   this field blank an AVDECC Controller can determine if the user has overridden the name and can
+         *	   use this name rather than the localized name.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint8_t * STDCALL object_name() = 0;
+        
+        /**
+         * \return The localized string reference pointing to the localized descriptor name.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL localized_description() = 0;
+
         /**
          * \return The MAC address of the interface.
          */

--- a/controller/lib/include/clock_domain_counters_response.h
+++ b/controller/lib/include/clock_domain_counters_response.h
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * clock_domain_counters_response.h
+ *
+ * clock domain counters response base class
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "build.h"
+
+namespace avdecc_lib
+{
+    class clock_domain_counters_response
+    {
+    public:
+        /**
+         * \param name avdecc_lib::counter_labels
+         *
+         * \return the avb counter valid after the GET_COUNTERS command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_counter_valid(int name) = 0;
+        
+        /**
+         * \param name avdecc_lib::counter_labels
+         *
+         * \return the avb counter by name after the GET_COUNTERS command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_counter_by_name(int name) = 0;
+    };
+}

--- a/controller/lib/include/clock_domain_counters_response.h
+++ b/controller/lib/include/clock_domain_counters_response.h
@@ -37,6 +37,7 @@ namespace avdecc_lib
     class clock_domain_counters_response
     {
     public:
+        virtual ~clock_domain_counters_response(){};
         /**
          * \param name avdecc_lib::counter_labels
          *

--- a/controller/lib/include/clock_domain_descriptor.h
+++ b/controller/lib/include/clock_domain_descriptor.h
@@ -37,6 +37,9 @@
 #include <stdint.h>
 #include "build.h"
 #include "descriptor_base.h"
+#include "clock_domain_descriptor_response.h"
+#include "clock_domain_counters_response.h"
+#include "clock_domain_get_clock_source_response.h"
 
 namespace avdecc_lib
 {
@@ -44,33 +47,19 @@ namespace avdecc_lib
     {
     public:
         /**
-         * \return The descriptor index of the CLOCK SOURCE descriptor describing the current CLOCK SOURCE
-         *	       for the CLOCK DOMAIN.
+         * \return the clock_domain descriptor response class.
          */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL clock_source_index() = 0;
+        AVDECC_CONTROLLER_LIB32_API virtual clock_domain_descriptor_response * STDCALL get_clock_domain_response() = 0;
+        
+        /**
+         * \return the clock_domain descriptor counters.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual clock_domain_counters_response * STDCALL get_clock_domain_counters_response() = 0;
 
         /**
-         * \return The number of CLOCK SOURCE indexes in the clock sources field. The maximum value for this field
-         *	       is 249 for this version of AEM.
+         * \return the clock_domain get clock source response class.
          */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL clock_sources_count() = 0;
-
-        /**
-         * \return The corresponding Clock Sources by index present in the CLOCK DOMAIN.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_clock_source_by_index(size_t clk_src_index) = 0;
-
-        /**
-         * \return The CLOCK SOURCE index of the requested CLOCK DOMAIN after sending a
-         *	       SET_CLOCK_SOURCE command and receiving a response back for the command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL set_clock_source_clock_source_index() = 0;
-
-        /**
-         * \return The CLOCK SOURCE index of the requested CLOCK DOMAIN after sending a
-         *	       GET_CLOCK_SOURCE command and receiving a response back for the command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_clock_source_clock_source_index() = 0;
+        AVDECC_CONTROLLER_LIB32_API virtual clock_domain_get_clock_source_response * STDCALL get_clock_domain_get_clock_source_response() = 0;
 
         /**
          * Send a SET_CLOCK_SOURCE command to change the CLOCK SOURCE of a CLOCK DOMAIN.
@@ -98,24 +87,8 @@ namespace avdecc_lib
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_get_clock_source_cmd(void *notification_id) = 0;
         
         /**
-         * Send a GET_COUNTERS command to get the counters of the AVDECC Entity.
+         * Send a GET_COUNTERS command to get the clock_domain counters of the AVDECC Entity.
          */
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_get_counters_cmd(void *notification_id) = 0;
-        
-        /**
-         * \param name avdecc_lib::counter_labels
-         *
-         * \return the clock_domain counters after the GET_COUNTERS command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_counter_valid(int name) = 0;
-        
-        /**
-         * \param name avdecc_lib::counter_labels
-         *
-         * \return the clock_domain counters block after the GET_COUNTERS command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_counter_by_name(int name) = 0;
-
     };
 }
-

--- a/controller/lib/include/clock_domain_descriptor.h
+++ b/controller/lib/include/clock_domain_descriptor.h
@@ -52,7 +52,7 @@ namespace avdecc_lib
         AVDECC_CONTROLLER_LIB32_API virtual clock_domain_descriptor_response * STDCALL get_clock_domain_response() = 0;
         
         /**
-         * \return the clock_domain descriptor counters.
+         * \return the clock_domain descriptor counters response class.
          */
         AVDECC_CONTROLLER_LIB32_API virtual clock_domain_counters_response * STDCALL get_clock_domain_counters_response() = 0;
 

--- a/controller/lib/include/clock_domain_descriptor_response.h
+++ b/controller/lib/include/clock_domain_descriptor_response.h
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * clock_domain_descriptor_response.h
+ *
+ * Public CLOCK DOMAIN descriptor response interface class
+ * The CLOCK DOMAIN descriptor describes a source of a common clock signal within an
+ * AVDECC Entity. This could be the output from a PLL, which can be locked to a
+ * number of sources or a clock signal generator. The CLOCK DOMAIN allows for the
+ * selection of the CLOCK SOURCE of the domain and determines what the valid
+ * sources are for the domain.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "build.h"
+#include "descriptor_base.h"
+
+namespace avdecc_lib
+{
+    class clock_domain_descriptor_response : public virtual descriptor_base
+    {
+    public:
+        /**
+         * \return The descriptor index of the CLOCK SOURCE descriptor describing the current CLOCK SOURCE
+         *	       for the CLOCK DOMAIN.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL clock_source_index() = 0;
+        
+        /**
+         * \return The number of CLOCK SOURCE indexes in the clock sources field. The maximum value for this field
+         *	       is 249 for this version of AEM.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL clock_sources_count() = 0;
+
+        /**
+         * \return The list of CLOCK_SOURCE descriptor indices which the clock_source index may be set to.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_clock_source_by_index(size_t clk_src_index) = 0;
+    };
+}

--- a/controller/lib/include/clock_domain_descriptor_response.h
+++ b/controller/lib/include/clock_domain_descriptor_response.h
@@ -36,13 +36,27 @@
 
 #include <stdint.h>
 #include "build.h"
-#include "descriptor_base.h"
 
 namespace avdecc_lib
 {
-    class clock_domain_descriptor_response : public virtual descriptor_base
+    class clock_domain_descriptor_response
     {
     public:
+        virtual ~clock_domain_descriptor_response(){};
+        /**
+         * \return The name of the descriptor object. This may be user set through the use of a SET_NAME command.
+         *	   The object name should be left blank (all zeros) by the manufacturer, with the manufacturer
+         *	   defined value being provided in a localized form via the localized descripton field. By leaving
+         *	   this field blank an AVDECC Controller can determine if the user has overridden the name and can
+         *	   use this name rather than the localized name.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint8_t * STDCALL object_name() = 0;
+        
+        /**
+         * \return The localized string reference pointing to the localized descriptor name.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL localized_description() = 0;
+
         /**
          * \return The descriptor index of the CLOCK SOURCE descriptor describing the current CLOCK SOURCE
          *	       for the CLOCK DOMAIN.

--- a/controller/lib/include/clock_domain_get_clock_source_response.h
+++ b/controller/lib/include/clock_domain_get_clock_source_response.h
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * clock_domain_get_clock_source_response.h
+ *
+ * CLOCK DOMAIN stream format response base class
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "build.h"
+
+namespace avdecc_lib
+{
+    class clock_domain_get_clock_source_response
+    {
+    public:
+        /**
+         * \return The stream format of a stream after sending a GET_clock_source command and
+         *	       receiving a response back for the command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_clock_source_clock_source_index() = 0;
+    };
+}

--- a/controller/lib/include/clock_domain_get_clock_source_response.h
+++ b/controller/lib/include/clock_domain_get_clock_source_response.h
@@ -24,7 +24,7 @@
 /**
  * clock_domain_get_clock_source_response.h
  *
- * CLOCK DOMAIN stream format response base class
+ * CLOCK DOMAIN get clock source response base class
  */
 
 #pragma once
@@ -37,6 +37,7 @@ namespace avdecc_lib
     class clock_domain_get_clock_source_response
     {
     public:
+        virtual ~clock_domain_get_clock_source_response(){};
         /**
          * \return The stream format of a stream after sending a GET_clock_source command and
          *	       receiving a response back for the command.

--- a/controller/lib/include/clock_source_descriptor.h
+++ b/controller/lib/include/clock_source_descriptor.h
@@ -35,6 +35,7 @@
 #include <stdint.h>
 #include "build.h"
 #include "descriptor_base.h"
+#include "clock_source_descriptor_response.h"
 
 namespace avdecc_lib
 {
@@ -42,36 +43,8 @@ namespace avdecc_lib
     {
     public:
         /**
-         * The flags describing the capabilities or features of the CLOCK SOURCE.
-         *
-         * \return 1 (Stream ID) if the Input Stream CLOCK SOURCE is identified by the stream ID. \n
-         *	       2 (Local ID) if the Input Stream CLOCK SOURCE is identified by it's local ID.
+         * \return the clock_source descriptor response class.
          */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL clock_source_flags() = 0;
-
-        /**
-         * The type of CLOCK SOURCE.
-         *
-         * \return 0 (Internal) if the clock is sourced from within the entity such as from a crystal oscillator. \n
-         *	       1 (External) if the clock is sourced from an external connection on the entity via a Jack. \n
-         *	       2 (Input Stream) if the clock is sourced from the media clock of an Input Stream.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL clock_source_type() = 0;
-
-        /**
-         * \return The identifier of the CLOCK SOURCE.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL clock_source_identifier() = 0;
-
-        /**
-         * \return The descriptor type of the object that this CLOCK SOURCE is associated with.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL clock_source_location_type() = 0;
-
-        /**
-         * \return The descriptor index of the object that this CLOCK SOURCE is associated with.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL clock_source_location_index() = 0;
+        AVDECC_CONTROLLER_LIB32_API virtual clock_source_descriptor_response * STDCALL get_clock_source_response() = 0;
     };
 }
-

--- a/controller/lib/include/clock_source_descriptor_response.h
+++ b/controller/lib/include/clock_source_descriptor_response.h
@@ -34,13 +34,27 @@
 
 #include <stdint.h>
 #include "build.h"
-#include "descriptor_base.h"
 
 namespace avdecc_lib
 {
-    class clock_source_descriptor_response : public virtual descriptor_base
+    class clock_source_descriptor_response
     {
     public:
+        virtual ~clock_source_descriptor_response(){};
+        /**
+         * \return The name of the descriptor object. This may be user set through the use of a SET_NAME command.
+         *	   The object name should be left blank (all zeros) by the manufacturer, with the manufacturer
+         *	   defined value being provided in a localized form via the localized descripton field. By leaving
+         *	   this field blank an AVDECC Controller can determine if the user has overridden the name and can
+         *	   use this name rather than the localized name.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint8_t * STDCALL object_name() = 0;
+        
+        /**
+         * \return The localized string reference pointing to the localized descriptor name.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL localized_description() = 0;
+
         /**
          * The flags describing the capabilities or features of the CLOCK SOURCE.
          *

--- a/controller/lib/include/clock_source_descriptor_response.h
+++ b/controller/lib/include/clock_source_descriptor_response.h
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2013 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * clock_source_descriptor_response.h
+ *
+ * Public CLOCK SOURCE descriptor response interface class
+ * The CLOCK SOURCE descriptor describes a CLOCK SOURCE. A CLOCK SOURCE may be an
+ * internal oscillator, an external CLOCK SOURCE such as a word clock or SPDIF
+ * jack or an Input Stream.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "build.h"
+#include "descriptor_base.h"
+
+namespace avdecc_lib
+{
+    class clock_source_descriptor_response : public virtual descriptor_base
+    {
+    public:
+        /**
+         * The flags describing the capabilities or features of the CLOCK SOURCE.
+         *
+         * \return 1 (Stream ID) if the Input Stream CLOCK SOURCE is identified by the stream ID. \n
+         *	       2 (Local ID) if the Input Stream CLOCK SOURCE is identified by it's local ID.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL clock_source_flags() = 0;
+        
+        /**
+         * The type of CLOCK SOURCE.
+         *
+         * \return 0 (Internal) if the clock is sourced from within the entity such as from a crystal oscillator. \n
+         *	       1 (External) if the clock is sourced from an external connection on the entity via a Jack. \n
+         *	       2 (Input Stream) if the clock is sourced from the media clock of an Input Stream.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL clock_source_type() = 0;
+        
+        /**
+         * \return The identifier of the CLOCK SOURCE.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL clock_source_identifier() = 0;
+        
+        /**
+         * \return The descriptor type of the object that this CLOCK SOURCE is associated with.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL clock_source_location_type() = 0;
+        
+        /**
+         * \return The descriptor index of the object that this CLOCK SOURCE is associated with.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL clock_source_location_index() = 0;
+    };
+}

--- a/controller/lib/include/configuration_descriptor.h
+++ b/controller/lib/include/configuration_descriptor.h
@@ -278,4 +278,3 @@ namespace avdecc_lib
         AVDECC_CONTROLLER_LIB32_API virtual external_port_output_descriptor * STDCALL get_external_port_output_desc_by_index(size_t index) = 0;
     };
 }
-

--- a/controller/lib/include/control_descriptor.h
+++ b/controller/lib/include/control_descriptor.h
@@ -33,73 +33,13 @@
 #include <stdint.h>
 #include "build.h"
 #include "descriptor_base.h"
+#include "control_descriptor_response.h"
 
 namespace avdecc_lib
 {
     class control_descriptor : public virtual descriptor_base
     {
     public:
-        /**
-         * \return This is the latency in nanoseconds between the output of the previous
-         *		   block and its output. The previous block is the object identified by the
-         *		   signal_type and signal_index fields. For a DELAY Control, the value
-         *		   of the delay is not included in this value.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL block_latency() = 0;
-        
-        /**
-         * \return The worst-case time in microseconds from when a Control value
-         *		change is received and when the Control has completely switched to
-         *		the new value.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL control_latency() = 0;
-        
-        /**
-         * \return The domain that this Control belongs to.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL control_domain() = 0;
-        
-        /**
-         * \return The type of the value contained in the Control as defined in 7.3.5.1
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL control_value_type() = 0;
-        
-        /**
-         * \return The type of the Control.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL control_type() = 0;
-        
-        /**
-         * \return The time period in milliseconds from when a Control is set with the 
-         *  SET_CONTROL command until it automatically resets to its default values.
-         *  When this is zero (0), automatic resets do not happen.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL reset_time() = 0;
-        
-        /**
-         * \return The offset from the start of the descriptor for the first octet
-         *  of the value_details. The field is 104 for this version of AEM.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL values_offset() = 0;
-        
-        /**
-         * \return The number of value settings this Control has.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_values() = 0;
-        
-        /**
-         * \return The descriptor_type for the signal source of the Control.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL signal_type() = 0;
-        
-        /**
-         * \return The descriptor_index for the signal source of the Control.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL signal_index() = 0;
-        
-        /**
-         * \return The index of the output of the signal source of the Control.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL signal_output() = 0;
+        AVDECC_CONTROLLER_LIB32_API virtual control_descriptor_response * STDCALL get_control_response() = 0;
     };
 }

--- a/controller/lib/include/control_descriptor_response.h
+++ b/controller/lib/include/control_descriptor_response.h
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 Renkus-Heinz Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * control_descriptor_response.h
+ *
+ * Public CONTROL descriptor response interface class
+ * The CONTROL descriptor describes a generic Control.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "build.h"
+#include "descriptor_base.h"
+
+namespace avdecc_lib
+{
+    class control_descriptor_response : public virtual descriptor_base
+    {
+    public:
+        /**
+         * \return This is the latency in nanoseconds between the output of the previous
+         *		   block and its output. The previous block is the object identified by the
+         *		   signal_type and signal_index fields. For a DELAY Control, the value
+         *		   of the delay is not included in this value.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL block_latency() = 0;
+        
+        /**
+         * \return The worst-case time in microseconds from when a Control value
+         *		change is received and when the Control has completely switched to
+         *		the new value.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL control_latency() = 0;
+        
+        /**
+         * \return The domain that this Control belongs to.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL control_domain() = 0;
+        
+        /**
+         * \return The type of the value contained in the Control as defined in 7.3.5.1
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL control_value_type() = 0;
+        
+        /**
+         * \return The type of the Control.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL control_type() = 0;
+        
+        /**
+         * \return The time period in milliseconds from when a Control is set with the
+         *  SET_CONTROL command until it automatically resets to its default values.
+         *  When this is zero (0), automatic resets do not happen.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL reset_time() = 0;
+        
+        /**
+         * \return The offset from the start of the descriptor for the first octet
+         *  of the value_details. The field is 104 for this version of AEM.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL values_offset() = 0;
+        
+        /**
+         * \return The number of value settings this Control has.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_values() = 0;
+        
+        /**
+         * \return The descriptor_type for the signal source of the Control.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL signal_type() = 0;
+        
+        /**
+         * \return The descriptor_index for the signal source of the Control.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL signal_index() = 0;
+        
+        /**
+         * \return The index of the output of the signal source of the Control.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL signal_output() = 0;
+    };
+}

--- a/controller/lib/include/control_descriptor_response.h
+++ b/controller/lib/include/control_descriptor_response.h
@@ -32,13 +32,27 @@
 
 #include <stdint.h>
 #include "build.h"
-#include "descriptor_base.h"
 
 namespace avdecc_lib
 {
-    class control_descriptor_response : public virtual descriptor_base
+    class control_descriptor_response
     {
     public:
+        virtual ~control_descriptor_response(){};
+        /**
+         * \return The name of the descriptor object. This may be user set through the use of a SET_NAME command.
+         *	   The object name should be left blank (all zeros) by the manufacturer, with the manufacturer
+         *	   defined value being provided in a localized form via the localized descripton field. By leaving
+         *	   this field blank an AVDECC Controller can determine if the user has overridden the name and can
+         *	   use this name rather than the localized name.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint8_t * STDCALL object_name() = 0;
+        
+        /**
+         * \return The localized string reference pointing to the localized descriptor name.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL localized_description() = 0;
+
         /**
          * \return This is the latency in nanoseconds between the output of the previous
          *		   block and its output. The previous block is the object identified by the

--- a/controller/lib/include/descriptor_base.h
+++ b/controller/lib/include/descriptor_base.h
@@ -40,6 +40,7 @@ namespace avdecc_lib
     class descriptor_base
     {
     public:
+        virtual ~descriptor_base(){}
         /**
          * \return The type of the descriptor.
          */

--- a/controller/lib/include/descriptor_base.h
+++ b/controller/lib/include/descriptor_base.h
@@ -31,6 +31,7 @@
 
 #include <stdint.h>
 #include "build.h"
+#include "response_frame.h"
 
 namespace avdecc_lib
 {
@@ -154,4 +155,3 @@ namespace avdecc_lib
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_get_name_cmd(void *notification_id, uint16_t name_index, uint16_t config_index) = 0;
     };
 }
-

--- a/controller/lib/include/entity_descriptor.h
+++ b/controller/lib/include/entity_descriptor.h
@@ -35,6 +35,7 @@
 #include <stdint.h>
 #include "build.h"
 #include "descriptor_base.h"
+#include "entity_descriptor_response.h"
 
 namespace avdecc_lib
 {
@@ -43,103 +44,11 @@ namespace avdecc_lib
     class entity_descriptor : public virtual descriptor_base
     {
     public:
+        
         /**
-         * \return The Entity ID of the AVDECC Entity.
+         * \return the entity descriptor response class.
          */
-        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL entity_id() = 0;
-
-        /**
-         * \return The vendor id of the AVDECC Entity.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL vendor_id() = 0;
-
-        /**
-         * \return The AVDECC Entity model id for the AVDECC Entity.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL entity_model_id() = 0;
-
-        /**
-         * \return The capabilities of the AVDECC Entity.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL entity_capabilities() = 0;
-
-        /**
-         * \return The number of Output Streams the AVDECC Entity has. This is also the number
-         *	       of STREAM_OUTPUT descriptors the AVDECC Entity has for Output Streams.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL talker_stream_sources() = 0;
-
-        /**
-         * \return The AVDECC Talker capabilities of the AVDECC Entity.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL talker_capabilities() = 0;
-
-        /**
-         * \return The number of Input Streams the AVDECC Entity has. This is also the number
-         *         of STREAM_INPUT descriptors the AVDECC Entity has for Input Streams.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL listener_stream_sinks() = 0;
-
-        /**
-         * \return The AVDECC Listener capabilities of the AVDECC Entity.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL listener_capabilities() = 0;
-
-        /**
-         * \return The AVDECC Controller capabilities of the AVDECC Entity.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL controller_capabilities() = 0;
-
-        /**
-         * \return The available index of the AVDECC Entity.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL available_index() = 0;
-
-        /**
-         * \return The association ID for the AVDECC Entity.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL association_id() = 0;
-
-        /**
-         * \return The name of the AVDECC Entity. This may be user set through the use of a SET_NAME command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint8_t * STDCALL entity_name() = 0;
-
-        /**
-         * \return The localized string reference pointing to the localized vendor name.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL vendor_name_string() = 0;
-
-        /**
-         * \return The localized string reference pointing to the localized model name.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL model_name_string() = 0;
-
-        /**
-         * \return The firmware version of the AVDECC Entity.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint8_t * STDCALL firmware_version() = 0;
-
-        /**
-         * \return The group name of the AVDECC Entity. This may be user set through the use of a SET_NAME command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint8_t * STDCALL group_name() = 0;
-
-        /**
-         * \return The serial number of the AVDECC Entity.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint8_t * STDCALL serial_number() = 0;
-
-        /**
-         * \return The number of Configurations the device has. A device is required to have at least 1 Configuration.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL configurations_count() = 0;
-
-        /**
-         * \return The index of the currently set Configuration.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL current_configuration() = 0;
-
+        AVDECC_CONTROLLER_LIB32_API virtual entity_descriptor_response * STDCALL get_entity_response() = 0;
         /**
          * \return The number of Configuration descriptors.
          * \see configurations_count()
@@ -147,7 +56,7 @@ namespace avdecc_lib
         AVDECC_CONTROLLER_LIB32_API virtual size_t STDCALL config_desc_count() = 0;
 
         /**
-         * \return The corresponding Configuration descriptorby index.
+         * \return The corresponding Configuration descriptor by index.
          */
         AVDECC_CONTROLLER_LIB32_API virtual configuration_descriptor * STDCALL get_config_desc_by_index(uint16_t config_desc_index) = 0;
 

--- a/controller/lib/include/entity_descriptor_response.h
+++ b/controller/lib/include/entity_descriptor_response.h
@@ -1,0 +1,141 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * entity_descriptor_response.h
+ *
+ * Public ENTITY descriptor interface response class
+ * The ENTITY descriptor describes the highest level of the AVDECC Entity. It repeats some of the information
+ * contained within the ADP advertise for the AVDECC Entity as well as the information required to read the
+ * rest of the descriptors from the AVDECC Entity.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "build.h"
+#include "descriptor_base.h"
+
+namespace avdecc_lib
+{
+    class entity_descriptor_response : public virtual descriptor_base
+    {
+    public:
+        /**
+         * \return The Entity ID of the AVDECC Entity.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL entity_id() = 0;
+        
+        /**
+         * \return The vendor id of the AVDECC Entity.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL vendor_id() = 0;
+        
+        /**
+         * \return The AVDECC Entity model id for the AVDECC Entity.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL entity_model_id() = 0;
+        
+        /**
+         * \return The capabilities of the AVDECC Entity.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL entity_capabilities() = 0;
+        
+        /**
+         * \return The number of Output Streams the AVDECC Entity has. This is also the number
+         *	       of STREAM_OUTPUT descriptors the AVDECC Entity has for Output Streams.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL talker_stream_sources() = 0;
+        
+        /**
+         * \return The AVDECC Talker capabilities of the AVDECC Entity.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL talker_capabilities() = 0;
+        
+        /**
+         * \return The number of Input Streams the AVDECC Entity has. This is also the number
+         *         of STREAM_INPUT descriptors the AVDECC Entity has for Input Streams.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL listener_stream_sinks() = 0;
+        
+        /**
+         * \return The AVDECC Listener capabilities of the AVDECC Entity.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL listener_capabilities() = 0;
+        
+        /**
+         * \return The AVDECC Controller capabilities of the AVDECC Entity.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL controller_capabilities() = 0;
+        
+        /**
+         * \return The available index of the AVDECC Entity.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL available_index() = 0;
+        
+        /**
+         * \return The association ID for the AVDECC Entity.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL association_id() = 0;
+        
+        /**
+         * \return The name of the AVDECC Entity. This may be user set through the use of a SET_NAME command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint8_t * STDCALL entity_name() = 0;
+        
+        /**
+         * \return The localized string reference pointing to the localized vendor name.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL vendor_name_string() = 0;
+        
+        /**
+         * \return The localized string reference pointing to the localized model name.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL model_name_string() = 0;
+        
+        /**
+         * \return The firmware version of the AVDECC Entity.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint8_t * STDCALL firmware_version() = 0;
+        
+        /**
+         * \return The group name of the AVDECC Entity. This may be user set through the use of a SET_NAME command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint8_t * STDCALL group_name() = 0;
+        
+        /**
+         * \return The serial number of the AVDECC Entity.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint8_t * STDCALL serial_number() = 0;
+        
+        /**
+         * \return The number of Configurations the device has. A device is required to have at least 1 Configuration.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL configurations_count() = 0;
+        
+        /**
+         * \return The index of the currently set Configuration.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL current_configuration() = 0;
+    };
+}

--- a/controller/lib/include/entity_descriptor_response.h
+++ b/controller/lib/include/entity_descriptor_response.h
@@ -34,13 +34,13 @@
 
 #include <stdint.h>
 #include "build.h"
-#include "descriptor_base.h"
 
 namespace avdecc_lib
 {
-    class entity_descriptor_response : public virtual descriptor_base
+    class entity_descriptor_response
     {
     public:
+        virtual ~entity_descriptor_response(){};
         /**
          * \return The Entity ID of the AVDECC Entity.
          */

--- a/controller/lib/include/external_port_input_descriptor.h
+++ b/controller/lib/include/external_port_input_descriptor.h
@@ -32,6 +32,7 @@
 #include <stdint.h>
 #include "build.h"
 #include "descriptor_base.h"
+#include "external_port_input_descriptor_response.h"
 
 namespace avdecc_lib
 {
@@ -39,49 +40,9 @@ namespace avdecc_lib
     {
     public:
         /**
-         * \return The flags describing the capabilities or features of the port.
+         * \return the external port input descriptor response class.
          */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL port_flags() = 0;
-
-        /**
-         * The index of the CLOCK_DOMAIN descriptor that describes the clock domain for the port.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL clock_domain_index() = 0;
-
-        /**
-        * \return The number of controls within this jack.
-        */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_controls() = 0;
-
-        /**
-        * \return The index of the first Control descriptor.
-        */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_control() = 0;
-
-        /**
-         * \return The signal type.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL signal_type() = 0;
-
-        /**
-        * \return The signal index.
-        */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL signal_index() = 0;
-
-        /**
-        * \return The signal output.
-        */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL signal_output() = 0;
-
-        /**
-        * \return Latency in nanoseconds.
-        */
-        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL block_latency() = 0;
-
-        /**
-        * \return The index of the jack connected to the port.
-        */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL jack_index() = 0;
+        AVDECC_CONTROLLER_LIB32_API virtual STDCALL external_port_input_descriptor_response * get_external_port_input_response() = 0;
     };
 }
 

--- a/controller/lib/include/external_port_input_descriptor.h
+++ b/controller/lib/include/external_port_input_descriptor.h
@@ -42,7 +42,7 @@ namespace avdecc_lib
         /**
          * \return the external port input descriptor response class.
          */
-        AVDECC_CONTROLLER_LIB32_API virtual STDCALL external_port_input_descriptor_response * get_external_port_input_response() = 0;
+        AVDECC_CONTROLLER_LIB32_API virtual external_port_input_descriptor_response * STDCALL get_external_port_input_response() = 0;
     };
 }
 

--- a/controller/lib/include/external_port_input_descriptor_response.h
+++ b/controller/lib/include/external_port_input_descriptor_response.h
@@ -38,6 +38,7 @@ namespace avdecc_lib
     class external_port_input_descriptor_response : public virtual descriptor_base
     {
     public:
+        virtual ~external_port_input_descriptor_response(){};
         /**
          * \return The flags describing the capabilities or features of the port.
          */

--- a/controller/lib/include/external_port_input_descriptor_response.h
+++ b/controller/lib/include/external_port_input_descriptor_response.h
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * external_port_input_descriptor_response.h
+ *
+ * Public EXTERNAL PORT INPUT descriptor response interface class
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "build.h"
+#include "descriptor_base.h"
+
+namespace avdecc_lib
+{
+    class external_port_input_descriptor_response : public virtual descriptor_base
+    {
+    public:
+        /**
+         * \return The flags describing the capabilities or features of the port.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL port_flags() = 0;
+        
+        /**
+         * The index of the CLOCK_DOMAIN descriptor that describes the clock domain for the port.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL clock_domain_index() = 0;
+        
+        /**
+         * \return The number of controls within this jack.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_controls() = 0;
+        
+        /**
+         * \return The index of the first Control descriptor.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_control() = 0;
+        
+        /**
+         * \return The signal type.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL signal_type() = 0;
+        
+        /**
+         * \return The signal index.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL signal_index() = 0;
+        
+        /**
+         * \return The signal output.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL signal_output() = 0;
+        
+        /**
+         * \return Latency in nanoseconds.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL block_latency() = 0;
+        
+        /**
+         * \return The index of the jack connected to the port.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL jack_index() = 0;
+    };
+}

--- a/controller/lib/include/external_port_output_descriptor.h
+++ b/controller/lib/include/external_port_output_descriptor.h
@@ -40,7 +40,7 @@ namespace avdecc_lib
     {
     public:
         /**
-         * \return the external port input descriptor response class.
+         * \return the external port output descriptor response class.
          */
         AVDECC_CONTROLLER_LIB32_API virtual STDCALL external_port_output_descriptor_response * get_external_port_output_response() = 0;
     };

--- a/controller/lib/include/external_port_output_descriptor.h
+++ b/controller/lib/include/external_port_output_descriptor.h
@@ -42,6 +42,6 @@ namespace avdecc_lib
         /**
          * \return the external port output descriptor response class.
          */
-        AVDECC_CONTROLLER_LIB32_API virtual STDCALL external_port_output_descriptor_response * get_external_port_output_response() = 0;
+        AVDECC_CONTROLLER_LIB32_API virtual external_port_output_descriptor_response * STDCALL get_external_port_output_response() = 0;
     };
 }

--- a/controller/lib/include/external_port_output_descriptor.h
+++ b/controller/lib/include/external_port_output_descriptor.h
@@ -32,6 +32,7 @@
 #include <stdint.h>
 #include "build.h"
 #include "descriptor_base.h"
+#include "external_port_output_descriptor_response.h"
 
 namespace avdecc_lib
 {
@@ -39,49 +40,8 @@ namespace avdecc_lib
     {
     public:
         /**
-         * \return The flags describing the capabilities or features of the port.
+         * \return the external port input descriptor response class.
          */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL port_flags() = 0;
-
-        /**
-         * The index of the CLOCK_DOMAIN descriptor that describes the clock domain for the port.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL clock_domain_index() = 0;
-
-        /**
-        * \return The number of controls within this jack.
-        */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_controls() = 0;
-
-        /**
-        * \return The index of the first Control descriptor.
-        */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_control() = 0;
-
-        /**
-         * \return The signal type.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL signal_type() = 0;
-
-        /**
-        * \return The signal index.
-        */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL signal_index() = 0;
-
-        /**
-        * \return The signal output.
-        */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL signal_output() = 0;
-
-        /**
-        * \return Latency in nanoseconds.
-        */
-        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL block_latency() = 0;
-
-        /**
-        * \return The index of the jack connected to the port.
-        */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL jack_index() = 0;
+        AVDECC_CONTROLLER_LIB32_API virtual STDCALL external_port_output_descriptor_response * get_external_port_output_response() = 0;
     };
 }
-

--- a/controller/lib/include/external_port_output_descriptor_response.h
+++ b/controller/lib/include/external_port_output_descriptor_response.h
@@ -31,13 +31,13 @@
 
 #include <stdint.h>
 #include "build.h"
-#include "descriptor_base.h"
 
 namespace avdecc_lib
 {
-    class external_port_output_descriptor_response : public virtual descriptor_base
+    class external_port_output_descriptor_response
     {
     public:
+        virtual ~external_port_output_descriptor_response(){};
         /**
          * \return The flags describing the capabilities or features of the port.
          */

--- a/controller/lib/include/external_port_output_descriptor_response.h
+++ b/controller/lib/include/external_port_output_descriptor_response.h
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * external_port_output_descriptor_response.h
+ *
+ * Public EXTERNAL PORT OUTPUT descriptor response interface class
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "build.h"
+#include "descriptor_base.h"
+
+namespace avdecc_lib
+{
+    class external_port_output_descriptor_response : public virtual descriptor_base
+    {
+    public:
+        /**
+         * \return The flags describing the capabilities or features of the port.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL port_flags() = 0;
+        
+        /**
+         * The index of the CLOCK_DOMAIN descriptor that describes the clock domain for the port.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL clock_domain_index() = 0;
+        
+        /**
+         * \return The number of controls within this jack.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_controls() = 0;
+        
+        /**
+         * \return The index of the first Control descriptor.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_control() = 0;
+        
+        /**
+         * \return The signal type.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL signal_type() = 0;
+        
+        /**
+         * \return The signal index.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL signal_index() = 0;
+        
+        /**
+         * \return The signal output.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL signal_output() = 0;
+        
+        /**
+         * \return Latency in nanoseconds.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL block_latency() = 0;
+        
+        /**
+         * \return The index of the jack connected to the port.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL jack_index() = 0;
+    };
+}

--- a/controller/lib/include/jack_input_descriptor.h
+++ b/controller/lib/include/jack_input_descriptor.h
@@ -43,6 +43,6 @@ namespace avdecc_lib
         /**
          * \return the jack input descriptor response class.
          */
-        AVDECC_CONTROLLER_LIB32_API virtual STDCALL jack_input_descriptor_response * get_jack_input_response() = 0;
+        AVDECC_CONTROLLER_LIB32_API virtual jack_input_descriptor_response * STDCALL get_jack_input_response() = 0;
     };
 }

--- a/controller/lib/include/jack_input_descriptor.h
+++ b/controller/lib/include/jack_input_descriptor.h
@@ -33,6 +33,7 @@
 #include <stdint.h>
 #include "build.h"
 #include "descriptor_base.h"
+#include "jack_input_descriptor_response.h"
 
 namespace avdecc_lib
 {
@@ -40,35 +41,8 @@ namespace avdecc_lib
     {
     public:
         /**
-         * \return The flags describing the capabilities or features of the Jack.
+         * \return the jack input descriptor response class.
          */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL jack_flags() = 0;
-
-        /**
-         * Check if the jack can be used as a clock synchronization source.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL jack_flag_clock_sync_source() = 0;
-
-        /**
-         * Check if the jack connection is hardwired, cannot be disconnected and
-         * may be physically within the device's structure.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL jack_flag_captive() = 0;
-
-        /**
-         * \return The type of the jack.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL jack_type() = 0;
-
-        /**
-         * \return The number of controls within this jack.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_controls() = 0;
-
-        /**
-         * \return The index of the first Control descriptor.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_control() = 0;
+        AVDECC_CONTROLLER_LIB32_API virtual STDCALL jack_input_descriptor_response * get_jack_input_response() = 0;
     };
 }
-

--- a/controller/lib/include/jack_input_descriptor_response.h
+++ b/controller/lib/include/jack_input_descriptor_response.h
@@ -32,13 +32,27 @@
 
 #include <stdint.h>
 #include "build.h"
-#include "descriptor_base.h"
 
 namespace avdecc_lib
 {
-    class jack_input_descriptor_response : public virtual descriptor_base
+    class jack_input_descriptor_response 
     {
     public:
+        virtual ~jack_input_descriptor_response(){};
+        /**
+         * \return The name of the descriptor object. This may be user set through the use of a SET_NAME command.
+         *	   The object name should be left blank (all zeros) by the manufacturer, with the manufacturer
+         *	   defined value being provided in a localized form via the localized descripton field. By leaving
+         *	   this field blank an AVDECC Controller can determine if the user has overridden the name and can
+         *	   use this name rather than the localized name.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint8_t * STDCALL object_name() = 0;
+        
+        /**
+         * \return The localized string reference pointing to the localized descriptor name.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL localized_description() = 0;
+
         /**
          * \return The flags describing the capabilities or features of the Jack.
          */

--- a/controller/lib/include/jack_input_descriptor_response.h
+++ b/controller/lib/include/jack_input_descriptor_response.h
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * jack_input_descriptor_response.h
+ *
+ * Public JACK INPUT descriptor response interface class
+ * The JACK INPUT descriptor describes an Input Jack.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "build.h"
+#include "descriptor_base.h"
+
+namespace avdecc_lib
+{
+    class jack_input_descriptor_response : public virtual descriptor_base
+    {
+    public:
+        /**
+         * \return The flags describing the capabilities or features of the Jack.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL jack_flags() = 0;
+        
+        /**
+         * Check if the jack can be used as a clock synchronization source.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL jack_flag_clock_sync_source() = 0;
+        
+        /**
+         * Check if the jack connection is hardwired, cannot be disconnected and
+         * may be physically within the device's structure.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL jack_flag_captive() = 0;
+        
+        /**
+         * \return The type of the jack.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL jack_type() = 0;
+        
+        /**
+         * \return The number of controls within this jack.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_controls() = 0;
+        
+        /**
+         * \return The index of the first Control descriptor.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_control() = 0;
+    };
+}

--- a/controller/lib/include/jack_output_descriptor.h
+++ b/controller/lib/include/jack_output_descriptor.h
@@ -33,6 +33,7 @@
 #include <stdint.h>
 #include "build.h"
 #include "descriptor_base.h"
+#include "jack_output_descriptor_response.h"
 
 namespace avdecc_lib
 {
@@ -40,35 +41,9 @@ namespace avdecc_lib
     {
     public:
         /**
-         * \return The flags describing the capabilities or features of the Jack.
+         * \return the jack output descriptor response class.
          */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL jack_flags() = 0;
-
-        /**
-         * Check if the jack can be used as a clock synchronization source.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL jack_flag_clock_sync_source() = 0;
-
-        /**
-         * Check if the jack connection is hardwired, cannot be disconnected and
-         * may be physically within the device's structure.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL jack_flag_captive() = 0;
-
-        /**
-         * \return The type of the jack.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL jack_type() = 0;
-
-        /**
-         * \return The number of controls within this jack.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_controls() = 0;
-
-        /**
-         * \return The index of the first Control descriptor.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_control() = 0;
+        AVDECC_CONTROLLER_LIB32_API virtual STDCALL jack_output_descriptor_response * get_jack_output_response() = 0;
     };
 }
 

--- a/controller/lib/include/jack_output_descriptor.h
+++ b/controller/lib/include/jack_output_descriptor.h
@@ -43,7 +43,7 @@ namespace avdecc_lib
         /**
          * \return the jack output descriptor response class.
          */
-        AVDECC_CONTROLLER_LIB32_API virtual STDCALL jack_output_descriptor_response * get_jack_output_response() = 0;
+        AVDECC_CONTROLLER_LIB32_API virtual jack_output_descriptor_response * STDCALL get_jack_output_response() = 0;
     };
 }
 

--- a/controller/lib/include/jack_output_descriptor_response.h
+++ b/controller/lib/include/jack_output_descriptor_response.h
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * jack_output_descriptor_response.h
+ *
+ * Public JACK OUTPUT descriptor response interface class
+ * The JACK OUTPUT descriptor describes an Output Jack.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "build.h"
+#include "descriptor_base.h"
+
+namespace avdecc_lib
+{
+    class jack_output_descriptor_response : public virtual descriptor_base
+    {
+    public:
+        /**
+         * \return The flags describing the capabilities or features of the Jack.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL jack_flags() = 0;
+        
+        /**
+         * Check if the jack can be used as a clock synchronization source.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL jack_flag_clock_sync_source() = 0;
+        
+        /**
+         * Check if the jack connection is hardwired, cannot be disconnected and
+         * may be physically within the device's structure.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL jack_flag_captive() = 0;
+        
+        /**
+         * \return The type of the jack.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL jack_type() = 0;
+        
+        /**
+         * \return The number of controls within this jack.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_controls() = 0;
+        
+        /**
+         * \return The index of the first Control descriptor.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_control() = 0;
+    };
+}

--- a/controller/lib/include/jack_output_descriptor_response.h
+++ b/controller/lib/include/jack_output_descriptor_response.h
@@ -32,13 +32,27 @@
 
 #include <stdint.h>
 #include "build.h"
-#include "descriptor_base.h"
 
 namespace avdecc_lib
 {
-    class jack_output_descriptor_response : public virtual descriptor_base
+    class jack_output_descriptor_response
     {
     public:
+        virtual ~jack_output_descriptor_response(){};
+        /**
+         * \return The name of the descriptor object. This may be user set through the use of a SET_NAME command.
+         *	   The object name should be left blank (all zeros) by the manufacturer, with the manufacturer
+         *	   defined value being provided in a localized form via the localized descripton field. By leaving
+         *	   this field blank an AVDECC Controller can determine if the user has overridden the name and can
+         *	   use this name rather than the localized name.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint8_t * STDCALL object_name() = 0;
+        
+        /**
+         * \return The localized string reference pointing to the localized descriptor name.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL localized_description() = 0;
+
         /**
          * \return The flags describing the capabilities or features of the Jack.
          */

--- a/controller/lib/include/locale_descriptor.h
+++ b/controller/lib/include/locale_descriptor.h
@@ -34,6 +34,7 @@
 #include <stdint.h>
 #include "build.h"
 #include "descriptor_base.h"
+#include "locale_descriptor_response.h"
 
 namespace avdecc_lib
 {
@@ -41,25 +42,8 @@ namespace avdecc_lib
     {
     public:
         /**
-         * The identifier is a UTF-8 string that contains one to three components such as a
-         * language code, a region code, or a variant code, separated by the dash character.
-         * Examples of valid locale identifiers are en-US for English in the US, en-AU for
-         * English in Australia, haw-US for Hawaiian in the US, and fr-CA for French in Canada.
-         *
-         * \return The identifier of the LOCALE.
+         *  \return the locale descriptor response class.
          */
-        AVDECC_CONTROLLER_LIB32_API virtual uint8_t * STDCALL locale_identifier() = 0;
-
-        /**
-         * \return The number of Strings descriptor in this locale. This is the same value for
-         *	       all locales in an AVDECC Entity.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_strings() = 0;
-
-        /**
-         * \return The descriptor index of the first Strings descriptor for this LOCALE.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_strings() = 0;
+        AVDECC_CONTROLLER_LIB32_API virtual locale_descriptor_response * STDCALL get_locale_response() = 0;
     };
 }
-

--- a/controller/lib/include/locale_descriptor_response.h
+++ b/controller/lib/include/locale_descriptor_response.h
@@ -33,14 +33,21 @@
 
 #include <stdint.h>
 #include "build.h"
-#include "descriptor_base.h"
 
 namespace avdecc_lib
 {
-    class locale_descriptor_response : public virtual descriptor_base
+    class locale_descriptor_response
     {
     public:
-
+        virtual ~locale_descriptor_response(){};
+        /**
+        * The identifier is a UTF-8 string that contains one to three components such as a
+        * language code, a region code, or a variant code, separated by the dash character.
+        * Examples of valid locale identifiers are en-US for English in the US, en-AU for
+        * English in Australia, haw-US for Hawaiian in the US, and fr-CA for French in Canada.
+        *
+        * \return The identifier of the LOCALE.
+        */
         AVDECC_CONTROLLER_LIB32_API virtual uint8_t * STDCALL locale_identifier() = 0;
         
         /**

--- a/controller/lib/include/locale_descriptor_response.h
+++ b/controller/lib/include/locale_descriptor_response.h
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * locale_descriptor_response.h
+ *
+ * Public LOCALE descriptor response interface class
+ * The LOCALE descriptor describes a localization of the immutable strings within
+ * the AVDECC Entity.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "build.h"
+#include "descriptor_base.h"
+
+namespace avdecc_lib
+{
+    class locale_descriptor_response : public virtual descriptor_base
+    {
+    public:
+
+        AVDECC_CONTROLLER_LIB32_API virtual uint8_t * STDCALL locale_identifier() = 0;
+        
+        /**
+         * \return The number of Strings descriptor in this locale. This is the same value for
+         *	       all locales in an AVDECC Entity.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_strings() = 0;
+        
+        /**
+         * \return The descriptor index of the first Strings descriptor for this LOCALE.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_strings() = 0;
+    };
+}
+

--- a/controller/lib/include/memory_object_descriptor.h
+++ b/controller/lib/include/memory_object_descriptor.h
@@ -43,7 +43,7 @@ namespace avdecc_lib
         /**
          * \return the memory object descriptor response class.
          */
-        AVDECC_CONTROLLER_LIB32_API virtual STDCALL memory_object_descriptor_response * get_memory_object_response() = 0;
+        AVDECC_CONTROLLER_LIB32_API virtual memory_object_descriptor_response * STDCALL get_memory_object_response() = 0;
 
         /**
          * Send a START_OPERATION command with a notification id to begin an operation on the memory object

--- a/controller/lib/include/memory_object_descriptor.h
+++ b/controller/lib/include/memory_object_descriptor.h
@@ -33,6 +33,7 @@
 #include <stdint.h>
 #include "build.h"
 #include "descriptor_base.h"
+#include "memory_object_descriptor_response.h"
 
 namespace avdecc_lib
 {
@@ -40,43 +41,9 @@ namespace avdecc_lib
     {
     public:
         /**
-         * \return The type of the Memory Object
+         * \return the memory object descriptor response class.
          */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL memory_object_type() = 0;
-
-        /**
-         * \return The descriptor_type of the object that is the target of the memory region.
-         *         This is the object to which the settings, log file, or firmware applies.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL target_descriptor_type() = 0;
-
-        /**
-         * \return The descriptor_index of the object that is the target of the memory region.
-         *         This is the object to which the settings, log file, or firmware applies.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL target_descriptor_index() = 0;
-
-        /**
-         * \return The 64-bit start address used for reading or writing the object’s data
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL start_address() = 0;
-
-        /**
-         * \return The 64-bit maximum length of the Memory Object.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL maximum_length() = 0;
-
-        /**
-         * \return The 64-bit actual length of the Memory Object.
-         *         This value will change and will reflect the actual size of the data contained
-         *         in the memory region described by this Memory Object.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL length() = 0;
-
-        /**
-         * \return String representation of the memory_object_type
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual const char * STDCALL memory_object_type_to_str() = 0;
+        AVDECC_CONTROLLER_LIB32_API virtual STDCALL memory_object_descriptor_response * get_memory_object_response() = 0;
 
         /**
          * Send a START_OPERATION command with a notification id to begin an operation on the memory object

--- a/controller/lib/include/memory_object_descriptor_response.h
+++ b/controller/lib/include/memory_object_descriptor_response.h
@@ -32,13 +32,27 @@
 
 #include <stdint.h>
 #include "build.h"
-#include "descriptor_base.h"
 
 namespace avdecc_lib
 {
-    class memory_object_descriptor_response : public virtual descriptor_base
+    class memory_object_descriptor_response
     {
     public:
+        virtual ~memory_object_descriptor_response(){};
+        /**
+         * \return The name of the descriptor object. This may be user set through the use of a SET_NAME command.
+         *	   The object name should be left blank (all zeros) by the manufacturer, with the manufacturer
+         *	   defined value being provided in a localized form via the localized descripton field. By leaving
+         *	   this field blank an AVDECC Controller can determine if the user has overridden the name and can
+         *	   use this name rather than the localized name.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint8_t * STDCALL object_name() = 0;
+        
+        /**
+         * \return The localized string reference pointing to the localized descriptor name.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL localized_description() = 0;
+
         /**
          * \return The type of the Memory Object
          */

--- a/controller/lib/include/memory_object_descriptor_response.h
+++ b/controller/lib/include/memory_object_descriptor_response.h
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * memory_object_descriptor_response.h
+ *
+ * Public MEMORY_OBJECT descriptor response interface class
+ * The MEMORY_OBJECT descriptor describes a Memory Object.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "build.h"
+#include "descriptor_base.h"
+
+namespace avdecc_lib
+{
+    class memory_object_descriptor_response : public virtual descriptor_base
+    {
+    public:
+        /**
+         * \return The type of the Memory Object
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL memory_object_type() = 0;
+        
+        /**
+         * \return The descriptor_type of the object that is the target of the memory region.
+         *         This is the object to which the settings, log file, or firmware applies.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL target_descriptor_type() = 0;
+        
+        /**
+         * \return The descriptor_index of the object that is the target of the memory region.
+         *         This is the object to which the settings, log file, or firmware applies.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL target_descriptor_index() = 0;
+        
+        /**
+         * \return The 64-bit start address used for reading or writing the object’s data
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL start_address() = 0;
+        
+        /**
+         * \return The 64-bit maximum length of the Memory Object.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL maximum_length() = 0;
+        
+        /**
+         * \return The 64-bit actual length of the Memory Object.
+         *         This value will change and will reflect the actual size of the data contained
+         *         in the memory region described by this Memory Object.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL length() = 0;
+        
+        /**
+         * \return String representation of the memory_object_type
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual const char * STDCALL memory_object_type_to_str() = 0;
+    };
+}
+

--- a/controller/lib/include/response_frame.h
+++ b/controller/lib/include/response_frame.h
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * response_frame.h
+ *
+ * Store current response frame
+ */
+
+#pragma once
+
+#include "build.h"
+#include <stdint.h>
+#include <cstring>
+#include <assert.h>
+
+namespace avdecc_lib
+{
+    class response_frame
+    {
+    public:
+        response_frame(const uint8_t *frame, size_t size, ssize_t pos);
+        virtual ~response_frame();
+        
+        uint8_t * buffer; //buffer to store the current descriptor frame
+        size_t frame_size;
+        ssize_t position;
+        
+        void replace_frame(const uint8_t* frame, ssize_t pos, size_t size);
+        uint8_t * get_buffer(); //methods to fetch frame info
+        ssize_t get_pos();
+        size_t get_size();
+    };
+}

--- a/controller/lib/include/response_frame.h
+++ b/controller/lib/include/response_frame.h
@@ -46,7 +46,7 @@ namespace avdecc_lib
         size_t frame_size;
         ssize_t position;
         
-        void replace_frame(const uint8_t* frame, ssize_t pos, size_t size);
+        int replace_frame(const uint8_t* frame, ssize_t pos, size_t size);
         uint8_t * get_buffer(); //methods to fetch frame info
         ssize_t get_pos();
         size_t get_size();

--- a/controller/lib/include/response_frame.h
+++ b/controller/lib/include/response_frame.h
@@ -42,13 +42,28 @@ namespace avdecc_lib
         response_frame(const uint8_t *frame, size_t size, ssize_t pos);
         virtual ~response_frame();
         
-        uint8_t * buffer; //buffer to store the current descriptor frame
+        /*
+         * Buffer to store counters and command response frames.  Will be updated
+         * by command response processing methods.
+         */
+        uint8_t * buffer;
+        /*
+         * Buffer to store descriptor response frames.  Will be updated by
+         * update_desc_database() method in configuration descriptor.
+         */
+        uint8_t * desc_buffer;
         size_t frame_size;
+        size_t desc_frame_size;
         ssize_t position;
+        ssize_t desc_position;
         
         int replace_frame(const uint8_t* frame, ssize_t pos, size_t size);
-        uint8_t * get_buffer(); //methods to fetch frame info
+        int replace_desc_frame(const uint8_t *frame, ssize_t pos, size_t size);
+        uint8_t * get_buffer();
+        uint8_t * get_desc_buffer();
         ssize_t get_pos();
+        ssize_t get_desc_pos();
         size_t get_size();
+        size_t get_desc_size();
     };
 }

--- a/controller/lib/include/response_frame.h
+++ b/controller/lib/include/response_frame.h
@@ -39,7 +39,7 @@ namespace avdecc_lib
     class response_frame
     {
     public:
-        response_frame(const uint8_t *frame, size_t size, ssize_t pos);
+        response_frame(const uint8_t *frame, size_t size, size_t pos);
         virtual ~response_frame();
         
         /*
@@ -54,15 +54,15 @@ namespace avdecc_lib
         uint8_t * desc_buffer;
         size_t frame_size;
         size_t desc_frame_size;
-        ssize_t position;
-        ssize_t desc_position;
+        size_t position;
+        size_t desc_position;
         
-        int replace_frame(const uint8_t* frame, ssize_t pos, size_t size);
-        int replace_desc_frame(const uint8_t *frame, ssize_t pos, size_t size);
+        int replace_frame(const uint8_t* frame, size_t pos, size_t size);
+        int replace_desc_frame(const uint8_t *frame, size_t pos, size_t size);
         uint8_t * get_buffer();
         uint8_t * get_desc_buffer();
-        ssize_t get_pos();
-        ssize_t get_desc_pos();
+        size_t get_pos();
+        size_t get_desc_pos();
         size_t get_size();
         size_t get_desc_size();
     };

--- a/controller/lib/include/stream_input_counters_response.h
+++ b/controller/lib/include/stream_input_counters_response.h
@@ -37,6 +37,7 @@ namespace avdecc_lib
     class stream_input_counters_response
     {
     public:
+        virtual ~stream_input_counters_response(){};
         /**
          * \param name avdecc_lib::counter_labels
          *

--- a/controller/lib/include/stream_input_counters_response.h
+++ b/controller/lib/include/stream_input_counters_response.h
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * stream_input_counters_response.h
+ *
+ * stream_input counters response base class
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "build.h"
+
+namespace avdecc_lib
+{
+    class stream_input_counters_response
+    {
+    public:
+        /**
+         * \param name avdecc_lib::counter_labels
+         *
+         * \return the stream input counter valid after the GET_COUNTERS command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_counter_valid(int name) = 0;
+        
+        /**
+         * \param name avdecc_lib::counter_labels
+         *
+         * \return the stream input counter by name after the GET_COUNTERS command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_counter_by_name(int name) = 0;
+    };
+}

--- a/controller/lib/include/stream_input_descriptor.h
+++ b/controller/lib/include/stream_input_descriptor.h
@@ -33,6 +33,11 @@
 #include <stdint.h>
 #include "build.h"
 #include "descriptor_base.h"
+#include "stream_input_counters_response.h"
+#include "stream_input_descriptor_response.h"
+#include "stream_input_get_stream_format_response.h"
+#include "stream_input_get_stream_info_response.h"
+#include "stream_input_get_rx_state_response.h"
 
 namespace avdecc_lib
 {
@@ -40,225 +45,36 @@ namespace avdecc_lib
     {
     public:
         /**
-         * \return The descriptor index of the CLOCK DOMAIN descriptor providing the media clock for the stream.
+         * \return the stream_input descriptor response class.
          */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL clock_domain_index() = 0;
+        AVDECC_CONTROLLER_LIB32_API virtual stream_input_descriptor_response * STDCALL get_stream_input_response() = 0;
+        
+        /**
+         * \return the stream_input descriptor counters.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual stream_input_counters_response * STDCALL get_stream_input_counters_response() = 0;
 
         /**
-         * \return The flags describing the capabilities or features of the stream.
+         * \return the stream_input get_stream_format response class.
          */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL stream_flags() = 0;
+        AVDECC_CONTROLLER_LIB32_API virtual stream_input_get_stream_format_response * STDCALL get_stream_input_get_stream_format_response() = 0;
 
         /**
-         * \return True if the stream can be used as a clock synchronization source.
+         * \return the stream_input get_stream_format response class.
          */
-        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_clock_sync_source() = 0;
+        AVDECC_CONTROLLER_LIB32_API virtual stream_input_get_stream_info_response * STDCALL get_stream_input_get_stream_info_response() = 0;
 
         /**
-         * \return True if the stream supports streaming at Class A.
+         * \return the stream_input get_rx_state response class.
          */
-        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_class_a() = 0;
-
-        /**
-         * \return True if the stream supports streaming at Class B.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_class_b() = 0;
-
-        /**
-         * \return True if the stream supports streaming with encrypted PDUs.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_supports_encrypted() = 0;
-
-        /**
-         * \return True if the primary backup AVDECC Talker's Entity ID and primary backup AVDECC Talker's Unique ID are supported.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_primary_backup_supported() = 0;
-
-        /**
-         * \return True if the primary backup AVDECC Talker's Entity ID and primary backup AVDECC Talker's Unique ID are valid.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_primary_backup_valid() = 0;
-
-        /**
-         * \return True if the secondary backup AVDECC Talker's Entity ID and secondary backup AVDECC Talker's Unique ID are supported.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_secondary_backup_supported() = 0;
-
-        /**
-         * \return True if the secondary backup AVDECC Talker's Entity ID and secondary backup AVDECC Talker's Unique ID are valid.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_secondary_backup_valid() = 0;
-
-        /**
-         * \return True if the tertiary backup AVDECC Talker's Entity ID and tertiary backup AVDECC Talker's Unique ID are supported.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_tertiary_backup_supported() = 0;
-
-        /**
-         * \return True if the tertiary backup AVDECC Talker's Entity ID and tertiary backup AVDECC Talker's Unique ID are valid.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_tertiary_backup_valid() = 0;
-
-        /**
-         * \return The current format of the stream.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual const char * STDCALL current_format() = 0;
-
-        /**
-         * \return The number of formats supported by this audio stream. The maximum value
-         *	       for this field is 47 for this version of AEM.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_formats() = 0;
-
-        /**
-         * \return The primary backup AVDECC Talker's Entity ID.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL backup_talker_entity_id_0() = 0;
-
-        /**
-         * \return The primary backup AVDECC Talker's Unique ID.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL backup_talker_unique_0() = 0;
-
-        /**
-         * \return The secondary backup AVDECC Talker's Entity ID.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL backup_talker_entity_id_1() = 0;
-
-        /**
-         * \return The secondary backup AVDECC Talker's Unique ID.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL backup_talker_unique_1() = 0;
-
-        /**
-         * \return The tertiary backup AVDECC Talker's Entity ID.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL backup_talker_entity_id_2() = 0;
-
-        /**
-         * \return The tertiary backup AVDECC Talker's Unique ID.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL backup_talker_unique_2() = 0;
-
-        /**
-         * \return The Entity ID of the AVDECC Talker that this stream is backing up.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL backedup_talker_entity_id() = 0;
-
-        /**
-         * \return The Unique ID of the AVDECC Talker that this stream is backing up.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL backedup_talker_unique() = 0;
-
-        /**
-         * \return The descriptor index of the AVB INTERFACE descriptor from which this stream
-         *	       is sourced or to which it is sinked.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL avb_interface_index() = 0;
-
-        /**
-         * \return The length in nanoseconds of the MAC's ingress buffer size.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL buffer_length() = 0;
-
+        AVDECC_CONTROLLER_LIB32_API virtual stream_input_get_rx_state_response * STDCALL get_stream_input_get_rx_state_response() = 0;
+        
+        
         /**
          * \return The stream format of a stream after sending a SET_STREAM_FORMAT command and
          *	       receiving a response back for the command.
          */
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL set_stream_format_stream_format() = 0;
-
-        /**
-         * \return The stream format of a stream after sending a GET_STREAM_FORMAT command and
-         *	       receiving a response back for the command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_stream_format_stream_format() = 0;
-
-        /**
-         * \return The stream info flags of a stream after sending a GET_STREAM_INFO command and
-         *	       receiving a response back for the command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_stream_info_flags() = 0;
-
-        /**
-         * \return The stream info stream format of a stream after sending a GET_STREAM_INFO command and
-         *	       receiving a response back for the command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_stream_info_stream_format() = 0;
-
-        /**
-         * \return The stream info stream id of a stream after sending a GET_STREAM_INFO command and
-         *	       receiving a response back for the command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_stream_info_stream_id() = 0;
-
-        /**
-         * \return The stream info MSRP accumulated latency of a stream after sending a GET_STREAM_INFO command and
-         *	       receiving a response back for the command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_stream_info_msrp_accumulated_latency() = 0;
-
-        /**
-         * \return The stream info stream destination MAC of a stream after sending a GET_STREAM_INFO command and
-         *	       receiving a response back for the command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_stream_info_stream_dest_mac() = 0;
-
-        /**
-         * \return The stream info MSRP failure code of a stream after sending a GET_STREAM_INFO command and
-         *	       receiving a response back for the command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint8_t STDCALL get_stream_info_msrp_failure_code() = 0;
-
-        /**
-         * \return The stream info MSRP failure bridge id of a stream after sending a GET_STREAM_INFO command and
-         *	       receiving a response back for the command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_stream_info_msrp_failure_bridge_id() = 0;
-
-        /**
-         * \return The stream id field used to identify and transfer the associated stream ID where suitable 
-         *         after sending a GET_RX_STATE command and receiving a response back for the command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_rx_state_stream_id() = 0;
-
-        /**
-         * \return The Talker unique ID used to uniquely identify the stream source of the AVDECC Talker 
-         *         after sending a GET_RX_STATE command and receiving a response back for the command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_rx_state_talker_unique_id() = 0;
-
-        /**
-         * \return The Listener unique ID used to uniquely identify the stream sink of the AVDECC Listener   
-         *         after sending a GET_RX_STATE command and receiving a response back for the command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_rx_state_listener_unique_id() = 0;
-
-        /**
-         * \return The stream destination MAC address used to convey the destination MAC address for a stream
-         *         from the AVDECC Talker to the AVDECC Listener, or from either to the AVDECC Controller after
-         *         sending a GET_RX_STATE command and receiving a response back for the command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_rx_state_stream_dest_mac() = 0;
-
-        /**
-         * \return The connection count used by the state commands to return the number of connections an AVDECC Talker
-         *         thinks it has on its stream source after sending a GET_RX_STATE command and receiving a response
-         *         back for the command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_rx_state_connection_count() = 0;
-
-        /**
-         * \return The flags used to indicate attributes of the connection or saved state after sending a GET_RX_STATE
-         *         command and receiving a response back for the command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_rx_state_flags() = 0;
-
-        /**
-         * \return The stream vlan id used to convey the VLAN ID for a stream from the AVDECC Talker to the AVDECC Listener,
-         *         or from either to the AVDECC Controller after sending a GET_RX_STATE command and receiving a response
-         *         back for the command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_rx_state_stream_vlan_id() = 0;
 
         /**
          * Send a SET_STREAM_FORMAT command with a notification id to change the format of a stream.
@@ -369,24 +185,9 @@ namespace avdecc_lib
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_get_rx_state_cmd(void *notification_id) = 0;
         
         /**
-         * Send a GET_COUNTERS command to get the counters of the AVDECC Entity.
+         * Send a GET_COUNTERS command to get the stream_input counters of the AVDECC Entity.
          */
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_get_counters_cmd(void *notification_id) = 0;
-        
-        /**
-         * \param name avdecc_lib::counter_labels
-         *
-         * \return the stream_input counters valid after the GET_COUNTERS command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_counter_valid(int name) = 0;
-        
-        /**
-         * \param name avdecc_lib::counter_labels
-         *
-         * \return the stream_input counters after the GET_COUNTERS command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_counter_by_name(int name) = 0;
-
     };
 }
 

--- a/controller/lib/include/stream_input_descriptor.h
+++ b/controller/lib/include/stream_input_descriptor.h
@@ -50,7 +50,7 @@ namespace avdecc_lib
         AVDECC_CONTROLLER_LIB32_API virtual stream_input_descriptor_response * STDCALL get_stream_input_response() = 0;
         
         /**
-         * \return the stream_input descriptor counters.
+         * \return the stream_input descriptor counters response class.
          */
         AVDECC_CONTROLLER_LIB32_API virtual stream_input_counters_response * STDCALL get_stream_input_counters_response() = 0;
 
@@ -68,8 +68,7 @@ namespace avdecc_lib
          * \return the stream_input get_rx_state response class.
          */
         AVDECC_CONTROLLER_LIB32_API virtual stream_input_get_rx_state_response * STDCALL get_stream_input_get_rx_state_response() = 0;
-        
-        
+
         /**
          * \return The stream format of a stream after sending a SET_STREAM_FORMAT command and
          *	       receiving a response back for the command.

--- a/controller/lib/include/stream_input_descriptor_response.h
+++ b/controller/lib/include/stream_input_descriptor_response.h
@@ -32,13 +32,27 @@
 
 #include <stdint.h>
 #include "build.h"
-#include "descriptor_base.h"
 
 namespace avdecc_lib
 {
-    class stream_input_descriptor_response : public virtual descriptor_base
+    class stream_input_descriptor_response
     {
     public:
+        virtual ~stream_input_descriptor_response(){};
+        /**
+         * \return The name of the descriptor object. This may be user set through the use of a SET_NAME command.
+         *	   The object name should be left blank (all zeros) by the manufacturer, with the manufacturer
+         *	   defined value being provided in a localized form via the localized descripton field. By leaving
+         *	   this field blank an AVDECC Controller can determine if the user has overridden the name and can
+         *	   use this name rather than the localized name.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint8_t * STDCALL object_name() = 0;
+        
+        /**
+         * \return The localized string reference pointing to the localized descriptor name.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL localized_description() = 0;
+
         /**
          * \return The descriptor index of the CLOCK DOMAIN descriptor providing the media clock for the stream.
          */

--- a/controller/lib/include/stream_input_descriptor_response.h
+++ b/controller/lib/include/stream_input_descriptor_response.h
@@ -1,0 +1,164 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * stream_input_descriptor_response.h
+ *
+ * Public STREAM INPUT descriptor interface
+ * The STREAM INPUT descriptor describes a sourced or sinked stream.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "build.h"
+#include "descriptor_base.h"
+
+namespace avdecc_lib
+{
+    class stream_input_descriptor_response : public virtual descriptor_base
+    {
+    public:
+        /**
+         * \return The descriptor index of the CLOCK DOMAIN descriptor providing the media clock for the stream.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL clock_domain_index() = 0;
+        
+        /**
+         * \return The flags describing the capabilities or features of the stream.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL stream_flags() = 0;
+        
+        /**
+         * \return True if the stream can be used as a clock synchronization source.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_clock_sync_source() = 0;
+        
+        /**
+         * \return True if the stream supports streaming at Class A.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_class_a() = 0;
+        
+        /**
+         * \return True if the stream supports streaming at Class B.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_class_b() = 0;
+        
+        /**
+         * \return True if the stream supports streaming with encrypted PDUs.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_supports_encrypted() = 0;
+        
+        /**
+         * \return True if the primary backup AVDECC Talker's Entity ID and primary backup AVDECC Talker's Unique ID are supported.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_primary_backup_supported() = 0;
+        
+        /**
+         * \return True if the primary backup AVDECC Talker's Entity ID and primary backup AVDECC Talker's Unique ID are valid.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_primary_backup_valid() = 0;
+        
+        /**
+         * \return True if the secondary backup AVDECC Talker's Entity ID and secondary backup AVDECC Talker's Unique ID are supported.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_secondary_backup_supported() = 0;
+        
+        /**
+         * \return True if the secondary backup AVDECC Talker's Entity ID and secondary backup AVDECC Talker's Unique ID are valid.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_secondary_backup_valid() = 0;
+        
+        /**
+         * \return True if the tertiary backup AVDECC Talker's Entity ID and tertiary backup AVDECC Talker's Unique ID are supported.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_tertiary_backup_supported() = 0;
+        
+        /**
+         * \return True if the tertiary backup AVDECC Talker's Entity ID and tertiary backup AVDECC Talker's Unique ID are valid.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_tertiary_backup_valid() = 0;
+        
+        /**
+         * \return The current format of the stream.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual const char * STDCALL current_format() = 0;
+        
+        /**
+         * \return The number of formats supported by this audio stream. The maximum value
+         *	       for this field is 47 for this version of AEM.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_formats() = 0;
+        
+        /**
+         * \return The primary backup AVDECC Talker's Entity ID.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL backup_talker_entity_id_0() = 0;
+        
+        /**
+         * \return The primary backup AVDECC Talker's Unique ID.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL backup_talker_unique_0() = 0;
+        
+        /**
+         * \return The secondary backup AVDECC Talker's Entity ID.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL backup_talker_entity_id_1() = 0;
+        
+        /**
+         * \return The secondary backup AVDECC Talker's Unique ID.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL backup_talker_unique_1() = 0;
+        
+        /**
+         * \return The tertiary backup AVDECC Talker's Entity ID.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL backup_talker_entity_id_2() = 0;
+        
+        /**
+         * \return The tertiary backup AVDECC Talker's Unique ID.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL backup_talker_unique_2() = 0;
+        
+        /**
+         * \return The Entity ID of the AVDECC Talker that this stream is backing up.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL backedup_talker_entity_id() = 0;
+        
+        /**
+         * \return The Unique ID of the AVDECC Talker that this stream is backing up.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL backedup_talker_unique() = 0;
+        
+        /**
+         * \return The descriptor index of the AVB INTERFACE descriptor from which this stream
+         *	       is sourced or to which it is sinked.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL avb_interface_index() = 0;
+        
+        /**
+         * \return The length in nanoseconds of the MAC's ingress buffer size.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL buffer_length() = 0;
+    };
+}

--- a/controller/lib/include/stream_input_get_rx_state_response.h
+++ b/controller/lib/include/stream_input_get_rx_state_response.h
@@ -24,7 +24,7 @@
 /**
  * stream_input_get_rx_state_response.h
  *
- * STREAM INPUT stream format response base class
+ * STREAM INPUT rx state response base class
  */
 
 #pragma once
@@ -37,6 +37,7 @@ namespace avdecc_lib
     class stream_input_get_rx_state_response
     {
     public:
+        virtual ~stream_input_get_rx_state_response(){};
         /**
          * \return The stream id field used to identify and transfer the associated stream ID where suitable
          *         after sending a GET_RX_STATE command and receiving a response back for the command.

--- a/controller/lib/include/stream_input_get_rx_state_response.h
+++ b/controller/lib/include/stream_input_get_rx_state_response.h
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * stream_input_get_rx_state_response.h
+ *
+ * STREAM INPUT stream format response base class
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "build.h"
+
+namespace avdecc_lib
+{
+    class stream_input_get_rx_state_response
+    {
+    public:
+        /**
+         * \return The stream id field used to identify and transfer the associated stream ID where suitable
+         *         after sending a GET_RX_STATE command and receiving a response back for the command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_rx_state_stream_id() = 0;
+        
+        /**
+         * \return The Talker unique ID used to uniquely identify the stream source of the AVDECC Talker
+         *         after sending a GET_RX_STATE command and receiving a response back for the command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_rx_state_talker_unique_id() = 0;
+        
+        /**
+         * \return The Listener unique ID used to uniquely identify the stream sink of the AVDECC Listener
+         *         after sending a GET_RX_STATE command and receiving a response back for the command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_rx_state_listener_unique_id() = 0;
+        
+        /**
+         * \return The stream destination MAC address used to convey the destination MAC address for a stream
+         *         from the AVDECC Talker to the AVDECC Listener, or from either to the AVDECC Controller after
+         *         sending a GET_RX_STATE command and receiving a response back for the command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_rx_state_stream_dest_mac() = 0;
+        
+        /**
+         * \return The connection count used by the state commands to return the number of connections an AVDECC Talker
+         *         thinks it has on its stream source after sending a GET_RX_STATE command and receiving a response
+         *         back for the command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_rx_state_connection_count() = 0;
+        
+        /**
+         * \return The flags used to indicate attributes of the connection or saved state after sending a GET_RX_STATE
+         *         command and receiving a response back for the command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_rx_state_flags() = 0;
+        
+        /**
+         * \return The stream vlan id used to convey the VLAN ID for a stream from the AVDECC Talker to the AVDECC Listener,
+         *         or from either to the AVDECC Controller after sending a GET_RX_STATE command and receiving a response
+         *         back for the command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_rx_state_stream_vlan_id() = 0;
+    };
+}

--- a/controller/lib/include/stream_input_get_stream_format_response.h
+++ b/controller/lib/include/stream_input_get_stream_format_response.h
@@ -37,6 +37,7 @@ namespace avdecc_lib
     class stream_input_get_stream_format_response
     {
     public:
+        virtual ~stream_input_get_stream_format_response(){};
         /**
          * \return The stream format of a stream after sending a GET_STREAM_FORMAT command and
          *	       receiving a response back for the command.

--- a/controller/lib/include/stream_input_get_stream_format_response.h
+++ b/controller/lib/include/stream_input_get_stream_format_response.h
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * stream_input_get_stream_format_response.h
+ *
+ * STREAM INPUT stream format response base class
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "build.h"
+
+namespace avdecc_lib
+{
+    class stream_input_get_stream_format_response
+    {
+    public:
+        /**
+         * \return The stream format of a stream after sending a GET_STREAM_FORMAT command and
+         *	       receiving a response back for the command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_stream_format() = 0;
+    };
+}

--- a/controller/lib/include/stream_input_get_stream_info_response.h
+++ b/controller/lib/include/stream_input_get_stream_info_response.h
@@ -37,6 +37,7 @@ namespace avdecc_lib
     class stream_input_get_stream_info_response
     {
     public:
+        virtual ~stream_input_get_stream_info_response(){};
         /**
          * \return The stream info flags of a stream after sending a GET_STREAM_INFO command and
          *	       receiving a response back for the command.

--- a/controller/lib/include/stream_input_get_stream_info_response.h
+++ b/controller/lib/include/stream_input_get_stream_info_response.h
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * stream_input_get_stream_info_response.h
+ *
+ * STREAM INPUT stream info response base class
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "build.h"
+
+namespace avdecc_lib
+{
+    class stream_input_get_stream_info_response
+    {
+    public:
+        /**
+         * \return The stream info flags of a stream after sending a GET_STREAM_INFO command and
+         *	       receiving a response back for the command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_stream_info_flags() = 0;
+        
+        /**
+         * \return The stream info stream format of a stream after sending a GET_STREAM_INFO command and
+         *	       receiving a response back for the command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_stream_info_stream_format() = 0;
+        
+        /**
+         * \return The stream info stream id of a stream after sending a GET_STREAM_INFO command and
+         *	       receiving a response back for the command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_stream_info_stream_id() = 0;
+        
+        /**
+         * \return The stream info MSRP accumulated latency of a stream after sending a GET_STREAM_INFO command and
+         *	       receiving a response back for the command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_stream_info_msrp_accumulated_latency() = 0;
+        
+        /**
+         * \return The stream info stream destination MAC of a stream after sending a GET_STREAM_INFO command and
+         *	       receiving a response back for the command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_stream_info_stream_dest_mac() = 0;
+        
+        /**
+         * \return The stream info MSRP failure code of a stream after sending a GET_STREAM_INFO command and
+         *	       receiving a response back for the command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint8_t STDCALL get_stream_info_msrp_failure_code() = 0;
+        
+        /**
+         * \return The stream info MSRP failure bridge id of a stream after sending a GET_STREAM_INFO command and
+         *	       receiving a response back for the command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_stream_info_msrp_failure_bridge_id() = 0;
+    };
+}

--- a/controller/lib/include/stream_output_descriptor.h
+++ b/controller/lib/include/stream_output_descriptor.h
@@ -74,7 +74,7 @@ namespace avdecc_lib
          *	       receiving a response back for the command.
          */
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL set_stream_format_stream_format() = 0;
-       
+
         /**
          * Send a SET_STREAM_FORMAT command with a notification id to change the format of a stream.
          *

--- a/controller/lib/include/stream_output_descriptor.h
+++ b/controller/lib/include/stream_output_descriptor.h
@@ -33,6 +33,11 @@
 #include <stdint.h>
 #include "build.h"
 #include "descriptor_base.h"
+#include "stream_output_descriptor_response.h"
+#include "stream_output_get_stream_format_response.h"
+#include "stream_output_get_stream_info_response.h"
+#include "stream_output_get_tx_state_response.h"
+#include "stream_output_get_tx_connection_response.h"
 
 namespace avdecc_lib
 {
@@ -40,259 +45,36 @@ namespace avdecc_lib
     {
     public:
         /**
-         * \return The descriptor index of the CLOCK DOMAIN descriptor providing the media clock for the stream.
+         * \return the stream_output descriptor response class.
          */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL clock_domain_index() = 0;
+        AVDECC_CONTROLLER_LIB32_API virtual stream_output_descriptor_response * STDCALL get_stream_output_response() = 0;
+        
+        /**
+         * \return the stream_output get_stream_format response class.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual stream_output_get_stream_format_response * STDCALL get_stream_output_get_stream_format_response() = 0;
 
         /**
-         * \return The flags describing the capabilities or features of the stream.
+         * \return the stream_output get_stream_info response class.
          */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL stream_flags() = 0;
+        AVDECC_CONTROLLER_LIB32_API virtual stream_output_get_stream_info_response * STDCALL get_stream_output_get_stream_info_response() = 0;
 
         /**
-         * \return True if the stream can be used as a clock synchronization source.
+         * \return the stream_output get_tx_state response class.
          */
-        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_clock_sync_source() = 0;
+        AVDECC_CONTROLLER_LIB32_API virtual stream_output_get_tx_state_response * STDCALL get_stream_output_get_tx_state_response() = 0;
 
         /**
-         * \return True if the stream supports streaming at Class A.
+         * \return the stream_output get_tx_connection response class.
          */
-        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_class_a() = 0;
-
-        /**
-         * \return True if the stream supports streaming at Class B.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_class_b() = 0;
-
-        /**
-         * \return True if the stream supports streaming with encrypted PDUs.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_supports_encrypted() = 0;
-
-        /**
-         * \return True if the primary backup AVDECC Talker's Entity ID and primary backup AVDECC Talker's Unique ID are supported.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_primary_backup_supported() = 0;
-
-        /**
-         * \return True if the primary backup AVDECC Talker's Entity ID and primary backup AVDECC Talker's Unique ID are valid.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_primary_backup_valid() = 0;
-
-        /**
-         * \return True if the secondary backup AVDECC Talker's Entity ID and secondary backup AVDECC Talker's Unique ID are supported.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_secondary_backup_supported() = 0;
-
-        /**
-         * \return True if the secondary backup AVDECC Talker's Entity ID and secondary backup AVDECC Talker's Unique ID are valid.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_secondary_backup_valid() = 0;
-
-        /**
-         * \return True if the tertiary backup AVDECC Talker's Entity ID and tertiary backup AVDECC Talker's Unique ID are supported.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_tertiary_backup_supported() = 0;
-
-        /**
-         * \return True if the tertiary backup AVDECC Talker's Entity ID and tertiary backup AVDECC Talker's Unique ID are valid.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_tertiary_backup_valid() = 0;
-
-        /**
-         * \return The current format of the stream.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual const char * STDCALL current_format() = 0;
-
-        /**
-         * \return The number of formats supported by this audio stream. The maximum value
-         *	       for this field is 47 for this version of AEM.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_formats() = 0;
-
-        /**
-         * \return The primary backup AVDECC Talker's Entity ID.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL backup_talker_entity_id_0() = 0;
-
-        /**
-         * \return The primary backup AVDECC Talker's Unique ID.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL backup_talker_unique_0() = 0;
-
-        /**
-         * \return The secondary backup AVDECC Talker's Entity ID.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL backup_talker_entity_id_1() = 0;
-
-        /**
-         * \return The secondary backup AVDECC Talker's Unique ID.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL backup_talker_unique_1() = 0;
-
-        /**
-         * \return The tertiary backup AVDECC Talker's Entity ID.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL backup_talker_entity_id_2() = 0;
-
-        /**
-         * \return The tertiary backup AVDECC Talker's Unique ID.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL backup_talker_unique_2() = 0;
-
-        /**
-         * \return The Entity ID of the AVDECC Talker that this stream is backing up.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL backedup_talker_entity_id() = 0;
-
-        /**
-         * \return The Unique ID of the AVDECC Talker that this stream is backing up.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL backedup_talker_unique() = 0;
-
-        /**
-         * \return The descriptor index of the AVB INTERFACE descriptor from which this stream
-         *	       is sourced or to which it is sinked.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL avb_interface_index() = 0;
-
-        /**
-         * \return The length in nanoseconds of the MAC's ingress buffer size.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL buffer_length() = 0;
+        AVDECC_CONTROLLER_LIB32_API virtual stream_output_get_tx_connection_response * STDCALL get_stream_output_get_tx_connection_response() = 0;
 
         /**
          * \return The stream format of a stream after sending a SET_STREAM_FORMAT command and
          *	       receiving a response back for the command.
          */
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL set_stream_format_stream_format() = 0;
-
-        /**
-         * \return The stream format of a stream after sending a GET_STREAM_FORMAT command and
-         *	       receiving a response back for the command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_stream_format_stream_format() = 0;
-
-        /**
-         * \return The stream info flags of a stream after sending a GET_STREAM_INFO command and
-         *	       receiving a response back for the command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_stream_info_flags() = 0;
-
-        /**
-         * \return The stream info stream format of a stream after sending a GET_STREAM_INFO command and
-         *	       receiving a response back for the command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_stream_info_stream_format() = 0;
-
-        /**
-         * \return The stream info stream id of a stream after sending a GET_STREAM_INFO command and
-         *	       receiving a response back for the command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_stream_info_stream_id() = 0;
-
-        /**
-         * \return The stream info MSRP accumulated latency of a stream after sending a GET_STREAM_INFO command and
-         *	       receiving a response back for the command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_stream_info_msrp_accumulated_latency() = 0;
-
-        /**
-         * \return The stream info stream destination MAC of a stream after sending a GET_STREAM_INFO command and
-         *	       receiving a response back for the command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_stream_info_stream_dest_mac() = 0;
-
-        /**
-         * \return The stream info MSRP failure code of a stream after sending a GET_STREAM_INFO command and
-         *	       receiving a response back for the command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint8_t STDCALL get_stream_info_msrp_failure_code() = 0;
-
-        /**
-         * \return The stream info MSRP failure bridge id of a stream after sending a GET_STREAM_INFO command and
-         *	       receiving a response back for the command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_stream_info_msrp_failure_bridge_id() = 0;
-
-	    /**
-         * \return The stream info vlan ID of a stream after sending a GET_STREAM_INFO command and
-         *	       receiving a response back for the command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_stream_info_stream_vlan_id() = 0;
-
-        /**
-         * \return The stream id field used to identify and transfer the associated stream ID where suitable 
-         * after sending a GET_TX_STATE command and receiving a response back for the command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_tx_state_stream_id() = 0;
-
-        /**
-         * \return The stream destination MAC address used to convey the destination MAC address for a stream
-         *         from the AVDECC Talker to the AVDECC Listener, or from either to the AVDECC Controller after
-         *         sending a GET_TX_STATE command and receiving a response back for the command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_tx_state_stream_dest_mac() = 0;
-
-        /**
-         * \return The connection count used by the state commands to return the number of connections an AVDECC Talker
-         *         thinks it has on its stream source after sending a GET_TX_STATE command and receiving a response
-         *         back for the command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_tx_state_connection_count() = 0;
-
-        /**
-         * \return The stream vlan id used to convey the VLAN ID for a stream from the AVDECC Talker to the AVDECC Listener,
-         *         or from either to the AVDECC Controller after sending a GET_TX_STATE command and receiving a response
-         *         back for the command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_tx_state_stream_vlan_id() = 0;
-
-        /**
-         * \return The stream id field used to identify and transfer the associated stream ID where suitable 
-         *         after sending a GET_TX_CONNECTION command and receiving a response back for the command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_tx_connection_stream_id() = 0;
-
-        /**
-         * \return The Talker unique ID used to uniquely identify the stream source of the AVDECC Talker 
-         *         after sending a GET_TX_CONNECTION command and receiving a response back for the command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_tx_connection_talker_unique_id() = 0;
-
-        /**
-         * \return The Listener unique ID used to uniquely identify the stream sink of the AVDECC Listener   
-         *         after sending a GET_TX_CONNECTION command and receiving a response back for the command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_tx_connection_listener_unique_id() = 0;
-
-        /**
-         * \return The Listener entity ID of the stream sink of the AVDECC Talker   
-         *         after sending a GET_TX_CONNECTION command and receiving a response back for the command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_tx_connection_listener_entity_id() = 0;
-
-        /**
-         * \return The stream destination MAC address used to convey the destination MAC address for a stream
-         *         from the AVDECC Talker to the AVDECC Listener, or from either to the AVDECC Controller after
-         *         sending a GET_TX_CONNECTION command and receiving a response back for the command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_tx_connection_stream_dest_mac() = 0;
-
-        /**
-         * \return The connection count used by the state commands to return the number of connections an AVDECC Talker
-         *         thinks it has on its stream source after sending a GET_TX_CONNECTION command and receiving a response
-         *         back for the command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_tx_connection_connection_count() = 0;
-
-        /**
-         * \return The stream vlan id used to convey the VLAN ID for a stream from the AVDECC Talker to the AVDECC Listener,
-         *         or from either to the AVDECC Controller after sending a GET_TX_CONNECTION command and receiving a response
-         *         back for the command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_tx_connection_stream_vlan_id() = 0;
-
+       
         /**
          * Send a SET_STREAM_FORMAT command with a notification id to change the format of a stream.
          *
@@ -339,21 +121,6 @@ namespace avdecc_lib
          *      get_stream_info_msrp_failure_code(), get_stream_info_msrp_failure_bridge_id()
          */
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_get_stream_info_cmd(void *notification_id) = 0;
-
-		 /**
-         * Tests state of a flag returned by last GET_STREAM_INFO command.
-         *
-         * \param flag The flag to check. Valid values are: 
-		 * CLASS_B, FAST_CONNECT, SAVED_STATE, STREAMING_WAIT, ENCRYPTED_PDU, STREAM_VLAN_ID_VALID
-		 * CONNECTED, MSRP_FAILURE_VALID, STREAM_DEST_MAC_VALID, MSRP_ACC_LAT_VALID, STREAM_ID_VALID,
-		 * STREAM_FORMAT_VALID.
-         *
-         * \see get_stream_info_flags(), get_stream_info_stream_format(), get_stream_info_stream_id(),
-         *      get_stream_info_msrp_accumulated_latency(), get_stream_info_stream_dest_mac(),
-         *      get_stream_info_msrp_failure_code(), get_stream_info_msrp_failure_bridge_id()
-         */
-
-        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL get_stream_info_flag(const char *flag) = 0;
 
         /**
          * Send a START_STREAMING command with a notification id to start streaming on a previously connected stream that was connected

--- a/controller/lib/include/stream_output_descriptor_response.h
+++ b/controller/lib/include/stream_output_descriptor_response.h
@@ -1,0 +1,180 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2013 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * stream_output_descriptor_response.h
+ *
+ * Public STREAM OUTPUT descriptor response interface class
+ * The STREAM OUTPUT descriptor describes a sourced or sinked stream.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "build.h"
+#include "descriptor_base.h"
+
+namespace avdecc_lib
+{
+    class stream_output_descriptor_response : public virtual descriptor_base
+    {
+    public:
+        /**
+         * \return The descriptor index of the CLOCK DOMAIN descriptor providing the media clock for the stream.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL clock_domain_index() = 0;
+        
+        /**
+         * \return The flags describing the capabilities or features of the stream.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL stream_flags() = 0;
+        
+        /**
+         * \return True if the stream can be used as a clock synchronization source.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_clock_sync_source() = 0;
+        
+        /**
+         * \return True if the stream supports streaming at Class A.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_class_a() = 0;
+        
+        /**
+         * \return True if the stream supports streaming at Class B.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_class_b() = 0;
+        
+        /**
+         * \return True if the stream supports streaming with encrypted PDUs.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_supports_encrypted() = 0;
+        
+        /**
+         * \return True if the primary backup AVDECC Talker's Entity ID and primary backup AVDECC Talker's Unique ID are supported.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_primary_backup_supported() = 0;
+        
+        /**
+         * \return True if the primary backup AVDECC Talker's Entity ID and primary backup AVDECC Talker's Unique ID are valid.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_primary_backup_valid() = 0;
+        
+        /**
+         * \return True if the secondary backup AVDECC Talker's Entity ID and secondary backup AVDECC Talker's Unique ID are supported.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_secondary_backup_supported() = 0;
+        
+        /**
+         * \return True if the secondary backup AVDECC Talker's Entity ID and secondary backup AVDECC Talker's Unique ID are valid.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_secondary_backup_valid() = 0;
+        
+        /**
+         * \return True if the tertiary backup AVDECC Talker's Entity ID and tertiary backup AVDECC Talker's Unique ID are supported.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_tertiary_backup_supported() = 0;
+        
+        /**
+         * \return True if the tertiary backup AVDECC Talker's Entity ID and tertiary backup AVDECC Talker's Unique ID are valid.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_tertiary_backup_valid() = 0;
+        
+        /**
+         * \return The current format of the stream.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual const char * STDCALL current_format() = 0;
+        
+        /**
+         * \return The number of formats supported by this audio stream. The maximum value
+         *	       for this field is 47 for this version of AEM.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_formats() = 0;
+        
+        /**
+         * \return The primary backup AVDECC Talker's Entity ID.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL backup_talker_entity_id_0() = 0;
+        
+        /**
+         * \return The primary backup AVDECC Talker's Unique ID.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL backup_talker_unique_0() = 0;
+        
+        /**
+         * \return The secondary backup AVDECC Talker's Entity ID.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL backup_talker_entity_id_1() = 0;
+        
+        /**
+         * \return The secondary backup AVDECC Talker's Unique ID.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL backup_talker_unique_1() = 0;
+        
+        /**
+         * \return The tertiary backup AVDECC Talker's Entity ID.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL backup_talker_entity_id_2() = 0;
+        
+        /**
+         * \return The tertiary backup AVDECC Talker's Unique ID.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL backup_talker_unique_2() = 0;
+        
+        /**
+         * \return The Entity ID of the AVDECC Talker that this stream is backing up.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL backedup_talker_entity_id() = 0;
+        
+        /**
+         * \return The Unique ID of the AVDECC Talker that this stream is backing up.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL backedup_talker_unique() = 0;
+        
+        /**
+         * \return The descriptor index of the AVB INTERFACE descriptor from which this stream
+         *	       is sourced or to which it is sinked.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL avb_interface_index() = 0;
+        
+        /**
+         * \return The length in nanoseconds of the MAC's ingress buffer size.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL buffer_length() = 0;
+        
+        /**
+         * Tests state of a flag returned by last GET_STREAM_INFO command.
+         *
+         * \param flag The flag to check. Valid values are:
+         * CLASS_B, FAST_CONNECT, SAVED_STATE, STREAMING_WAIT, ENCRYPTED_PDU, STREAM_VLAN_ID_VALID
+         * CONNECTED, MSRP_FAILURE_VALID, STREAM_DEST_MAC_VALID, MSRP_ACC_LAT_VALID, STREAM_ID_VALID,
+         * STREAM_FORMAT_VALID.
+         *
+         * \see get_stream_info_flags(), get_stream_info_stream_format(), get_stream_info_stream_id(),
+         *      get_stream_info_msrp_accumulated_latency(), get_stream_info_stream_dest_mac(),
+         *      get_stream_info_msrp_failure_code(), get_stream_info_msrp_failure_bridge_id()
+         */
+        
+        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL get_stream_info_flag(const char *flag) = 0;
+    };
+}
+

--- a/controller/lib/include/stream_output_descriptor_response.h
+++ b/controller/lib/include/stream_output_descriptor_response.h
@@ -32,13 +32,27 @@
 
 #include <stdint.h>
 #include "build.h"
-#include "descriptor_base.h"
 
 namespace avdecc_lib
 {
-    class stream_output_descriptor_response : public virtual descriptor_base
+    class stream_output_descriptor_response
     {
     public:
+        virtual ~stream_output_descriptor_response(){};
+        /**
+         * \return The name of the descriptor object. This may be user set through the use of a SET_NAME command.
+         *	   The object name should be left blank (all zeros) by the manufacturer, with the manufacturer
+         *	   defined value being provided in a localized form via the localized descripton field. By leaving
+         *	   this field blank an AVDECC Controller can determine if the user has overridden the name and can
+         *	   use this name rather than the localized name.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint8_t * STDCALL object_name() = 0;
+        
+        /**
+         * \return The localized string reference pointing to the localized descriptor name.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL localized_description() = 0;
+
         /**
          * \return The descriptor index of the CLOCK DOMAIN descriptor providing the media clock for the stream.
          */

--- a/controller/lib/include/stream_output_get_stream_format_response.h
+++ b/controller/lib/include/stream_output_get_stream_format_response.h
@@ -37,6 +37,7 @@ namespace avdecc_lib
     class stream_output_get_stream_format_response
     {
     public:
+        virtual ~stream_output_get_stream_format_response(){};
         /**
          * \return The stream format of a stream after sending a GET_STREAM_FORMAT command and
          *	       receiving a response back for the command.

--- a/controller/lib/include/stream_output_get_stream_format_response.h
+++ b/controller/lib/include/stream_output_get_stream_format_response.h
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * stream_output_get_stream_format_response.h
+ *
+ * STREAM output stream format response base class
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "build.h"
+
+namespace avdecc_lib
+{
+    class stream_output_get_stream_format_response
+    {
+    public:
+        /**
+         * \return The stream format of a stream after sending a GET_STREAM_FORMAT command and
+         *	       receiving a response back for the command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_stream_format() = 0;
+    };
+}

--- a/controller/lib/include/stream_output_get_stream_info_response.h
+++ b/controller/lib/include/stream_output_get_stream_info_response.h
@@ -37,6 +37,7 @@ namespace avdecc_lib
     class stream_output_get_stream_info_response
     {
     public:
+        virtual ~stream_output_get_stream_info_response(){};
         /**
          * \return The stream info flags of a stream after sending a GET_STREAM_INFO command and
          *	       receiving a response back for the command.

--- a/controller/lib/include/stream_output_get_stream_info_response.h
+++ b/controller/lib/include/stream_output_get_stream_info_response.h
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * stream_output_get_stream_info_response.h
+ *
+ * STREAM OUTPUT stream info response base class
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "build.h"
+
+namespace avdecc_lib
+{
+    class stream_output_get_stream_info_response
+    {
+    public:
+        /**
+         * \return The stream info flags of a stream after sending a GET_STREAM_INFO command and
+         *	       receiving a response back for the command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_stream_info_flags() = 0;
+        
+        /**
+         * \return The stream info stream format of a stream after sending a GET_STREAM_INFO command and
+         *	       receiving a response back for the command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_stream_info_stream_format() = 0;
+        
+        /**
+         * \return The stream info stream id of a stream after sending a GET_STREAM_INFO command and
+         *	       receiving a response back for the command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_stream_info_stream_id() = 0;
+        
+        /**
+         * \return The stream info MSRP accumulated latency of a stream after sending a GET_STREAM_INFO command and
+         *	       receiving a response back for the command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_stream_info_msrp_accumulated_latency() = 0;
+        
+        /**
+         * \return The stream info stream destination MAC of a stream after sending a GET_STREAM_INFO command and
+         *	       receiving a response back for the command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_stream_info_stream_dest_mac() = 0;
+        
+        /**
+         * \return The stream info MSRP failure code of a stream after sending a GET_STREAM_INFO command and
+         *	       receiving a response back for the command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint8_t STDCALL get_stream_info_msrp_failure_code() = 0;
+        
+        /**
+         * \return The stream info MSRP failure bridge id of a stream after sending a GET_STREAM_INFO command and
+         *	       receiving a response back for the command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_stream_info_msrp_failure_bridge_id() = 0;
+        
+        /**
+         * \return The stream info vlan id of a stream after sending a GET_STREAM_INFO command and
+         *	       receiving a response back for the command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_stream_info_stream_vlan_id() = 0;
+    };
+}

--- a/controller/lib/include/stream_output_get_tx_connection_response.h
+++ b/controller/lib/include/stream_output_get_tx_connection_response.h
@@ -37,7 +37,7 @@ namespace avdecc_lib
     class stream_output_get_tx_connection_response
     {
     public:
-        
+        virtual ~stream_output_get_tx_connection_response(){};
         /**
          * \return The stream id field used to identify and transfer the associated stream ID where suitable
          *         after sending a GET_TX_CONNECTION command and receiving a response back for the command.

--- a/controller/lib/include/stream_output_get_tx_connection_response.h
+++ b/controller/lib/include/stream_output_get_tx_connection_response.h
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * stream_output_get_tx_connection_response.h
+ *
+ * STREAM OUTPUT tx connection response base class
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "build.h"
+
+namespace avdecc_lib
+{
+    class stream_output_get_tx_connection_response
+    {
+    public:
+        
+        /**
+         * \return The stream id field used to identify and transfer the associated stream ID where suitable
+         *         after sending a GET_TX_CONNECTION command and receiving a response back for the command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_tx_connection_stream_id() = 0;
+        
+        /**
+         * \return The Talker unique ID used to uniquely identify the stream source of the AVDECC Talker
+         *         after sending a GET_TX_CONNECTION command and receiving a response back for the command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_tx_connection_talker_unique_id() = 0;
+        
+        /**
+         * \return The Listener unique ID used to uniquely identify the stream sink of the AVDECC Listener
+         *         after sending a GET_TX_CONNECTION command and receiving a response back for the command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_tx_connection_listener_unique_id() = 0;
+        
+        /**
+         * \return The Listener entity ID of the stream sink of the AVDECC Talker
+         *         after sending a GET_TX_CONNECTION command and receiving a response back for the command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_tx_connection_listener_entity_id() = 0;
+        
+        /**
+         * \return The stream destination MAC address used to convey the destination MAC address for a stream
+         *         from the AVDECC Talker to the AVDECC Listener, or from either to the AVDECC Controller after
+         *         sending a GET_TX_CONNECTION command and receiving a response back for the command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_tx_connection_stream_dest_mac() = 0;
+        
+        /**
+         * \return The connection count used by the state commands to return the number of connections an AVDECC Talker
+         *         thinks it has on its stream source after sending a GET_TX_CONNECTION command and receiving a response
+         *         back for the command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_tx_connection_connection_count() = 0;
+        
+        /**
+         * \return The stream vlan id used to convey the VLAN ID for a stream from the AVDECC Talker to the AVDECC Listener,
+         *         or from either to the AVDECC Controller after sending a GET_TX_CONNECTION command and receiving a response
+         *         back for the command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_tx_connection_stream_vlan_id() = 0;
+    };
+}

--- a/controller/lib/include/stream_output_get_tx_state_response.h
+++ b/controller/lib/include/stream_output_get_tx_state_response.h
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * stream_output_get_tx_state_response.h
+ *
+ * STREAM OUTPUT tx state response base class
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "build.h"
+
+namespace avdecc_lib
+{
+    class stream_output_get_tx_state_response
+    {
+    public:
+        
+        /**
+         * \return The stream id field used to identify and transfer the associated stream ID where suitable
+         * after sending a GET_TX_STATE command and receiving a response back for the command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_tx_state_stream_id() = 0;
+        
+        /**
+         * \return The stream destination MAC address used to convey the destination MAC address for a stream
+         *         from the AVDECC Talker to the AVDECC Listener, or from either to the AVDECC Controller after
+         *         sending a GET_TX_STATE command and receiving a response back for the command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_tx_state_stream_dest_mac() = 0;
+        
+        /**
+         * \return The connection count used by the state commands to return the number of connections an AVDECC Talker
+         *         thinks it has on its stream source after sending a GET_TX_STATE command and receiving a response
+         *         back for the command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_tx_state_connection_count() = 0;
+        
+        /**
+         * \return The stream vlan id used to convey the VLAN ID for a stream from the AVDECC Talker to the AVDECC Listener,
+         *         or from either to the AVDECC Controller after sending a GET_TX_STATE command and receiving a response
+         *         back for the command.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_tx_state_stream_vlan_id() = 0;
+    };
+}

--- a/controller/lib/include/stream_output_get_tx_state_response.h
+++ b/controller/lib/include/stream_output_get_tx_state_response.h
@@ -37,7 +37,7 @@ namespace avdecc_lib
     class stream_output_get_tx_state_response
     {
     public:
-        
+        virtual ~stream_output_get_tx_state_response(){};
         /**
          * \return The stream id field used to identify and transfer the associated stream ID where suitable
          * after sending a GET_TX_STATE command and receiving a response back for the command.

--- a/controller/lib/include/stream_port_input_descriptor.h
+++ b/controller/lib/include/stream_port_input_descriptor.h
@@ -33,6 +33,7 @@
 #include <stdint.h>
 #include "build.h"
 #include "descriptor_base.h"
+#include "stream_port_input_descriptor_response.h"
 
 namespace avdecc_lib
 {
@@ -40,53 +41,8 @@ namespace avdecc_lib
     {
     public:
         /**
-         * \return The descriptor index of the CLOCK DOMAIN descriptor describing the CLOCK DOMAIN for the port.
+         * \return the stream port input descriptor response class.
          */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL clock_domain_index() = 0;
-
-        /**
-         * The flags describing the capabilities or features of the port.
-         *
-         * \return 1 (Clock Sync Source) if the port can be used as a clock synchronization source. \n
-         *	       2 (Async Sample Rate Conv) if the port has an asynchronous sample rate converter
-         *	         to convert sample rates between another CLOCK DOMAIN and the Unit's. \n
-         *	       3 (Sync Sample Rate Conv) if the port has a synchronous sample rate converter
-         *	         to convert between sample rates in the same CLOCK DOMAIN.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL port_flags() = 0;
-
-        /**
-         * \return The number of controls within the port.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_controls() = 0;
-
-        /**
-         * \return The index of the first Control descriptor.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_control() = 0;
-
-        /**
-         * \return The number of clusters within the port. This corresponds to the number of Audio Cluster,
-         *	       Video Cluster, and Sensor Cluster descriptors which represent these clusters.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_clusters() = 0;
-
-        /**
-         * \return The index of the first Audio Cluster, Video Cluster, or Sensor Cluster descriptor
-         *	       describing the clusters within the port.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_cluster() = 0;
-
-        /**
-         * \return The number of map descriptors used to define the mapping between the stream and the port.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_maps() = 0;
-
-        /**
-         * \return The index of the first Audio Map, Video Map, or Sensor Map, descriptor which defines
-         *	       the mappling between the stream and the port.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_map() = 0;
+        AVDECC_CONTROLLER_LIB32_API virtual STDCALL stream_port_input_descriptor_response * get_stream_port_input_response() = 0;
     };
 }
-

--- a/controller/lib/include/stream_port_input_descriptor.h
+++ b/controller/lib/include/stream_port_input_descriptor.h
@@ -43,6 +43,6 @@ namespace avdecc_lib
         /**
          * \return the stream port input descriptor response class.
          */
-        AVDECC_CONTROLLER_LIB32_API virtual STDCALL stream_port_input_descriptor_response * get_stream_port_input_response() = 0;
+        AVDECC_CONTROLLER_LIB32_API virtual stream_port_input_descriptor_response * STDCALL get_stream_port_input_response() = 0;
     };
 }

--- a/controller/lib/include/stream_port_input_descriptor_response.h
+++ b/controller/lib/include/stream_port_input_descriptor_response.h
@@ -32,13 +32,13 @@
 
 #include <stdint.h>
 #include "build.h"
-#include "descriptor_base.h"
 
 namespace avdecc_lib
 {
-    class stream_port_input_descriptor_response : public virtual descriptor_base
+    class stream_port_input_descriptor_response
     {
     public:
+        virtual ~stream_port_input_descriptor_response(){};
         /**
          * \return The descriptor index of the CLOCK DOMAIN descriptor describing the CLOCK DOMAIN for the port.
          */

--- a/controller/lib/include/stream_port_input_descriptor_response.h
+++ b/controller/lib/include/stream_port_input_descriptor_response.h
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * stream_port_input_descriptor_response.h
+ *
+ * Public Stream Port Input descriptor response interface class
+ * The Stream Port Input descriptor describes a STREAM INPUT Port of the Unit.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "build.h"
+#include "descriptor_base.h"
+
+namespace avdecc_lib
+{
+    class stream_port_input_descriptor_response : public virtual descriptor_base
+    {
+    public:
+        /**
+         * \return The descriptor index of the CLOCK DOMAIN descriptor describing the CLOCK DOMAIN for the port.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL clock_domain_index() = 0;
+        
+        /**
+         * The flags describing the capabilities or features of the port.
+         *
+         * \return 1 (Clock Sync Source) if the port can be used as a clock synchronization source. \n
+         *	       2 (Async Sample Rate Conv) if the port has an asynchronous sample rate converter
+         *	         to convert sample rates between another CLOCK DOMAIN and the Unit's. \n
+         *	       3 (Sync Sample Rate Conv) if the port has a synchronous sample rate converter
+         *	         to convert between sample rates in the same CLOCK DOMAIN.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL port_flags() = 0;
+        
+        /**
+         * \return The number of controls within the port.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_controls() = 0;
+        
+        /**
+         * \return The index of the first Control descriptor.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_control() = 0;
+        
+        /**
+         * \return The number of clusters within the port. This corresponds to the number of Audio Cluster,
+         *	       Video Cluster, and Sensor Cluster descriptors which represent these clusters.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_clusters() = 0;
+        
+        /**
+         * \return The index of the first Audio Cluster, Video Cluster, or Sensor Cluster descriptor
+         *	       describing the clusters within the port.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_cluster() = 0;
+        
+        /**
+         * \return The number of map descriptors used to define the mapping between the stream and the port.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_maps() = 0;
+        
+        /**
+         * \return The index of the first Audio Map, Video Map, or Sensor Map, descriptor which defines
+         *	       the mappling between the stream and the port.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_map() = 0;
+    };
+}
+

--- a/controller/lib/include/stream_port_output_descriptor.h
+++ b/controller/lib/include/stream_port_output_descriptor.h
@@ -43,6 +43,6 @@ namespace avdecc_lib
         /**
          * \return the stream port output descriptor response class.
          */
-        AVDECC_CONTROLLER_LIB32_API virtual STDCALL stream_port_output_descriptor_response * get_stream_port_output_response() = 0;
+        AVDECC_CONTROLLER_LIB32_API virtual stream_port_output_descriptor_response * STDCALL get_stream_port_output_response() = 0;
     };
 }

--- a/controller/lib/include/stream_port_output_descriptor.h
+++ b/controller/lib/include/stream_port_output_descriptor.h
@@ -33,6 +33,7 @@
 #include <stdint.h>
 #include "build.h"
 #include "descriptor_base.h"
+#include "stream_port_output_descriptor_response.h"
 
 namespace avdecc_lib
 {
@@ -40,53 +41,8 @@ namespace avdecc_lib
     {
     public:
         /**
-         * \return The descriptor index of the CLOCK DOMAIN descriptor describing the CLOCK DOMAIN for the port.
+         * \return the stream port output descriptor response class.
          */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL clock_domain_index() = 0;
-
-        /**
-         * The flags describing the capabilities or features of the port.
-         *
-         * \return 1 (Clock Sync Source) if the port can be used as a clock synchronization source. \n
-         *	       2 (Async Sample Rate Conv) if the port has an asynchronous sample rate converter
-         *	         to convert sample rates between another CLOCK DOMAIN and the Unit's. \n
-         *	       3 (Sync Sample Rate Conv) if the port has a synchronous sample rate converter
-         *	         to convert between sample rates in the same CLOCK DOMAIN.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL port_flags() = 0;
-
-        /**
-         * \return The number of controls within the port.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_controls() = 0;
-
-        /**
-         * \return The index of the first Control descriptor.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_control() = 0;
-
-        /**
-         * \return The number of clusters within the port. This corresponds to the number of Audio Cluster,
-         *	       Video Cluster, and Sensor Cluster descriptors which represent these clusters.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_clusters() = 0;
-
-        /**
-         * \return The index of the first Audio Cluster, Video Cluster, or Sensor Cluster descriptor
-         *	       describing the clusters within the port.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_cluster() = 0;
-
-        /**
-         * \return The number of map descriptors used to define the mapping between the stream and the port.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_maps() = 0;
-
-        /**
-         * \return The index of the first Audio Map, Video Map, or Sensor Map, descriptor which defines
-         *	       the mappling between the stream and the port.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_map() = 0;
+        AVDECC_CONTROLLER_LIB32_API virtual STDCALL stream_port_output_descriptor_response * get_stream_port_output_response() = 0;
     };
 }
-

--- a/controller/lib/include/stream_port_output_descriptor_response.h
+++ b/controller/lib/include/stream_port_output_descriptor_response.h
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * stream_port_output_descriptor_response.h
+ *
+ * Public Stream Port Output descriptor response interface class
+ * The Stream Port Output descriptor describes a STREAM OUTPUT Port of the Unit.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "build.h"
+#include "descriptor_base.h"
+
+namespace avdecc_lib
+{
+    class stream_port_output_descriptor_response : public virtual descriptor_base
+    {
+    public:
+        /**
+         * \return The descriptor index of the CLOCK DOMAIN descriptor describing the CLOCK DOMAIN for the port.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL clock_domain_index() = 0;
+        
+        /**
+         * The flags describing the capabilities or features of the port.
+         *
+         * \return 1 (Clock Sync Source) if the port can be used as a clock synchronization source. \n
+         *	       2 (Async Sample Rate Conv) if the port has an asynchronous sample rate converter
+         *	         to convert sample rates between another CLOCK DOMAIN and the Unit's. \n
+         *	       3 (Sync Sample Rate Conv) if the port has a synchronous sample rate converter
+         *	         to convert between sample rates in the same CLOCK DOMAIN.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL port_flags() = 0;
+        
+        /**
+         * \return The number of controls within the port.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_controls() = 0;
+        
+        /**
+         * \return The index of the first Control descriptor.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_control() = 0;
+        
+        /**
+         * \return The number of clusters within the port. This corresponds to the number of Audio Cluster,
+         *	       Video Cluster, and Sensor Cluster descriptors which represent these clusters.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_clusters() = 0;
+        
+        /**
+         * \return The index of the first Audio Cluster, Video Cluster, or Sensor Cluster descriptor
+         *	       describing the clusters within the port.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_cluster() = 0;
+        
+        /**
+         * \return The number of map descriptors used to define the mapping between the stream and the port.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_maps() = 0;
+        
+        /**
+         * \return The index of the first Audio Map, Video Map, or Sensor Map, descriptor which defines
+         *	       the mappling between the stream and the port.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_map() = 0;
+    };
+}

--- a/controller/lib/include/stream_port_output_descriptor_response.h
+++ b/controller/lib/include/stream_port_output_descriptor_response.h
@@ -32,13 +32,13 @@
 
 #include <stdint.h>
 #include "build.h"
-#include "descriptor_base.h"
 
 namespace avdecc_lib
 {
-    class stream_port_output_descriptor_response : public virtual descriptor_base
+    class stream_port_output_descriptor_response
     {
     public:
+        virtual ~stream_port_output_descriptor_response(){};
         /**
          * \return The descriptor index of the CLOCK DOMAIN descriptor describing the CLOCK DOMAIN for the port.
          */

--- a/controller/lib/include/strings_descriptor.h
+++ b/controller/lib/include/strings_descriptor.h
@@ -33,6 +33,7 @@
 #include <stdint.h>
 #include "build.h"
 #include "descriptor_base.h"
+#include "strings_descriptor_response.h"
 
 namespace avdecc_lib
 {
@@ -40,9 +41,8 @@ namespace avdecc_lib
     {
     public:
         /**
-         * \return The corresponding localized string of the Strings descriptor.
+         * \return the strings descriptor response class.
          */
-        AVDECC_CONTROLLER_LIB32_API virtual uint8_t * STDCALL get_string_by_index(size_t string_index) = 0;
+        AVDECC_CONTROLLER_LIB32_API virtual STDCALL strings_descriptor_response * get_strings_response() = 0;
     };
 }
-

--- a/controller/lib/include/strings_descriptor.h
+++ b/controller/lib/include/strings_descriptor.h
@@ -43,6 +43,6 @@ namespace avdecc_lib
         /**
          * \return the strings descriptor response class.
          */
-        AVDECC_CONTROLLER_LIB32_API virtual STDCALL strings_descriptor_response * get_strings_response() = 0;
+        AVDECC_CONTROLLER_LIB32_API virtual strings_descriptor_response * STDCALL get_strings_response() = 0;
     };
 }

--- a/controller/lib/include/strings_descriptor_response.h
+++ b/controller/lib/include/strings_descriptor_response.h
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * strings_descriptor_response.h
+ *
+ * Public Strings descriptor response interface class
+ * The Strings descriptor describes the localized strings.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "build.h"
+#include "descriptor_base.h"
+
+namespace avdecc_lib
+{
+    class strings_descriptor_response : public virtual descriptor_base
+    {
+    public:
+        /**
+         * \return The corresponding localized string of the Strings descriptor.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual uint8_t * STDCALL get_string_by_index(size_t string_index) = 0;
+    };
+}

--- a/controller/lib/include/strings_descriptor_response.h
+++ b/controller/lib/include/strings_descriptor_response.h
@@ -31,14 +31,15 @@
 #pragma once
 
 #include <stdint.h>
+#include <cstddef>
 #include "build.h"
-#include "descriptor_base.h"
 
 namespace avdecc_lib
 {
-    class strings_descriptor_response : public virtual descriptor_base
+    class strings_descriptor_response
     {
     public:
+        virtual ~strings_descriptor_response(){};
         /**
          * \return The corresponding localized string of the Strings descriptor.
          */

--- a/controller/lib/src/aecp_controller_state_machine.cpp
+++ b/controller/lib/src/aecp_controller_state_machine.cpp
@@ -323,6 +323,7 @@ namespace avdecc_lib
         uint32_t status = jdksavdecc_common_control_header_get_status(frame, ETHER_HDR_SIZE);
         uint16_t desc_type = 0;
         uint16_t desc_index = 0;
+        
         bool is_unsolicited = cmd_type >> 15 & 0x01;
         
         switch(cmd_type)
@@ -506,7 +507,7 @@ namespace avdecc_lib
 
     bool aecp_controller_state_machine::is_inflight_cmd_with_notification_id(void *notification_id)
     {
-       std::vector<inflight>::iterator j =
+        std::vector<inflight>::iterator j =
             std::find_if(inflight_cmds.begin(), inflight_cmds.end(), NotificationComp(notification_id));
 
         if(j != inflight_cmds.end()) // found?

--- a/controller/lib/src/aecp_controller_state_machine.cpp
+++ b/controller/lib/src/aecp_controller_state_machine.cpp
@@ -323,7 +323,6 @@ namespace avdecc_lib
         uint32_t status = jdksavdecc_common_control_header_get_status(frame, ETHER_HDR_SIZE);
         uint16_t desc_type = 0;
         uint16_t desc_index = 0;
-        
         bool is_unsolicited = cmd_type >> 15 & 0x01;
         
         switch(cmd_type)

--- a/controller/lib/src/aecp_controller_state_machine.h
+++ b/controller/lib/src/aecp_controller_state_machine.h
@@ -123,4 +123,3 @@ namespace avdecc_lib
 
     extern aecp_controller_state_machine *aecp_controller_state_machine_ref;
 }
-

--- a/controller/lib/src/audio_cluster_descriptor_imp.cpp
+++ b/controller/lib/src/audio_cluster_descriptor_imp.cpp
@@ -48,15 +48,4 @@ namespace avdecc_lib
         return resp = new audio_cluster_descriptor_response_imp(resp_ref->get_buffer(),
                                                                 resp_ref->get_size(), resp_ref->get_pos());
     }
-
-    uint16_t STDCALL audio_cluster_descriptor_imp::descriptor_type() const
-    {
-        assert(jdksavdecc_descriptor_audio_cluster_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos()) == JDKSAVDECC_DESCRIPTOR_AUDIO_CLUSTER);
-        return jdksavdecc_descriptor_audio_cluster_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
-    }
-
-    uint16_t STDCALL audio_cluster_descriptor_imp::descriptor_index() const
-    {
-        return jdksavdecc_descriptor_audio_cluster_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
-    }
 }

--- a/controller/lib/src/audio_cluster_descriptor_imp.cpp
+++ b/controller/lib/src/audio_cluster_descriptor_imp.cpp
@@ -35,29 +35,25 @@
 
 namespace avdecc_lib
 {
-    audio_cluster_descriptor_imp::audio_cluster_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos)
-    {
-        m_type = jdksavdecc_descriptor_audio_cluster_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
-        m_index = jdksavdecc_descriptor_audio_cluster_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
-    }
+    audio_cluster_descriptor_imp::audio_cluster_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos) {}
 
     audio_cluster_descriptor_imp::~audio_cluster_descriptor_imp() {}
-    
+
     audio_cluster_descriptor_response * STDCALL audio_cluster_descriptor_imp::get_audio_cluster_response()
     {
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
         return resp = new audio_cluster_descriptor_response_imp(resp_ref->get_buffer(),
-                                                             resp_ref->get_size(), resp_ref->get_pos());
+                                                                resp_ref->get_size(), resp_ref->get_pos());
     }
 
     uint16_t STDCALL audio_cluster_descriptor_imp::descriptor_type() const
     {
-        assert(m_type == JDKSAVDECC_DESCRIPTOR_AUDIO_CLUSTER);
-        return m_type;
+        assert(jdksavdecc_descriptor_audio_cluster_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos()) == JDKSAVDECC_DESCRIPTOR_AUDIO_CLUSTER);
+        return jdksavdecc_descriptor_audio_cluster_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 
     uint16_t STDCALL audio_cluster_descriptor_imp::descriptor_index() const
     {
-        return m_index;
+        return jdksavdecc_descriptor_audio_cluster_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 }

--- a/controller/lib/src/audio_cluster_descriptor_imp.cpp
+++ b/controller/lib/src/audio_cluster_descriptor_imp.cpp
@@ -35,71 +35,29 @@
 
 namespace avdecc_lib
 {
-    audio_cluster_descriptor_imp::audio_cluster_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj)
+    audio_cluster_descriptor_imp::audio_cluster_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos)
     {
-        ssize_t ret = jdksavdecc_descriptor_audio_cluster_read(&audio_cluster_desc, frame, pos, frame_len);
-
-        if (ret < 0)
-        {
-            throw avdecc_read_descriptor_error("audio_cluster_desc_read error");
-        }
+        m_type = jdksavdecc_descriptor_audio_cluster_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
+        m_index = jdksavdecc_descriptor_audio_cluster_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 
     audio_cluster_descriptor_imp::~audio_cluster_descriptor_imp() {}
+    
+    audio_cluster_descriptor_response * STDCALL audio_cluster_descriptor_imp::get_audio_cluster_response()
+    {
+        std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
+        return resp = new audio_cluster_descriptor_response_imp(resp_ref->get_buffer(),
+                                                             resp_ref->get_size(), resp_ref->get_pos());
+    }
 
     uint16_t STDCALL audio_cluster_descriptor_imp::descriptor_type() const
     {
-        assert(audio_cluster_desc.descriptor_type == JDKSAVDECC_DESCRIPTOR_AUDIO_CLUSTER);
-        return audio_cluster_desc.descriptor_type;
+        assert(m_type == JDKSAVDECC_DESCRIPTOR_AUDIO_CLUSTER);
+        return m_type;
     }
 
     uint16_t STDCALL audio_cluster_descriptor_imp::descriptor_index() const
     {
-        return audio_cluster_desc.descriptor_index;
-    }
-
-    uint8_t * STDCALL audio_cluster_descriptor_imp::object_name()
-    {
-        return audio_cluster_desc.object_name.value;
-    }
-
-    uint16_t STDCALL audio_cluster_descriptor_imp::localized_description()
-    {
-        return audio_cluster_desc.localized_description;
-    }
-
-    uint16_t STDCALL audio_cluster_descriptor_imp::signal_type()
-    {
-        return audio_cluster_desc.signal_type;
-    }
-
-    uint16_t STDCALL audio_cluster_descriptor_imp::signal_index()
-    {
-        return audio_cluster_desc.signal_index;
-    }
-
-    uint16_t STDCALL audio_cluster_descriptor_imp::signal_output()
-    {
-        return audio_cluster_desc.signal_output;
-    }
-
-    uint32_t STDCALL audio_cluster_descriptor_imp::path_latency()
-    {
-        return audio_cluster_desc.path_latency;
-    }
-
-    uint32_t STDCALL audio_cluster_descriptor_imp::block_latency()
-    {
-        return audio_cluster_desc.block_latency;
-    }
-
-    uint16_t STDCALL audio_cluster_descriptor_imp::channel_count()
-    {
-        return audio_cluster_desc.channel_count;
-    }
-
-    uint8_t STDCALL audio_cluster_descriptor_imp::format()
-    {
-        return audio_cluster_desc.format;
+        return m_index;
     }
 }

--- a/controller/lib/src/audio_cluster_descriptor_imp.cpp
+++ b/controller/lib/src/audio_cluster_descriptor_imp.cpp
@@ -27,6 +27,9 @@
  * Audio Cluster descriptor implementation
  */
 
+#include <thread>
+#include <mutex>
+
 #include "avdecc_error.h"
 #include "enumeration.h"
 #include "log_imp.h"

--- a/controller/lib/src/audio_cluster_descriptor_imp.h
+++ b/controller/lib/src/audio_cluster_descriptor_imp.h
@@ -37,9 +37,6 @@ namespace avdecc_lib
 {
     class audio_cluster_descriptor_imp : public audio_cluster_descriptor, public virtual descriptor_base_imp
     {
-    private:
-        uint16_t m_type;
-        uint16_t m_index;
     public:
         audio_cluster_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
         virtual ~audio_cluster_descriptor_imp();

--- a/controller/lib/src/audio_cluster_descriptor_imp.h
+++ b/controller/lib/src/audio_cluster_descriptor_imp.h
@@ -43,8 +43,6 @@ namespace avdecc_lib
         
         audio_cluster_descriptor_response_imp *resp;
 
-        uint16_t STDCALL descriptor_type() const;
-        uint16_t STDCALL descriptor_index() const;
         audio_cluster_descriptor_response * STDCALL get_audio_cluster_response();
     };
 }

--- a/controller/lib/src/audio_cluster_descriptor_imp.h
+++ b/controller/lib/src/audio_cluster_descriptor_imp.h
@@ -31,30 +31,23 @@
 
 #include "descriptor_base_imp.h"
 #include "audio_cluster_descriptor.h"
+#include "audio_cluster_descriptor_response_imp.h"
 
 namespace avdecc_lib
 {
     class audio_cluster_descriptor_imp : public audio_cluster_descriptor, public virtual descriptor_base_imp
     {
     private:
-        struct jdksavdecc_descriptor_audio_cluster audio_cluster_desc; // Structure containing the audio_cluster_desc fields
-
+        uint16_t m_type;
+        uint16_t m_index;
     public:
         audio_cluster_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
-
         virtual ~audio_cluster_descriptor_imp();
+        
+        audio_cluster_descriptor_response_imp *resp;
 
         uint16_t STDCALL descriptor_type() const;
         uint16_t STDCALL descriptor_index() const;
-        uint8_t * STDCALL object_name();
-        uint16_t STDCALL localized_description();
-        uint16_t STDCALL signal_type();
-        uint16_t STDCALL signal_index();
-        uint16_t STDCALL signal_output();
-        uint32_t STDCALL path_latency();
-        uint32_t STDCALL block_latency();
-        uint16_t STDCALL channel_count();
-        uint8_t STDCALL format();
+        audio_cluster_descriptor_response * STDCALL get_audio_cluster_response();
     };
 }
-

--- a/controller/lib/src/audio_cluster_descriptor_response_imp.cpp
+++ b/controller/lib/src/audio_cluster_descriptor_response_imp.cpp
@@ -32,7 +32,7 @@
 
 namespace avdecc_lib
 {
-    audio_cluster_descriptor_response_imp::audio_cluster_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos) : descriptor_base_imp(nullptr, frame, frame_len, pos)
+    audio_cluster_descriptor_response_imp::audio_cluster_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos)
     {
         frame_size = frame_len;
         buffer = (uint8_t *)malloc(frame_size * sizeof(uint8_t));
@@ -40,7 +40,10 @@ namespace avdecc_lib
         position = pos;
     }
     
-    audio_cluster_descriptor_response_imp::~audio_cluster_descriptor_response_imp() {}
+    audio_cluster_descriptor_response_imp::~audio_cluster_descriptor_response_imp()
+    {
+        free(buffer);
+    }
     
     uint8_t * STDCALL audio_cluster_descriptor_response_imp::object_name()
     {

--- a/controller/lib/src/audio_cluster_descriptor_response_imp.cpp
+++ b/controller/lib/src/audio_cluster_descriptor_response_imp.cpp
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * audio_cluster_descriptor_response_imp.cpp
+ *
+ * AUDIO CLUSTER descriptor response implementation
+ */
+
+#include <vector>
+#include "audio_cluster_descriptor_response_imp.h"
+
+namespace avdecc_lib
+{
+    audio_cluster_descriptor_response_imp::audio_cluster_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos) : descriptor_base_imp(nullptr, frame, frame_len, pos)
+    {
+        frame_size = frame_len;
+        buffer = (uint8_t *)malloc(frame_size * sizeof(uint8_t));
+        memcpy(buffer, frame, frame_size);
+        position = pos;
+    }
+    
+    audio_cluster_descriptor_response_imp::~audio_cluster_descriptor_response_imp() {}
+    
+    uint8_t * STDCALL audio_cluster_descriptor_response_imp::object_name()
+    {
+        return (uint8_t *)&buffer[position + JDKSAVDECC_DESCRIPTOR_AUDIO_CLUSTER_OFFSET_OBJECT_NAME];
+    }
+    
+    uint16_t STDCALL audio_cluster_descriptor_response_imp::localized_description()
+    {
+        return jdksavdecc_descriptor_audio_cluster_get_localized_description(buffer, position);
+    }
+    
+    uint16_t STDCALL audio_cluster_descriptor_response_imp::signal_type()
+    {
+        return jdksavdecc_descriptor_audio_cluster_get_signal_type(buffer, position);
+    }
+    
+    uint16_t STDCALL audio_cluster_descriptor_response_imp::signal_index()
+    {
+        return jdksavdecc_descriptor_audio_cluster_get_signal_index(buffer, position);
+    }
+
+    uint16_t STDCALL audio_cluster_descriptor_response_imp::signal_output()
+    {
+        return jdksavdecc_descriptor_audio_cluster_get_signal_output(buffer, position);
+    }
+    
+    uint32_t STDCALL audio_cluster_descriptor_response_imp::path_latency()
+    {
+        return jdksavdecc_descriptor_audio_cluster_get_path_latency(buffer, position);
+    }
+    
+    uint32_t STDCALL audio_cluster_descriptor_response_imp::block_latency()
+    {
+        return jdksavdecc_descriptor_audio_cluster_get_block_latency(buffer, position);
+    }
+    
+    uint16_t STDCALL audio_cluster_descriptor_response_imp::channel_count()
+    {
+        return jdksavdecc_descriptor_audio_cluster_get_channel_count(buffer, position);
+    }
+    
+    uint8_t STDCALL audio_cluster_descriptor_response_imp::format()
+    {
+        return jdksavdecc_descriptor_audio_cluster_get_format(buffer, position);
+    }
+}

--- a/controller/lib/src/audio_cluster_descriptor_response_imp.h
+++ b/controller/lib/src/audio_cluster_descriptor_response_imp.h
@@ -29,12 +29,12 @@
 
 #pragma once
 
-#include "descriptor_base_imp.h"
 #include "audio_cluster_descriptor_response.h"
+#include "jdksavdecc_aem_descriptor.h"
 
 namespace avdecc_lib
 {
-    class audio_cluster_descriptor_response_imp : public audio_cluster_descriptor_response, public virtual descriptor_base_imp
+    class audio_cluster_descriptor_response_imp : public audio_cluster_descriptor_response
     {
     private:
         uint8_t * buffer;

--- a/controller/lib/src/audio_cluster_descriptor_response_imp.h
+++ b/controller/lib/src/audio_cluster_descriptor_response_imp.h
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * audio_cluster_descriptor_response_imp.h
+ *
+ * Audio Cluster descriptor response implementation class
+ */
+
+#pragma once
+
+#include "descriptor_base_imp.h"
+#include "audio_cluster_descriptor_response.h"
+
+namespace avdecc_lib
+{
+    class audio_cluster_descriptor_response_imp : public audio_cluster_descriptor_response, public virtual descriptor_base_imp
+    {
+    private:
+        uint8_t * buffer;
+        ssize_t position;
+        size_t frame_size;
+    public:
+        audio_cluster_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos);
+        virtual ~audio_cluster_descriptor_response_imp();
+        
+        uint8_t * STDCALL object_name();
+        uint16_t STDCALL localized_description();
+        uint16_t STDCALL signal_type();
+        uint16_t STDCALL signal_index();
+        uint16_t STDCALL signal_output();
+        uint32_t STDCALL path_latency();
+        uint32_t STDCALL block_latency();
+        uint16_t STDCALL channel_count();
+        uint8_t STDCALL format();
+    };
+}

--- a/controller/lib/src/audio_map_descriptor_imp.cpp
+++ b/controller/lib/src/audio_map_descriptor_imp.cpp
@@ -47,15 +47,4 @@ namespace avdecc_lib
         return resp = new audio_map_descriptor_response_imp(resp_ref->get_buffer(),
                                                             resp_ref->get_size(), resp_ref->get_pos());
     }
-
-    uint16_t STDCALL audio_map_descriptor_imp::descriptor_type() const
-    {
-        assert(jdksavdecc_descriptor_audio_map_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos()) == JDKSAVDECC_DESCRIPTOR_AUDIO_MAP);
-        return jdksavdecc_descriptor_audio_map_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
-    }
-
-    uint16_t STDCALL audio_map_descriptor_imp::descriptor_index() const
-    {
-        return jdksavdecc_descriptor_audio_map_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
-    }
 }

--- a/controller/lib/src/audio_map_descriptor_imp.cpp
+++ b/controller/lib/src/audio_map_descriptor_imp.cpp
@@ -27,6 +27,8 @@
  * Audio Map descriptor implementation
  */
 
+#include <mutex>
+
 #include "avdecc_error.h"
 #include "enumeration.h"
 #include "log_imp.h"

--- a/controller/lib/src/audio_map_descriptor_imp.cpp
+++ b/controller/lib/src/audio_map_descriptor_imp.cpp
@@ -35,11 +35,7 @@
 
 namespace avdecc_lib
 {
-    audio_map_descriptor_imp::audio_map_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos)
-    {
-        m_type = jdksavdecc_descriptor_audio_map_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
-        m_index = jdksavdecc_descriptor_audio_map_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
-    }
+    audio_map_descriptor_imp::audio_map_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos) {}
 
     audio_map_descriptor_imp::~audio_map_descriptor_imp() {}
     
@@ -47,17 +43,17 @@ namespace avdecc_lib
     {
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
         return resp = new audio_map_descriptor_response_imp(resp_ref->get_buffer(),
-                                                             resp_ref->get_size(), resp_ref->get_pos());
+                                                            resp_ref->get_size(), resp_ref->get_pos());
     }
 
     uint16_t STDCALL audio_map_descriptor_imp::descriptor_type() const
     {
-        assert(m_type == JDKSAVDECC_DESCRIPTOR_AUDIO_MAP);
-        return m_type;
+        assert(jdksavdecc_descriptor_audio_map_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos()) == JDKSAVDECC_DESCRIPTOR_AUDIO_MAP);
+        return jdksavdecc_descriptor_audio_map_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 
     uint16_t STDCALL audio_map_descriptor_imp::descriptor_index() const
     {
-        return m_index;
+        return jdksavdecc_descriptor_audio_map_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 }

--- a/controller/lib/src/audio_map_descriptor_imp.cpp
+++ b/controller/lib/src/audio_map_descriptor_imp.cpp
@@ -35,61 +35,29 @@
 
 namespace avdecc_lib
 {
-    audio_map_descriptor_imp::audio_map_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj)
+    audio_map_descriptor_imp::audio_map_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos)
     {
-        ssize_t ret = jdksavdecc_descriptor_audio_map_read(&audio_map_desc, frame, pos, frame_len);
-
-        if (ret < 0)
-        {
-            throw avdecc_read_descriptor_error("audio_map_desc_read error");
-        }
-
-        ssize_t offset = pos + mappings_offset();
-        for (unsigned int i = 0; i < (unsigned int)number_of_mappings(); i++)
-        {
-            struct audio_map_mapping map;
-
-            map.stream_index = jdksavdecc_uint16_get(frame, offset);
-            map.stream_channel = jdksavdecc_uint16_get(frame, offset + 2);
-            map.cluster_offset = jdksavdecc_uint16_get(frame, offset + 4);
-            map.cluster_channel = jdksavdecc_uint16_get(frame, offset + 6);
-            maps.push_back(map);
-            offset += sizeof(struct audio_map_mapping);
-        }
+        m_type = jdksavdecc_descriptor_audio_map_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
+        m_index = jdksavdecc_descriptor_audio_map_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 
     audio_map_descriptor_imp::~audio_map_descriptor_imp() {}
+    
+    audio_map_descriptor_response * STDCALL audio_map_descriptor_imp::get_audio_map_response()
+    {
+        std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
+        return resp = new audio_map_descriptor_response_imp(resp_ref->get_buffer(),
+                                                             resp_ref->get_size(), resp_ref->get_pos());
+    }
 
     uint16_t STDCALL audio_map_descriptor_imp::descriptor_type() const
     {
-        assert(audio_map_desc.descriptor_type == JDKSAVDECC_DESCRIPTOR_AUDIO_MAP);
-        return audio_map_desc.descriptor_type;
+        assert(m_type == JDKSAVDECC_DESCRIPTOR_AUDIO_MAP);
+        return m_type;
     }
 
     uint16_t STDCALL audio_map_descriptor_imp::descriptor_index() const
     {
-        return audio_map_desc.descriptor_index;
+        return m_index;
     }
-
-    uint16_t audio_map_descriptor_imp::mappings_offset()
-    {
-        assert(audio_map_desc.mappings_offset == 8);
-        return audio_map_desc.mappings_offset;
-    }
-
-    uint16_t STDCALL audio_map_descriptor_imp::number_of_mappings()
-    {
-        return audio_map_desc.number_of_mappings;
-    }
-    
-    int STDCALL audio_map_descriptor_imp::mapping(size_t index, struct audio_map_mapping &map)
-    {
-        if (index >= audio_map_desc.number_of_mappings)
-            return -1;
-
-        map = maps.at(index);
-        return 0;
-    }
-
-
 }

--- a/controller/lib/src/audio_map_descriptor_imp.h
+++ b/controller/lib/src/audio_map_descriptor_imp.h
@@ -31,25 +31,23 @@
 
 #include "descriptor_base_imp.h"
 #include "audio_map_descriptor.h"
+#include "audio_map_descriptor_response_imp.h"
 
 namespace avdecc_lib
 {
     class audio_map_descriptor_imp : public audio_map_descriptor, public virtual descriptor_base_imp
     {
-
     private:
-        struct jdksavdecc_descriptor_audio_map audio_map_desc; // Structure containing the audio_map_desc fields
-        std::vector<struct audio_map_mapping> maps; // Store maps in a vector
-
+        uint16_t m_type;
+        uint16_t m_index;
     public:
         audio_map_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
         virtual ~audio_map_descriptor_imp();
+        
+        audio_map_descriptor_response_imp *resp;
 
         uint16_t STDCALL descriptor_type() const;
         uint16_t STDCALL descriptor_index() const;
-        uint16_t mappings_offset();
-        uint16_t STDCALL number_of_mappings();
-        int STDCALL mapping(size_t index, struct audio_map_mapping &map);
+        audio_map_descriptor_response * STDCALL get_audio_map_response();
     };
 }
-

--- a/controller/lib/src/audio_map_descriptor_imp.h
+++ b/controller/lib/src/audio_map_descriptor_imp.h
@@ -43,8 +43,6 @@ namespace avdecc_lib
         
         audio_map_descriptor_response_imp *resp;
 
-        uint16_t STDCALL descriptor_type() const;
-        uint16_t STDCALL descriptor_index() const;
         audio_map_descriptor_response * STDCALL get_audio_map_response();
     };
 }

--- a/controller/lib/src/audio_map_descriptor_imp.h
+++ b/controller/lib/src/audio_map_descriptor_imp.h
@@ -37,9 +37,6 @@ namespace avdecc_lib
 {
     class audio_map_descriptor_imp : public audio_map_descriptor, public virtual descriptor_base_imp
     {
-    private:
-        uint16_t m_type;
-        uint16_t m_index;
     public:
         audio_map_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
         virtual ~audio_map_descriptor_imp();

--- a/controller/lib/src/audio_map_descriptor_response_imp.cpp
+++ b/controller/lib/src/audio_map_descriptor_response_imp.cpp
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * audio_map_descriptor_response_imp.cpp
+ *
+ * AUDIO MAP descriptor response implementation
+ */
+
+#include <vector>
+#include "audio_map_descriptor_response_imp.h"
+
+namespace avdecc_lib
+{
+    audio_map_descriptor_response_imp::audio_map_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos) : descriptor_base_imp(nullptr, frame, frame_len, pos)
+    {
+        frame_size = frame_len;
+        buffer = (uint8_t *)malloc(frame_size * sizeof(uint8_t));
+        memcpy(buffer, frame, frame_size);
+        position = pos;
+        
+        ssize_t offset = pos + mappings_offset();
+        for (unsigned int i = 0; i < (unsigned int)number_of_mappings(); i++)
+        {
+            struct audio_map_mapping map;
+            
+            map.stream_index = jdksavdecc_uint16_get(frame, offset);
+            map.stream_channel = jdksavdecc_uint16_get(frame, offset + 2);
+            map.cluster_offset = jdksavdecc_uint16_get(frame, offset + 4);
+            map.cluster_channel = jdksavdecc_uint16_get(frame, offset + 6);
+            maps.push_back(map);
+            offset += sizeof(struct audio_map_mapping);
+        }
+    }
+    
+    audio_map_descriptor_response_imp::~audio_map_descriptor_response_imp() {}
+    
+    uint16_t audio_map_descriptor_response_imp::mappings_offset()
+    {
+        return jdksavdecc_descriptor_audio_map_get_mappings_offset(buffer, position);
+    }
+    
+    uint16_t STDCALL audio_map_descriptor_response_imp::number_of_mappings()
+    {
+        return jdksavdecc_descriptor_audio_map_get_number_of_mappings(buffer, position);
+    }
+    
+    int STDCALL audio_map_descriptor_response_imp::mapping(size_t index, struct audio_map_mapping &map)
+    {
+        if (index >= number_of_mappings())
+            return -1;
+        
+        map = maps.at(index);
+        return 0;
+    }
+}

--- a/controller/lib/src/audio_map_descriptor_response_imp.cpp
+++ b/controller/lib/src/audio_map_descriptor_response_imp.cpp
@@ -32,7 +32,7 @@
 
 namespace avdecc_lib
 {
-    audio_map_descriptor_response_imp::audio_map_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos) : descriptor_base_imp(nullptr, frame, frame_len, pos)
+    audio_map_descriptor_response_imp::audio_map_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos)
     {
         frame_size = frame_len;
         buffer = (uint8_t *)malloc(frame_size * sizeof(uint8_t));
@@ -53,7 +53,10 @@ namespace avdecc_lib
         }
     }
     
-    audio_map_descriptor_response_imp::~audio_map_descriptor_response_imp() {}
+    audio_map_descriptor_response_imp::~audio_map_descriptor_response_imp()
+    {
+        free(buffer);
+    }
     
     uint16_t audio_map_descriptor_response_imp::mappings_offset()
     {
@@ -65,7 +68,7 @@ namespace avdecc_lib
         return jdksavdecc_descriptor_audio_map_get_number_of_mappings(buffer, position);
     }
     
-    int STDCALL audio_map_descriptor_response_imp::mapping(size_t index, struct audio_map_mapping &map)
+    int const STDCALL audio_map_descriptor_response_imp::mapping(size_t index, struct audio_map_mapping &map)
     {
         if (index >= number_of_mappings())
             return -1;

--- a/controller/lib/src/audio_map_descriptor_response_imp.h
+++ b/controller/lib/src/audio_map_descriptor_response_imp.h
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * audio_map_descriptor_response_imp.h
+ *
+ * Audio Map descriptor response implementation class
+ */
+
+#pragma once
+
+#include "descriptor_base_imp.h"
+#include "audio_map_descriptor_response.h"
+
+namespace avdecc_lib
+{
+    class audio_map_descriptor_response_imp : public audio_map_descriptor_response, public virtual descriptor_base_imp
+    {
+    private:
+        uint8_t * buffer;
+        ssize_t position;
+        size_t frame_size;
+        std::vector<struct audio_map_mapping> maps; // Store maps in a vector
+    public:
+        audio_map_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos);
+        virtual ~audio_map_descriptor_response_imp();
+        
+        uint16_t mappings_offset();
+        uint16_t STDCALL number_of_mappings();
+        int STDCALL mapping(size_t index, struct audio_map_mapping &map);
+    };
+}

--- a/controller/lib/src/audio_map_descriptor_response_imp.h
+++ b/controller/lib/src/audio_map_descriptor_response_imp.h
@@ -29,12 +29,12 @@
 
 #pragma once
 
-#include "descriptor_base_imp.h"
 #include "audio_map_descriptor_response.h"
+#include "jdksavdecc_aem_descriptor.h"
 
 namespace avdecc_lib
 {
-    class audio_map_descriptor_response_imp : public audio_map_descriptor_response, public virtual descriptor_base_imp
+    class audio_map_descriptor_response_imp : public audio_map_descriptor_response
     {
     private:
         uint8_t * buffer;
@@ -47,6 +47,6 @@ namespace avdecc_lib
         
         uint16_t mappings_offset();
         uint16_t STDCALL number_of_mappings();
-        int STDCALL mapping(size_t index, struct audio_map_mapping &map);
+        int const STDCALL mapping(size_t index, struct audio_map_mapping &map);
     };
 }

--- a/controller/lib/src/audio_unit_descriptor_imp.cpp
+++ b/controller/lib/src/audio_unit_descriptor_imp.cpp
@@ -39,257 +39,40 @@
 
 namespace avdecc_lib
 {
-    audio_unit_descriptor_imp::audio_unit_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj)
+    audio_unit_descriptor_imp::audio_unit_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos)
     {
-        ssize_t ret = jdksavdecc_descriptor_audio_read(&audio_unit_desc, frame, pos, frame_len);
-
-        if(ret < 0)
-        {
-            throw avdecc_read_descriptor_error("audio_unit_desc_read error");
-        }
-
-        sampling_rates_init(frame);
-
         memset(&aem_cmd_set_sampling_rate_resp, 0, sizeof(struct jdksavdecc_aem_command_set_sampling_rate_response));
-        memset(&aem_cmd_get_sampling_rate_resp, 0, sizeof(struct jdksavdecc_aem_command_get_sampling_rate_response));
+        
+        m_type = jdksavdecc_descriptor_audio_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
+        m_index = jdksavdecc_descriptor_audio_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 
     audio_unit_descriptor_imp::~audio_unit_descriptor_imp() {}
+    
+    audio_unit_descriptor_response * STDCALL audio_unit_descriptor_imp::get_audio_unit_response()
+    {
+        std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
+        return resp = new audio_unit_descriptor_response_imp(resp_ref->get_buffer(),
+                                                             resp_ref->get_size(), resp_ref->get_pos());
+    }
+    
+    audio_unit_get_sampling_rate_response * STDCALL audio_unit_descriptor_imp::get_audio_unit_get_sampling_rate_response()
+    {
+        std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
+        return sampling_rate_resp = new audio_unit_get_sampling_rate_response_imp(resp_ref->get_buffer(),
+                                                             resp_ref->get_size(), resp_ref->get_pos());
+    }
 
     uint16_t STDCALL audio_unit_descriptor_imp::descriptor_type() const
     {
-        assert(audio_unit_desc.descriptor_type == JDKSAVDECC_DESCRIPTOR_AUDIO_UNIT);
-        return audio_unit_desc.descriptor_type;
-    }
-
-    void audio_unit_descriptor_imp::sampling_rates_init(const uint8_t *frame)
-    {
-        uint16_t offset = 0;
-        uint32_t sampling_rate = 0;
-
-        for(uint32_t i = 0; i < sampling_rates_count(); i++)
-        {
-            sampling_rate = jdksavdecc_uint32_get(frame, ETHER_HDR_SIZE + JDKSAVDECC_AEM_COMMAND_READ_DESCRIPTOR_RESPONSE_LEN + sampling_rates_offset() + offset);
-            sample_rates_vec.push_back(sampling_rate);
-            offset += 0x4;
-        }
+        assert(m_type == JDKSAVDECC_DESCRIPTOR_AUDIO_UNIT);
+        return m_type;
     }
 
     uint16_t STDCALL audio_unit_descriptor_imp::descriptor_index() const
     {
-        return audio_unit_desc.descriptor_index;
+        return m_index;
     }
-
-    uint8_t * STDCALL audio_unit_descriptor_imp::object_name()
-    {
-        return audio_unit_desc.object_name.value;
-    }
-
-    uint16_t STDCALL audio_unit_descriptor_imp::localized_description()
-    {
-        return audio_unit_desc.localized_description;
-    }
-
-    uint16_t STDCALL audio_unit_descriptor_imp::clock_domain_index()
-    {
-        return audio_unit_desc.clock_domain_index;
-    }
-
-    uint16_t STDCALL audio_unit_descriptor_imp::number_of_stream_input_ports()
-    {
-        return audio_unit_desc.number_of_stream_input_ports;
-    }
-
-    uint16_t STDCALL audio_unit_descriptor_imp::base_stream_input_port()
-    {
-        return audio_unit_desc.base_stream_input_port;
-    }
-
-    uint16_t STDCALL audio_unit_descriptor_imp::number_of_stream_output_ports()
-    {
-        return audio_unit_desc.number_of_stream_output_ports;
-    }
-
-    uint16_t STDCALL audio_unit_descriptor_imp::base_stream_output_port()
-    {
-        return audio_unit_desc.base_stream_output_port;
-    }
-
-    uint16_t STDCALL audio_unit_descriptor_imp::number_of_external_input_ports()
-    {
-        return audio_unit_desc.number_of_external_input_ports;
-    }
-
-    uint16_t STDCALL audio_unit_descriptor_imp::base_external_input_port()
-    {
-        return audio_unit_desc.base_external_input_port;
-    }
-
-    uint16_t STDCALL audio_unit_descriptor_imp::number_of_external_output_ports()
-    {
-        return audio_unit_desc.number_of_external_output_ports;
-    }
-
-    uint16_t STDCALL audio_unit_descriptor_imp::base_external_output_port()
-    {
-        return audio_unit_desc.base_external_output_port;
-    }
-
-    uint16_t STDCALL audio_unit_descriptor_imp::number_of_internal_input_ports()
-    {
-        return audio_unit_desc.number_of_internal_input_ports;
-    }
-
-    uint16_t STDCALL audio_unit_descriptor_imp::base_internal_input_port()
-    {
-        return audio_unit_desc.base_internal_input_port;
-    }
-
-    uint16_t STDCALL audio_unit_descriptor_imp::number_of_internal_output_ports()
-    {
-        return audio_unit_desc.number_of_internal_output_ports;
-    }
-
-    uint16_t STDCALL audio_unit_descriptor_imp::base_internal_output_port()
-    {
-        return audio_unit_desc.base_internal_output_port;
-    }
-
-    uint16_t STDCALL audio_unit_descriptor_imp::number_of_controls()
-    {
-        return audio_unit_desc.number_of_controls;
-    }
-
-    uint16_t STDCALL audio_unit_descriptor_imp::base_control()
-    {
-        return audio_unit_desc.base_control;
-    }
-
-    uint16_t STDCALL audio_unit_descriptor_imp::number_of_signal_selectors()
-    {
-        return audio_unit_desc.number_of_signal_selectors;
-    }
-
-    uint16_t STDCALL audio_unit_descriptor_imp::base_signal_selector()
-    {
-        return audio_unit_desc.base_signal_selector;
-    }
-
-    uint16_t STDCALL audio_unit_descriptor_imp::number_of_mixers()
-    {
-        return audio_unit_desc.number_of_mixers;
-    }
-
-    uint16_t STDCALL audio_unit_descriptor_imp::base_mixer()
-    {
-        return audio_unit_desc.base_mixer;
-    }
-
-    uint16_t STDCALL audio_unit_descriptor_imp::number_of_matrices()
-    {
-        return audio_unit_desc.number_of_matrices;
-    }
-
-    uint16_t STDCALL audio_unit_descriptor_imp::base_matrix()
-    {
-        return audio_unit_desc.base_matrix;
-    }
-
-    uint16_t STDCALL audio_unit_descriptor_imp::number_of_splitters()
-    {
-        return audio_unit_desc.number_of_splitters;
-    }
-
-    uint16_t STDCALL audio_unit_descriptor_imp::base_splitter()
-    {
-        return audio_unit_desc.base_splitter;
-    }
-
-    uint16_t STDCALL audio_unit_descriptor_imp::number_of_combiners()
-    {
-        return audio_unit_desc.number_of_combiners;
-    }
-
-    uint16_t STDCALL audio_unit_descriptor_imp::base_combiner()
-    {
-        return audio_unit_desc.base_combiner;
-    }
-
-    uint16_t STDCALL audio_unit_descriptor_imp::number_of_demultiplexers()
-    {
-        return audio_unit_desc.number_of_demultiplexers;
-    }
-
-    uint16_t STDCALL audio_unit_descriptor_imp::base_demultiplexer()
-    {
-        return audio_unit_desc.base_demultiplexer;
-    }
-
-    uint16_t STDCALL audio_unit_descriptor_imp::number_of_multiplexers()
-    {
-        return audio_unit_desc.number_of_multiplexers;
-    }
-
-    uint16_t STDCALL audio_unit_descriptor_imp::base_multiplexer()
-    {
-        return audio_unit_desc.base_multiplexer;
-    }
-
-    uint16_t STDCALL audio_unit_descriptor_imp::number_of_transcoders()
-    {
-        return audio_unit_desc.number_of_transcoders;
-    }
-
-    uint16_t STDCALL audio_unit_descriptor_imp::base_transcoder()
-    {
-        return audio_unit_desc.base_transcoder;
-    }
-
-    uint16_t STDCALL audio_unit_descriptor_imp::number_of_control_blocks()
-    {
-        return audio_unit_desc.number_of_control_blocks;
-    }
-
-    uint16_t STDCALL audio_unit_descriptor_imp::base_control_block()
-    {
-        return audio_unit_desc.base_control_block;
-    }
-
-    uint32_t STDCALL audio_unit_descriptor_imp::current_sampling_rate()
-    {
-        return audio_unit_desc.current_sampling_rate;
-    }
-
-    uint32_t STDCALL audio_unit_descriptor_imp::get_sampling_rate_by_index(size_t sampling_rate_index)
-    {
-        return sample_rates_vec.at(sampling_rate_index);
-    }
-
-    uint16_t audio_unit_descriptor_imp::sampling_rates_offset()
-    {
-        return audio_unit_desc.sampling_rates_offset;
-    }
-
-    uint16_t STDCALL audio_unit_descriptor_imp::sampling_rates_count()
-    {
-        return audio_unit_desc.sampling_rates_count;
-    }
-
-    uint32_t STDCALL audio_unit_descriptor_imp::set_sampling_rate_sampling_rate()
-    {
-        return aem_cmd_set_sampling_rate_resp.sampling_rate;
-    }
-
-    void audio_unit_descriptor_imp::update_sampling_rate(uint32_t sampling_rate)
-    {
-        audio_unit_desc.current_sampling_rate = sampling_rate;
-    }
-
-    uint32_t STDCALL audio_unit_descriptor_imp::get_sampling_rate_sampling_rate()
-    {
-        return aem_cmd_get_sampling_rate_resp.sampling_rate;
-    }
-
 
     int STDCALL audio_unit_descriptor_imp::send_set_sampling_rate_cmd(void *notification_id, uint32_t new_sampling_rate)
     {
@@ -362,11 +145,6 @@ namespace avdecc_lib
 
         aecp_controller_state_machine_ref->update_inflight_for_rcvd_resp(notification_id, msg_type, u_field, &cmd_frame);
 
-        if(status == AEM_STATUS_SUCCESS)
-        {
-            update_sampling_rate(aem_cmd_set_sampling_rate_resp.sampling_rate);
-        }
-
         return 0;
     }
 
@@ -411,10 +189,10 @@ namespace avdecc_lib
         return 0;
     }
 
-
     int audio_unit_descriptor_imp::proc_get_sampling_rate_resp(void *&notification_id, const uint8_t *frame, size_t frame_len, int &status)
     {
         struct jdksavdecc_frame cmd_frame;
+        struct jdksavdecc_aem_command_get_sampling_rate_response aem_cmd_get_sampling_rate_resp;
         ssize_t aem_cmd_get_sampling_rate_resp_returned;
         uint32_t msg_type;
         bool u_field;
@@ -432,6 +210,8 @@ namespace avdecc_lib
             assert(aem_cmd_get_sampling_rate_resp_returned >= 0);
             return -1;
         }
+        
+        replace_frame(frame, ETHER_HDR_SIZE, frame_len);
 
         msg_type = aem_cmd_get_sampling_rate_resp.aem_header.aecpdu_header.header.message_type;
         status = aem_cmd_get_sampling_rate_resp.aem_header.aecpdu_header.header.status;

--- a/controller/lib/src/audio_unit_descriptor_imp.cpp
+++ b/controller/lib/src/audio_unit_descriptor_imp.cpp
@@ -27,7 +27,9 @@
  * AUDIO UNIT descriptor implementation
  */
 
+#include <mutex>
 #include <vector>
+
 #include "avdecc_error.h"
 #include "enumeration.h"
 #include "log_imp.h"

--- a/controller/lib/src/audio_unit_descriptor_imp.cpp
+++ b/controller/lib/src/audio_unit_descriptor_imp.cpp
@@ -42,20 +42,17 @@ namespace avdecc_lib
     audio_unit_descriptor_imp::audio_unit_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos)
     {
         memset(&aem_cmd_set_sampling_rate_resp, 0, sizeof(struct jdksavdecc_aem_command_set_sampling_rate_response));
-        
-        m_type = jdksavdecc_descriptor_audio_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
-        m_index = jdksavdecc_descriptor_audio_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 
     audio_unit_descriptor_imp::~audio_unit_descriptor_imp() {}
-    
+
     audio_unit_descriptor_response * STDCALL audio_unit_descriptor_imp::get_audio_unit_response()
     {
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
         return resp = new audio_unit_descriptor_response_imp(resp_ref->get_buffer(),
                                                              resp_ref->get_size(), resp_ref->get_pos());
     }
-    
+
     audio_unit_get_sampling_rate_response * STDCALL audio_unit_descriptor_imp::get_audio_unit_get_sampling_rate_response()
     {
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
@@ -65,13 +62,13 @@ namespace avdecc_lib
 
     uint16_t STDCALL audio_unit_descriptor_imp::descriptor_type() const
     {
-        assert(m_type == JDKSAVDECC_DESCRIPTOR_AUDIO_UNIT);
-        return m_type;
+        assert(jdksavdecc_descriptor_audio_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos()) == JDKSAVDECC_DESCRIPTOR_AUDIO_UNIT);
+        return jdksavdecc_descriptor_audio_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 
     uint16_t STDCALL audio_unit_descriptor_imp::descriptor_index() const
     {
-        return m_index;
+        return jdksavdecc_descriptor_audio_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 
     int STDCALL audio_unit_descriptor_imp::send_set_sampling_rate_cmd(void *notification_id, uint32_t new_sampling_rate)

--- a/controller/lib/src/audio_unit_descriptor_imp.h
+++ b/controller/lib/src/audio_unit_descriptor_imp.h
@@ -40,9 +40,6 @@ namespace avdecc_lib
     {
     private:
         struct jdksavdecc_aem_command_set_sampling_rate_response aem_cmd_set_sampling_rate_resp; // Store the response received after sending a SET_SAMPLING_RATE command.
-        uint16_t m_type;
-        uint16_t m_index;
-
     public:
         audio_unit_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
         virtual ~audio_unit_descriptor_imp();

--- a/controller/lib/src/audio_unit_descriptor_imp.h
+++ b/controller/lib/src/audio_unit_descriptor_imp.h
@@ -46,9 +46,7 @@ namespace avdecc_lib
         
         audio_unit_descriptor_response_imp *resp;
         audio_unit_get_sampling_rate_response_imp *sampling_rate_resp;
-        
-        uint16_t STDCALL descriptor_type() const;
-        uint16_t STDCALL descriptor_index() const;
+
         audio_unit_descriptor_response * STDCALL get_audio_unit_response();
         audio_unit_get_sampling_rate_response * STDCALL get_audio_unit_get_sampling_rate_response();
         int STDCALL send_set_sampling_rate_cmd(void *notification_id, uint32_t new_sampling_rate);

--- a/controller/lib/src/audio_unit_descriptor_imp.h
+++ b/controller/lib/src/audio_unit_descriptor_imp.h
@@ -31,80 +31,33 @@
 
 #include "descriptor_base_imp.h"
 #include "audio_unit_descriptor.h"
+#include "audio_unit_descriptor_response_imp.h"
+#include "audio_unit_get_sampling_rate_response_imp.h"
 
 namespace avdecc_lib
 {
     class audio_unit_descriptor_imp : public audio_unit_descriptor, public virtual descriptor_base_imp
     {
     private:
-        struct jdksavdecc_descriptor_audio audio_unit_desc; // Structure containing the audio_unit_desc fields
-
-        std::vector<uint32_t> sample_rates_vec; // Store sample rates information
         struct jdksavdecc_aem_command_set_sampling_rate_response aem_cmd_set_sampling_rate_resp; // Store the response received after sending a SET_SAMPLING_RATE command.
-        struct jdksavdecc_aem_command_get_sampling_rate_response aem_cmd_get_sampling_rate_resp; // Store the response received after sending a GET_SAMPLING_RATE command.
+        uint16_t m_type;
+        uint16_t m_index;
 
     public:
         audio_unit_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
         virtual ~audio_unit_descriptor_imp();
-
+        
+        audio_unit_descriptor_response_imp *resp;
+        audio_unit_get_sampling_rate_response_imp *sampling_rate_resp;
+        
         uint16_t STDCALL descriptor_type() const;
         uint16_t STDCALL descriptor_index() const;
-        uint8_t * STDCALL object_name();
-        uint16_t STDCALL localized_description();
-        uint16_t STDCALL clock_domain_index();
-        uint16_t STDCALL number_of_stream_input_ports();
-        uint16_t STDCALL base_stream_input_port();
-        uint16_t STDCALL number_of_stream_output_ports();
-        uint16_t STDCALL base_stream_output_port();
-        uint16_t STDCALL number_of_external_input_ports();
-        uint16_t STDCALL base_external_input_port();
-        uint16_t STDCALL number_of_external_output_ports();
-        uint16_t STDCALL base_external_output_port();
-        uint16_t STDCALL number_of_internal_input_ports();
-        uint16_t STDCALL base_internal_input_port();
-        uint16_t STDCALL number_of_internal_output_ports();
-        uint16_t STDCALL base_internal_output_port();
-        uint16_t STDCALL number_of_controls();
-        uint16_t STDCALL base_control();
-        uint16_t STDCALL number_of_signal_selectors();
-        uint16_t STDCALL base_signal_selector();
-        uint16_t STDCALL number_of_mixers();
-        uint16_t STDCALL base_mixer();
-        uint16_t STDCALL number_of_matrices();
-        uint16_t STDCALL base_matrix();
-        uint16_t STDCALL number_of_splitters();
-        uint16_t STDCALL base_splitter();
-        uint16_t STDCALL number_of_combiners();
-        uint16_t STDCALL base_combiner();
-        uint16_t STDCALL number_of_demultiplexers();
-        uint16_t STDCALL base_demultiplexer();
-        uint16_t STDCALL number_of_multiplexers();
-        uint16_t STDCALL base_multiplexer();
-        uint16_t STDCALL number_of_transcoders();
-        uint16_t STDCALL base_transcoder();
-        uint16_t STDCALL number_of_control_blocks();
-        uint16_t STDCALL base_control_block();
-        uint32_t STDCALL current_sampling_rate();
-        uint32_t STDCALL get_sampling_rate_by_index(size_t sampling_rate_index);
-        uint16_t sampling_rates_offset();
-        uint16_t STDCALL sampling_rates_count();
-        uint32_t STDCALL set_sampling_rate_sampling_rate();
-        uint32_t STDCALL get_sampling_rate_sampling_rate();
+        audio_unit_descriptor_response * STDCALL get_audio_unit_response();
+        audio_unit_get_sampling_rate_response * STDCALL get_audio_unit_get_sampling_rate_response();
         int STDCALL send_set_sampling_rate_cmd(void *notification_id, uint32_t new_sampling_rate);
         int proc_set_sampling_rate_resp(void *&notification_id, const uint8_t *frame, size_t frame_len, int &status);
+
         int STDCALL send_get_sampling_rate_cmd(void *notification_id);
         int proc_get_sampling_rate_resp(void *&notification_id, const uint8_t *frame, size_t frame_len, int &status);
-
-    private:
-        /**
-         * Store the sampling rates of the AUDIO UNIT in a vector.
-         */
-        void sampling_rates_init(const uint8_t *frame);
-
-        /**
-         * Update the internal AUDIO UNIT's sampling rate field.
-         */
-        void update_sampling_rate(uint32_t sampling_rate);
     };
 }
-

--- a/controller/lib/src/audio_unit_descriptor_response_imp.cpp
+++ b/controller/lib/src/audio_unit_descriptor_response_imp.cpp
@@ -33,7 +33,7 @@
 
 namespace avdecc_lib
 {
-    audio_unit_descriptor_response_imp::audio_unit_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos) : descriptor_base_imp(nullptr, frame, frame_len, pos)
+    audio_unit_descriptor_response_imp::audio_unit_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos)
     {
         frame_size = frame_len;
         buffer = (uint8_t *)malloc(frame_size * sizeof(uint8_t));
@@ -43,16 +43,19 @@ namespace avdecc_lib
         sampling_rates_init(frame);
     }
     
-    audio_unit_descriptor_response_imp::~audio_unit_descriptor_response_imp() {}
+    audio_unit_descriptor_response_imp::~audio_unit_descriptor_response_imp()
+    {
+        free(buffer);
+    }
     
     void audio_unit_descriptor_response_imp::sampling_rates_init(const uint8_t *frame)
     {
-        uint16_t offset = 0;
+        uint16_t offset = ETHER_HDR_SIZE + JDKSAVDECC_AEM_COMMAND_READ_DESCRIPTOR_RESPONSE_LEN + sampling_rates_offset();
         uint32_t sampling_rate = 0;
         
         for(uint32_t i = 0; i < sampling_rates_count(); i++)
         {
-            sampling_rate = jdksavdecc_uint32_get(frame, ETHER_HDR_SIZE + JDKSAVDECC_AEM_COMMAND_READ_DESCRIPTOR_RESPONSE_LEN + sampling_rates_offset() + offset);
+            sampling_rate = jdksavdecc_uint32_get(frame, offset);
             sample_rates_vec.push_back(sampling_rate);
             offset += 0x4;
         }

--- a/controller/lib/src/audio_unit_descriptor_response_imp.cpp
+++ b/controller/lib/src/audio_unit_descriptor_response_imp.cpp
@@ -1,0 +1,255 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * audio_unit_descriptor_response_imp.cpp
+ *
+ * AUDIO UNIT descriptor response implementation
+ */
+
+#include <vector>
+#include "enumeration.h"
+#include "audio_unit_descriptor_response_imp.h"
+
+namespace avdecc_lib
+{
+    audio_unit_descriptor_response_imp::audio_unit_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos) : descriptor_base_imp(nullptr, frame, frame_len, pos)
+    {
+        frame_size = frame_len;
+        buffer = (uint8_t *)malloc(frame_size * sizeof(uint8_t));
+        memcpy(buffer, frame, frame_size);
+        position = pos;
+        
+        sampling_rates_init(frame);
+    }
+    
+    audio_unit_descriptor_response_imp::~audio_unit_descriptor_response_imp() {}
+    
+    void audio_unit_descriptor_response_imp::sampling_rates_init(const uint8_t *frame)
+    {
+        uint16_t offset = 0;
+        uint32_t sampling_rate = 0;
+        
+        for(uint32_t i = 0; i < sampling_rates_count(); i++)
+        {
+            sampling_rate = jdksavdecc_uint32_get(frame, ETHER_HDR_SIZE + JDKSAVDECC_AEM_COMMAND_READ_DESCRIPTOR_RESPONSE_LEN + sampling_rates_offset() + offset);
+            sample_rates_vec.push_back(sampling_rate);
+            offset += 0x4;
+        }
+    }
+    
+    uint8_t * STDCALL audio_unit_descriptor_response_imp::object_name()
+    {
+        return (uint8_t *)&buffer[position + JDKSAVDECC_DESCRIPTOR_AUDIO_OFFSET_OBJECT_NAME];
+    }
+    
+    uint16_t STDCALL audio_unit_descriptor_response_imp::localized_description()
+    {
+        return jdksavdecc_descriptor_audio_get_localized_description(buffer, position);
+    }
+    
+    uint16_t STDCALL audio_unit_descriptor_response_imp::clock_domain_index()
+    {
+        return jdksavdecc_descriptor_audio_get_clock_domain_index(buffer, position);
+    }
+    
+    uint16_t STDCALL audio_unit_descriptor_response_imp::number_of_stream_input_ports()
+    {
+        return jdksavdecc_descriptor_audio_get_number_of_stream_input_ports(buffer, position);
+    }
+    
+    uint16_t STDCALL audio_unit_descriptor_response_imp::base_stream_input_port()
+    {
+        return jdksavdecc_descriptor_audio_get_base_stream_input_port(buffer, position);
+    }
+    
+    uint16_t STDCALL audio_unit_descriptor_response_imp::number_of_stream_output_ports()
+    {
+        return jdksavdecc_descriptor_audio_get_number_of_stream_output_ports(buffer, position);
+    }
+    
+    uint16_t STDCALL audio_unit_descriptor_response_imp::base_stream_output_port()
+    {
+        return jdksavdecc_descriptor_audio_get_base_stream_output_port(buffer, position);
+    }
+    
+    uint16_t STDCALL audio_unit_descriptor_response_imp::number_of_external_input_ports()
+    {
+        return jdksavdecc_descriptor_audio_get_number_of_external_input_ports(buffer, position);
+    }
+    
+    uint16_t STDCALL audio_unit_descriptor_response_imp::base_external_input_port()
+    {
+        return jdksavdecc_descriptor_audio_get_base_external_input_port(buffer, position);
+    }
+    
+    uint16_t STDCALL audio_unit_descriptor_response_imp::number_of_external_output_ports()
+    {
+        return jdksavdecc_descriptor_audio_get_number_of_external_output_ports(buffer, position);
+    }
+    
+    uint16_t STDCALL audio_unit_descriptor_response_imp::base_external_output_port()
+    {
+        return jdksavdecc_descriptor_audio_get_base_external_output_port(buffer, position);    }
+    
+    uint16_t STDCALL audio_unit_descriptor_response_imp::number_of_internal_input_ports()
+    {
+        return jdksavdecc_descriptor_audio_get_number_of_internal_input_ports(buffer, position);
+    }
+    
+    uint16_t STDCALL audio_unit_descriptor_response_imp::base_internal_input_port()
+    {
+        return jdksavdecc_descriptor_audio_get_base_internal_input_port(buffer, position);
+    }
+    
+    uint16_t STDCALL audio_unit_descriptor_response_imp::number_of_internal_output_ports()
+    {
+        return jdksavdecc_descriptor_audio_get_number_of_internal_output_ports(buffer, position);
+    }
+    
+    uint16_t STDCALL audio_unit_descriptor_response_imp::base_internal_output_port()
+    {
+        return jdksavdecc_descriptor_audio_get_base_internal_output_port(buffer, position);
+    }
+    
+    uint16_t STDCALL audio_unit_descriptor_response_imp::number_of_controls()
+    {
+        return jdksavdecc_descriptor_audio_get_number_of_controls(buffer, position);
+    }
+    
+    uint16_t STDCALL audio_unit_descriptor_response_imp::base_control()
+    {
+        return jdksavdecc_descriptor_audio_get_base_control(buffer, position);
+    }
+    
+    uint16_t STDCALL audio_unit_descriptor_response_imp::number_of_signal_selectors()
+    {
+        return jdksavdecc_descriptor_audio_get_number_of_signal_selectors(buffer, position);
+    }
+    
+    uint16_t STDCALL audio_unit_descriptor_response_imp::base_signal_selector()
+    {
+        return jdksavdecc_descriptor_audio_get_base_signal_selector(buffer, position);
+    }
+    
+    uint16_t STDCALL audio_unit_descriptor_response_imp::number_of_mixers()
+    {
+        return jdksavdecc_descriptor_audio_get_number_of_mixers(buffer, position);
+    }
+    
+    uint16_t STDCALL audio_unit_descriptor_response_imp::base_mixer()
+    {
+        return jdksavdecc_descriptor_audio_get_base_mixer(buffer, position);
+    }
+    
+    uint16_t STDCALL audio_unit_descriptor_response_imp::number_of_matrices()
+    {
+        return jdksavdecc_descriptor_audio_get_number_of_matrices(buffer, position);
+    }
+    
+    uint16_t STDCALL audio_unit_descriptor_response_imp::base_matrix()
+    {
+        return jdksavdecc_descriptor_audio_get_base_matrix(buffer, position);
+    }
+    
+    uint16_t STDCALL audio_unit_descriptor_response_imp::number_of_splitters()
+    {
+        return jdksavdecc_descriptor_audio_get_number_of_splitters(buffer, position);
+    }
+    
+    uint16_t STDCALL audio_unit_descriptor_response_imp::base_splitter()
+    {
+        return jdksavdecc_descriptor_audio_get_base_splitter(buffer, position);
+    }
+    
+    uint16_t STDCALL audio_unit_descriptor_response_imp::number_of_combiners()
+    {
+        return jdksavdecc_descriptor_audio_get_number_of_combiners(buffer, position);
+    }
+    
+    uint16_t STDCALL audio_unit_descriptor_response_imp::base_combiner()
+    {
+        return jdksavdecc_descriptor_audio_get_base_combiner(buffer, position);
+    }
+    
+    uint16_t STDCALL audio_unit_descriptor_response_imp::number_of_demultiplexers()
+    {
+        return jdksavdecc_descriptor_audio_get_number_of_demultiplexers(buffer, position);
+    }
+    
+    uint16_t STDCALL audio_unit_descriptor_response_imp::base_demultiplexer()
+    {
+        return jdksavdecc_descriptor_audio_get_base_demultiplexer(buffer, position);
+    }
+    
+    uint16_t STDCALL audio_unit_descriptor_response_imp::number_of_multiplexers()
+    {
+        return jdksavdecc_descriptor_audio_get_number_of_multiplexers(buffer, position);
+    }
+    
+    uint16_t STDCALL audio_unit_descriptor_response_imp::base_multiplexer()
+    {
+        return jdksavdecc_descriptor_audio_get_base_multiplexer(buffer, position);
+    }
+    
+    uint16_t STDCALL audio_unit_descriptor_response_imp::number_of_transcoders()
+    {
+        return jdksavdecc_descriptor_audio_get_number_of_transcoders(buffer, position);
+    }
+    
+    uint16_t STDCALL audio_unit_descriptor_response_imp::base_transcoder()
+    {
+        return jdksavdecc_descriptor_audio_get_base_transcoder(buffer, position);
+
+    }
+    
+    uint16_t STDCALL audio_unit_descriptor_response_imp::number_of_control_blocks()
+    {
+        return jdksavdecc_descriptor_audio_get_number_of_control_blocks(buffer, position);
+    }
+    
+    uint16_t STDCALL audio_unit_descriptor_response_imp::base_control_block()
+    {
+        return jdksavdecc_descriptor_audio_get_base_control_block(buffer, position);
+    }
+    
+    uint32_t STDCALL audio_unit_descriptor_response_imp::current_sampling_rate()
+    {
+        return jdksavdecc_descriptor_audio_get_current_sampling_rate(buffer, position);
+    }
+    
+    uint32_t STDCALL audio_unit_descriptor_response_imp::get_sampling_rate_by_index(size_t sampling_rate_index)
+    {
+        return sample_rates_vec.at(sampling_rate_index);
+    }
+    
+    uint16_t audio_unit_descriptor_response_imp::sampling_rates_offset()
+    {
+        return jdksavdecc_descriptor_audio_get_sampling_rates_offset(buffer, position);
+    }
+    
+    uint16_t STDCALL audio_unit_descriptor_response_imp::sampling_rates_count()
+    {
+        return jdksavdecc_descriptor_audio_get_sampling_rates_count(buffer, position);
+    }
+}

--- a/controller/lib/src/audio_unit_descriptor_response_imp.h
+++ b/controller/lib/src/audio_unit_descriptor_response_imp.h
@@ -29,12 +29,13 @@
 
 #pragma once
 
-#include "descriptor_base_imp.h"
 #include "audio_unit_descriptor_response.h"
+#include "jdksavdecc_aem_descriptor.h"
+#include "jdksavdecc_aem_command.h"
 
 namespace avdecc_lib
 {
-    class audio_unit_descriptor_response_imp : public audio_unit_descriptor_response, public virtual descriptor_base_imp
+    class audio_unit_descriptor_response_imp : public audio_unit_descriptor_response
     {
     private:
         uint8_t * buffer;

--- a/controller/lib/src/audio_unit_descriptor_response_imp.h
+++ b/controller/lib/src/audio_unit_descriptor_response_imp.h
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * audio_unit_descriptor_response_imp.h
+ *
+ * AUDIO UNIT response implementation class
+ */
+
+#pragma once
+
+#include "descriptor_base_imp.h"
+#include "audio_unit_descriptor_response.h"
+
+namespace avdecc_lib
+{
+    class audio_unit_descriptor_response_imp : public audio_unit_descriptor_response, public virtual descriptor_base_imp
+    {
+    private:
+        uint8_t * buffer;
+        ssize_t position;
+        size_t frame_size;
+        std::vector<uint32_t> sample_rates_vec; // Store sample rates information
+    public:
+        audio_unit_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos);
+        virtual ~audio_unit_descriptor_response_imp();
+        
+        uint8_t * STDCALL object_name();
+        uint16_t STDCALL localized_description();
+        uint16_t STDCALL clock_domain_index();
+        uint16_t STDCALL number_of_stream_input_ports();
+        uint16_t STDCALL base_stream_input_port();
+        uint16_t STDCALL number_of_stream_output_ports();
+        uint16_t STDCALL base_stream_output_port();
+        uint16_t STDCALL number_of_external_input_ports();
+        uint16_t STDCALL base_external_input_port();
+        uint16_t STDCALL number_of_external_output_ports();
+        uint16_t STDCALL base_external_output_port();
+        uint16_t STDCALL number_of_internal_input_ports();
+        uint16_t STDCALL base_internal_input_port();
+        uint16_t STDCALL number_of_internal_output_ports();
+        uint16_t STDCALL base_internal_output_port();
+        uint16_t STDCALL number_of_controls();
+        uint16_t STDCALL base_control();
+        uint16_t STDCALL number_of_signal_selectors();
+        uint16_t STDCALL base_signal_selector();
+        uint16_t STDCALL number_of_mixers();
+        uint16_t STDCALL base_mixer();
+        uint16_t STDCALL number_of_matrices();
+        uint16_t STDCALL base_matrix();
+        uint16_t STDCALL number_of_splitters();
+        uint16_t STDCALL base_splitter();
+        uint16_t STDCALL number_of_combiners();
+        uint16_t STDCALL base_combiner();
+        uint16_t STDCALL number_of_demultiplexers();
+        uint16_t STDCALL base_demultiplexer();
+        uint16_t STDCALL number_of_multiplexers();
+        uint16_t STDCALL base_multiplexer();
+        uint16_t STDCALL number_of_transcoders();
+        uint16_t STDCALL base_transcoder();
+        uint16_t STDCALL number_of_control_blocks();
+        uint16_t STDCALL base_control_block();
+        uint32_t STDCALL current_sampling_rate();
+        uint32_t STDCALL get_sampling_rate_by_index(size_t sampling_rate_index);
+        uint16_t sampling_rates_offset();
+        uint16_t STDCALL sampling_rates_count();
+    private:
+        /**
+         * Store the sampling rates of the AUDIO UNIT in a vector.
+         */
+        void sampling_rates_init(const uint8_t *frame);
+    };
+}

--- a/controller/lib/src/audio_unit_get_sampling_rate_response_imp.cpp
+++ b/controller/lib/src/audio_unit_get_sampling_rate_response_imp.cpp
@@ -24,7 +24,7 @@
 /**
  * audio_unit_get_sampling_rate_response_imp.cpp
  *
- * Audio Unit get clock source response implementation
+ * Audio Unit get sampling rate response implementation
  */
 
 #include "enumeration.h"
@@ -42,10 +42,16 @@ namespace avdecc_lib
         memcpy(m_frame, frame, m_size);
     }
     
-    audio_unit_get_sampling_rate_response_imp::~audio_unit_get_sampling_rate_response_imp(){}
+    audio_unit_get_sampling_rate_response_imp::~audio_unit_get_sampling_rate_response_imp()
+    {
+        free(m_frame);
+    }
     
     uint32_t STDCALL audio_unit_get_sampling_rate_response_imp::get_sampling_rate_sampling_rate()
     {
-        return jdksavdecc_aem_command_get_sampling_rate_response_get_sampling_rate(m_frame, m_position);
+        uint32_t sampling_rate;
+        sampling_rate = jdksavdecc_aem_command_get_sampling_rate_response_get_sampling_rate(m_frame, m_position);
+        
+        return sampling_rate;
     }
 }

--- a/controller/lib/src/audio_unit_get_sampling_rate_response_imp.cpp
+++ b/controller/lib/src/audio_unit_get_sampling_rate_response_imp.cpp
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * audio_unit_get_sampling_rate_response_imp.cpp
+ *
+ * Audio Unit get clock source response implementation
+ */
+
+#include "enumeration.h"
+#include "log_imp.h"
+#include "audio_unit_get_sampling_rate_response_imp.h"
+#include "util.h"
+
+namespace avdecc_lib
+{
+    audio_unit_get_sampling_rate_response_imp::audio_unit_get_sampling_rate_response_imp(uint8_t *frame, size_t frame_len, ssize_t pos)
+    {
+        m_position = pos;
+        m_size = frame_len;
+        m_frame = (uint8_t *)malloc(m_size * sizeof(uint8_t));
+        memcpy(m_frame, frame, m_size);
+    }
+    
+    audio_unit_get_sampling_rate_response_imp::~audio_unit_get_sampling_rate_response_imp(){}
+    
+    uint32_t STDCALL audio_unit_get_sampling_rate_response_imp::get_sampling_rate_sampling_rate()
+    {
+        return jdksavdecc_aem_command_get_sampling_rate_response_get_sampling_rate(m_frame, m_position);
+    }
+}

--- a/controller/lib/src/audio_unit_get_sampling_rate_response_imp.h
+++ b/controller/lib/src/audio_unit_get_sampling_rate_response_imp.h
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * audio_unit_get_sampling_rate_response_imp.h
+ *
+ * Audio Unit get sampling rate response implementation class
+ */
+
+#pragma once
+
+#include "audio_unit_get_sampling_rate_response.h"
+#include "jdksavdecc_aem_command.h"
+
+namespace avdecc_lib
+{
+    class audio_unit_get_sampling_rate_response_imp : public audio_unit_get_sampling_rate_response
+    {
+    private:
+        uint8_t * m_frame;
+        size_t m_size;
+        ssize_t m_position;
+        
+    public:
+        audio_unit_get_sampling_rate_response_imp(uint8_t *frame, size_t frame_len, ssize_t pos);
+        virtual ~audio_unit_get_sampling_rate_response_imp();
+        
+        uint32_t STDCALL get_sampling_rate_sampling_rate();
+    };
+}

--- a/controller/lib/src/avb_counters_response_imp.cpp
+++ b/controller/lib/src/avb_counters_response_imp.cpp
@@ -52,7 +52,10 @@ namespace avdecc_lib
         }
     }
     
-    avb_counters_response_imp::~avb_counters_response_imp(){}
+    avb_counters_response_imp::~avb_counters_response_imp()
+    {
+        free(m_frame);
+    }
 
     uint32_t STDCALL avb_counters_response_imp::get_counter_valid(int name)
     {

--- a/controller/lib/src/avb_counters_response_imp.cpp
+++ b/controller/lib/src/avb_counters_response_imp.cpp
@@ -1,0 +1,100 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * avb_counters_response_imp.cpp
+ *
+ * AVB INTERFACE counters response implementation
+ */
+
+#include "enumeration.h"
+#include "log_imp.h"
+#include "avb_counters_response_imp.h"
+
+namespace avdecc_lib
+{
+    avb_counters_response_imp::avb_counters_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos)
+    {
+        m_position = pos;
+        m_size = frame_len;
+        m_frame = (uint8_t *)malloc(m_size * sizeof(uint8_t));
+        memcpy(m_frame, frame, m_size);
+        
+        m_counters_valid = jdksavdecc_uint32_get(m_frame, ETHER_HDR_SIZE
+                                                 + JDKSAVDECC_AEM_COMMAND_GET_COUNTERS_RESPONSE_OFFSET_COUNTERS_VALID);
+        
+        for(int i = 0; i<31; i++){
+            int r = jdksavdecc_uint32_read(&m_counters_block[i], frame, ETHER_HDR_SIZE
+                                       + JDKSAVDECC_AEM_COMMAND_GET_COUNTERS_RESPONSE_OFFSET_COUNTERS_BLOCK + 4 * i,
+                                       frame_len);
+            if (r < 0)
+                break;
+        }
+    }
+    
+    avb_counters_response_imp::~avb_counters_response_imp(){}
+
+    uint32_t STDCALL avb_counters_response_imp::get_counter_valid(int name)
+    {
+        switch(name)
+        {
+            case AVB_INTERFACE_LINK_UP:
+                return m_counters_valid & 0x01;
+            case AVB_INTERFACE_LINK_DOWN:
+                return m_counters_valid >> 1 & 0x01;
+            case AVB_INTERFACE_FRAMES_TX:
+                return m_counters_valid >> 2 & 0x01;
+            case AVB_INTERFACE_FRAMES_RX:
+                return m_counters_valid >> 3 & 0x01;
+            case AVB_INTERFACE_RX_CRC_ERROR:
+                return m_counters_valid >> 4 & 0x01;
+            case AVB_GPTP_GM_CHANGED:
+                return m_counters_valid >> 5 & 0x01;
+            default:
+                log_imp_ref->post_log_msg(LOGGING_LEVEL_ERROR, "counter name not found\n");
+        }
+        return 0;
+    }
+
+    uint32_t STDCALL avb_counters_response_imp::get_counter_by_name(int name)
+    {
+        switch(name)
+        {
+            case AVB_INTERFACE_LINK_UP:
+                return m_counters_block[0];
+            case AVB_INTERFACE_LINK_DOWN:
+                return m_counters_block[1];
+            case AVB_INTERFACE_FRAMES_TX:
+                return m_counters_block[2];
+            case AVB_INTERFACE_FRAMES_RX:
+                return m_counters_block[3];
+            case AVB_INTERFACE_RX_CRC_ERROR:
+                return m_counters_block[4];
+            case AVB_GPTP_GM_CHANGED:
+                return m_counters_block[5];
+            default:
+                log_imp_ref->post_log_msg(LOGGING_LEVEL_ERROR, "counter name not found\n");
+        }
+        return 0;
+    }
+}

--- a/controller/lib/src/avb_counters_response_imp.h
+++ b/controller/lib/src/avb_counters_response_imp.h
@@ -47,7 +47,7 @@ namespace avdecc_lib
         avb_counters_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos);
         virtual ~avb_counters_response_imp();
  
-        uint32_t get_counter_valid(int name);
-        uint32_t get_counter_by_name(int name);
+        uint32_t STDCALL get_counter_valid(int name);
+        uint32_t STDCALL get_counter_by_name(int name);
     };
 }

--- a/controller/lib/src/avb_counters_response_imp.h
+++ b/controller/lib/src/avb_counters_response_imp.h
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * avb_counters_response_imp.h
+ *
+ * AVB counters response implementation class
+ */
+
+#pragma once
+
+#include "avb_counters_response.h"
+#include "jdksavdecc_aem_command.h"
+
+namespace avdecc_lib
+{
+    class avb_counters_response_imp : public avb_counters_response
+    {
+    private:
+        uint32_t m_counters_valid;
+        uint32_t m_counters_block [31];
+        uint8_t * m_frame;
+        size_t m_size;
+        ssize_t m_position;
+        
+    public:
+        avb_counters_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos);
+        virtual ~avb_counters_response_imp();
+ 
+        uint32_t get_counter_valid(int name);
+        uint32_t get_counter_by_name(int name);
+    };
+}

--- a/controller/lib/src/avb_interface_descriptor_imp.cpp
+++ b/controller/lib/src/avb_interface_descriptor_imp.cpp
@@ -39,108 +39,37 @@
 
 namespace avdecc_lib
 {
-    avb_interface_descriptor_imp::avb_interface_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj)
+    avb_interface_descriptor_imp::avb_interface_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos)
     {
-        ssize_t ret = jdksavdecc_descriptor_avb_interface_read(&avb_interface_desc, frame, pos, frame_len);
+        m_type = jdksavdecc_descriptor_avb_interface_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
+        m_index = jdksavdecc_descriptor_avb_interface_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
+    }
+    
+    avb_interface_descriptor_imp::~avb_interface_descriptor_imp(){}
 
-        if (ret < 0)
-        {
-            throw avdecc_read_descriptor_error("avb_interface_desc_read error");
-        }
-        
-        memset(&aem_cmd_get_counters_resp, 0, sizeof(struct jdksavdecc_aem_command_get_counters_response));
-        memset(&counters_response, 0, sizeof(struct get_counters_response_with_block));
+    avb_interface_descriptor_response * STDCALL avb_interface_descriptor_imp::get_avb_interface_response()
+    {
+        std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
+        return resp = new avb_interface_descriptor_response_imp(resp_ref->get_buffer(),
+                                                                resp_ref->get_size(), resp_ref->get_pos());
     }
 
-    avb_interface_descriptor_imp::~avb_interface_descriptor_imp() {}
+    avb_counters_response * STDCALL avb_interface_descriptor_imp::get_avb_interface_counters_response()
+    {
+        std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
+        return counters_resp = new avb_counters_response_imp(resp_ref->get_buffer(),
+                                                             resp_ref->get_size(), resp_ref->get_pos());
+    }
 
     uint16_t STDCALL avb_interface_descriptor_imp::descriptor_type() const
     {
-        //assert(avb_interface_desc.descriptor_type == JDKSAVDECC_DESCRIPTOR_AVB_INTERFACE);
-        return avb_interface_desc.descriptor_type;
+        assert(m_type == JDKSAVDECC_DESCRIPTOR_AVB_INTERFACE);
+        return m_type;
     }
 
     uint16_t STDCALL avb_interface_descriptor_imp::descriptor_index() const
     {
-        return avb_interface_desc.descriptor_index;
-    }
-
-    uint8_t * STDCALL avb_interface_descriptor_imp::object_name()
-    {
-        return avb_interface_desc.object_name.value;
-    }
-
-    uint16_t STDCALL avb_interface_descriptor_imp::localized_description()
-    {
-        return avb_interface_desc.localized_description;
-    }
-
-    uint64_t STDCALL avb_interface_descriptor_imp::mac_addr()
-    {
-        uint64_t mac_addr;
-        utility::convert_eui48_to_uint64(avb_interface_desc.mac_address.value, mac_addr);
-
-        return mac_addr;
-    }
-
-    uint16_t STDCALL avb_interface_descriptor_imp::interface_flags()
-    {
-        return avb_interface_desc.interface_flags;
-    }
-
-    uint64_t STDCALL avb_interface_descriptor_imp::clock_identity()
-    {
-        return jdksavdecc_uint64_get(&avb_interface_desc.clock_identity, 0);
-    }
-
-    uint8_t STDCALL avb_interface_descriptor_imp::priority1()
-    {
-        return avb_interface_desc.priority1;
-    }
-
-    uint8_t STDCALL avb_interface_descriptor_imp::clock_class()
-    {
-        return avb_interface_desc.clock_class;
-    }
-
-    uint16_t STDCALL avb_interface_descriptor_imp::offset_scaled_log_variance()
-    {
-        return avb_interface_desc.offset_scaled_log_variance;
-    }
-
-    uint8_t STDCALL avb_interface_descriptor_imp::clock_accuracy()
-    {
-        return avb_interface_desc.clock_accuracy;
-    }
-
-    uint8_t STDCALL avb_interface_descriptor_imp::priority2()
-    {
-        return avb_interface_desc.priority2;
-    }
-
-    uint8_t STDCALL avb_interface_descriptor_imp::domain_number()
-    {
-        return avb_interface_desc.domain_number;
-    }
-
-    uint8_t STDCALL avb_interface_descriptor_imp::log_sync_interval()
-    {
-        return avb_interface_desc.log_sync_interval;
-    }
-
-    uint8_t STDCALL avb_interface_descriptor_imp::log_announce_interval()
-    {
-        return avb_interface_desc.log_announce_interval;
-    }
-
-    uint8_t STDCALL avb_interface_descriptor_imp::log_pdelay_interval()
-    {
-        return avb_interface_desc.log_pdelay_interval;
-    }
-
-    uint16_t STDCALL avb_interface_descriptor_imp::port_number()
-    {
-        return avb_interface_desc.port_number;
+        return m_index;
     }
     
     int STDCALL avb_interface_descriptor_imp::send_get_counters_cmd(void *notification_id)
@@ -149,7 +78,6 @@ namespace avdecc_lib
         struct jdksavdecc_aem_command_get_counters aem_cmd_get_counters;
         memset(&aem_cmd_get_counters,0,sizeof(aem_cmd_get_counters));
         ssize_t aem_cmd_get_counters_returned;
-        
         /******************************************** AECP Common Data *********************************************/
         aem_cmd_get_counters.aem_header.aecpdu_header.controller_entity_id = base_end_station_imp_ref->get_adp()->get_controller_entity_id();
         // Fill aem_cmd_get_counters.sequence_id in AEM Controller State Machine
@@ -162,6 +90,7 @@ namespace avdecc_lib
         /******************************* Fill frame payload with AECP data and send the frame **************************/
         aecp_controller_state_machine_ref->ether_frame_init(base_end_station_imp_ref->mac(), &cmd_frame,
                                                             ETHER_HDR_SIZE + JDKSAVDECC_AEM_COMMAND_GET_COUNTERS_COMMAND_LEN);
+        
         aem_cmd_get_counters_returned = jdksavdecc_aem_command_get_counters_write(&aem_cmd_get_counters,
                                                                                          cmd_frame.payload,
                                                                                          ETHER_HDR_SIZE,
@@ -183,32 +112,21 @@ namespace avdecc_lib
         
         return 0;
     }
-    
+
     int avb_interface_descriptor_imp::proc_get_counters_resp(void *&notification_id, const uint8_t *frame, size_t frame_len, int &status)
     {
         struct jdksavdecc_frame cmd_frame;
+        struct jdksavdecc_aem_command_get_counters_response avb_interface_counters_resp;
         ssize_t aem_cmd_get_counters_resp_returned;
         uint32_t msg_type;
         bool u_field;
-        int r = 0;
-        int i = 0;
         
         memcpy(cmd_frame.payload, frame, frame_len);
-        
-        aem_cmd_get_counters_resp_returned = jdksavdecc_aem_command_get_counters_response_read(&aem_cmd_get_counters_resp,
-                                                                                                      frame,
-                                                                                                      ETHER_HDR_SIZE,
-                                                                                                      frame_len);
-        
-        
-        for(i = 0; i<31; i++){
-            r = jdksavdecc_uint32_read(&counters_response.counters_block[i], frame, ETHER_HDR_SIZE + JDKSAVDECC_AEM_COMMAND_GET_COUNTERS_RESPONSE_OFFSET_COUNTERS_BLOCK + 4 * i,
-                frame_len);
-            
-            if (r < 0)
-                break;
-        }
-        
+
+        aem_cmd_get_counters_resp_returned = jdksavdecc_aem_command_get_counters_response_read(&avb_interface_counters_resp,
+                                                                                               frame,
+                                                                                               ETHER_HDR_SIZE,
+                                                                                               frame_len);
         
         if(aem_cmd_get_counters_resp_returned < 0)
         {
@@ -217,56 +135,14 @@ namespace avdecc_lib
             return -1;
         }
         
-        msg_type = aem_cmd_get_counters_resp.aem_header.aecpdu_header.header.message_type;
-        status = aem_cmd_get_counters_resp.aem_header.aecpdu_header.header.status;
-        u_field = aem_cmd_get_counters_resp.aem_header.command_type >> 15 & 0x01; // u_field = the msb of the uint16_t command_type
+        replace_frame(frame, ETHER_HDR_SIZE, frame_len);
+        
+        msg_type = avb_interface_counters_resp.aem_header.aecpdu_header.header.message_type;
+        status = avb_interface_counters_resp.aem_header.aecpdu_header.header.status;
+        u_field = avb_interface_counters_resp.aem_header.command_type >> 15 & 0x01; // u_field = the msb of the uint16_t command_type
         
         aecp_controller_state_machine_ref->update_inflight_for_rcvd_resp(notification_id, msg_type, u_field, &cmd_frame);
         
-        return 0;
-    }
-    
-    uint32_t STDCALL avb_interface_descriptor_imp::get_counter_by_name(int name)
-    {
-        switch(name)
-        {
-            case AVB_INTERFACE_LINK_UP:
-                return counters_response.counters_block[0];
-            case AVB_INTERFACE_LINK_DOWN:
-                return counters_response.counters_block[1];
-            case AVB_INTERFACE_FRAMES_TX:
-                return counters_response.counters_block[2];
-            case AVB_INTERFACE_FRAMES_RX:
-                return counters_response.counters_block[3];
-            case AVB_INTERFACE_RX_CRC_ERROR:
-                return counters_response.counters_block[4];
-            case AVB_GPTP_GM_CHANGED:
-                return counters_response.counters_block[5];
-            default:
-                log_imp_ref->post_log_msg(LOGGING_LEVEL_ERROR, "counter name not found\n");
-        }
-        return 0;
-    }
-    
-    uint32_t STDCALL avb_interface_descriptor_imp::get_counter_valid(int name)
-    {
-        switch(name)
-        {
-            case AVB_INTERFACE_LINK_UP:
-                return aem_cmd_get_counters_resp.counters_valid & 0x01;
-            case AVB_INTERFACE_LINK_DOWN:
-                return aem_cmd_get_counters_resp.counters_valid >> 1 & 0x01;
-            case AVB_INTERFACE_FRAMES_TX:
-                return aem_cmd_get_counters_resp.counters_valid >> 2 & 0x01;
-            case AVB_INTERFACE_FRAMES_RX:
-                return aem_cmd_get_counters_resp.counters_valid >> 3 & 0x01;
-            case AVB_INTERFACE_RX_CRC_ERROR:
-                return aem_cmd_get_counters_resp.counters_valid >> 4 & 0x01;
-            case AVB_GPTP_GM_CHANGED:
-                return aem_cmd_get_counters_resp.counters_valid >> 5 & 0x01;
-            default:
-                log_imp_ref->post_log_msg(LOGGING_LEVEL_ERROR, "counter name not found\n");
-        }
         return 0;
     }
 }

--- a/controller/lib/src/avb_interface_descriptor_imp.cpp
+++ b/controller/lib/src/avb_interface_descriptor_imp.cpp
@@ -27,6 +27,8 @@
  * AVB INTERFACE descriptor implementation
  */
 
+#include <mutex>
+
 #include "avdecc_error.h"
 #include "enumeration.h"
 #include "log_imp.h"

--- a/controller/lib/src/avb_interface_descriptor_imp.cpp
+++ b/controller/lib/src/avb_interface_descriptor_imp.cpp
@@ -39,11 +39,7 @@
 
 namespace avdecc_lib
 {
-    avb_interface_descriptor_imp::avb_interface_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos)
-    {
-        m_type = jdksavdecc_descriptor_avb_interface_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
-        m_index = jdksavdecc_descriptor_avb_interface_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
-    }
+    avb_interface_descriptor_imp::avb_interface_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos) {}
     
     avb_interface_descriptor_imp::~avb_interface_descriptor_imp(){}
 
@@ -63,13 +59,13 @@ namespace avdecc_lib
 
     uint16_t STDCALL avb_interface_descriptor_imp::descriptor_type() const
     {
-        assert(m_type == JDKSAVDECC_DESCRIPTOR_AVB_INTERFACE);
-        return m_type;
+        assert(jdksavdecc_descriptor_avb_interface_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos()) == JDKSAVDECC_DESCRIPTOR_AVB_INTERFACE);
+        return jdksavdecc_descriptor_avb_interface_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 
     uint16_t STDCALL avb_interface_descriptor_imp::descriptor_index() const
     {
-        return m_index;
+        return jdksavdecc_descriptor_avb_interface_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
     }
     
     int STDCALL avb_interface_descriptor_imp::send_get_counters_cmd(void *notification_id)
@@ -90,7 +86,6 @@ namespace avdecc_lib
         /******************************* Fill frame payload with AECP data and send the frame **************************/
         aecp_controller_state_machine_ref->ether_frame_init(base_end_station_imp_ref->mac(), &cmd_frame,
                                                             ETHER_HDR_SIZE + JDKSAVDECC_AEM_COMMAND_GET_COUNTERS_COMMAND_LEN);
-        
         aem_cmd_get_counters_returned = jdksavdecc_aem_command_get_counters_write(&aem_cmd_get_counters,
                                                                                          cmd_frame.payload,
                                                                                          ETHER_HDR_SIZE,

--- a/controller/lib/src/avb_interface_descriptor_imp.h
+++ b/controller/lib/src/avb_interface_descriptor_imp.h
@@ -38,10 +38,6 @@ namespace avdecc_lib
 {
     class avb_interface_descriptor_imp : public avb_interface_descriptor, public virtual descriptor_base_imp
     {
-    private:
-        uint16_t m_type;
-        uint16_t m_index;
-
     public:
         avb_interface_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
         virtual ~avb_interface_descriptor_imp();

--- a/controller/lib/src/avb_interface_descriptor_imp.h
+++ b/controller/lib/src/avb_interface_descriptor_imp.h
@@ -44,9 +44,7 @@ namespace avdecc_lib
         
         avb_interface_descriptor_response_imp *resp;
         avb_counters_response_imp *counters_resp;
-        
-        uint16_t STDCALL descriptor_type() const;
-        uint16_t STDCALL descriptor_index() const;
+
         avb_interface_descriptor_response * STDCALL get_avb_interface_response();
         avb_counters_response * STDCALL get_avb_interface_counters_response();
         int STDCALL send_get_counters_cmd(void *notification_id);

--- a/controller/lib/src/avb_interface_descriptor_imp.h
+++ b/controller/lib/src/avb_interface_descriptor_imp.h
@@ -30,48 +30,30 @@
 #pragma once
 
 #include "descriptor_base_imp.h"
+#include "avb_interface_descriptor_response_imp.h"
 #include "avb_interface_descriptor.h"
+#include "avb_counters_response_imp.h"
 
 namespace avdecc_lib
 {
     class avb_interface_descriptor_imp : public avb_interface_descriptor, public virtual descriptor_base_imp
     {
     private:
-        struct jdksavdecc_descriptor_avb_interface avb_interface_desc; // Structure containing the avb_interface_desc fields
-        struct jdksavdecc_aem_command_get_counters_response aem_cmd_get_counters_resp; // Store the response received after sending a GET_COUNTERS command.
-        struct get_counters_response_with_block
-        {
-            jdksavdecc_aem_command_get_counters_response aem_cmd_get_counters_response;
-            uint32_t counters_block [31];
-        };
-        
-        struct get_counters_response_with_block counters_response;
+        uint16_t m_type;
+        uint16_t m_index;
 
     public:
         avb_interface_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
         virtual ~avb_interface_descriptor_imp();
-
+        
+        avb_interface_descriptor_response_imp *resp;
+        avb_counters_response_imp *counters_resp;
+        
         uint16_t STDCALL descriptor_type() const;
         uint16_t STDCALL descriptor_index() const;
-        uint8_t * STDCALL object_name();
-        uint16_t STDCALL localized_description();
-        uint64_t STDCALL mac_addr();
-        uint16_t STDCALL interface_flags();
-        uint64_t STDCALL clock_identity();
-        uint8_t STDCALL priority1();
-        uint8_t STDCALL clock_class();
-        uint16_t STDCALL offset_scaled_log_variance();
-        uint8_t STDCALL clock_accuracy();
-        uint8_t STDCALL priority2();
-        uint8_t STDCALL domain_number();
-        uint8_t STDCALL log_sync_interval();
-        uint8_t STDCALL log_announce_interval();
-        uint8_t STDCALL log_pdelay_interval();
-        uint16_t STDCALL port_number();
-        uint32_t STDCALL get_counter_valid(int name);
-        uint32_t STDCALL get_counter_by_name(int name);
+        avb_interface_descriptor_response * STDCALL get_avb_interface_response();
+        avb_counters_response * STDCALL get_avb_interface_counters_response();
         int STDCALL send_get_counters_cmd(void *notification_id);
-        int proc_get_counters_resp(void *&notification_id, const uint8_t *fram, size_t frame_len, int &status);
+        int proc_get_counters_resp(void *&notification_id, const uint8_t *frame, size_t frame_len, int &status);
     };
 }
-

--- a/controller/lib/src/avb_interface_descriptor_response_imp.cpp
+++ b/controller/lib/src/avb_interface_descriptor_response_imp.cpp
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * avb_interface_descriptor_response_imp.cpp
+ *
+ * AVB INTERFACE descriptor response implementation
+ */
+
+#include "avdecc_error.h"
+#include "enumeration.h"
+#include "log_imp.h"
+#include "avb_interface_descriptor_response_imp.h"
+#include "end_station_imp.h"
+#include "util.h"
+
+namespace avdecc_lib
+{
+    avb_interface_descriptor_response_imp::avb_interface_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos) : descriptor_base_imp(nullptr, frame, frame_len, pos)
+    {
+        frame_size = frame_len;
+        buffer = (uint8_t *)malloc(frame_size * sizeof(uint8_t));
+        memcpy(buffer, frame, frame_size);
+        position = pos;
+    }
+    
+    avb_interface_descriptor_response_imp::~avb_interface_descriptor_response_imp() {}
+    
+    uint8_t * STDCALL avb_interface_descriptor_response_imp::object_name()
+    {
+        return (uint8_t *)&buffer[position + JDKSAVDECC_DESCRIPTOR_AVB_INTERFACE_OFFSET_OBJECT_NAME];
+    }
+    uint16_t STDCALL avb_interface_descriptor_response_imp::localized_description()
+    {
+        return jdksavdecc_descriptor_avb_interface_get_localized_description(buffer, position);
+    }
+    uint64_t STDCALL avb_interface_descriptor_response_imp::mac_addr()
+    {
+        uint64_t mac_addr;
+        utility::convert_eui48_to_uint64(&buffer[position +
+                                JDKSAVDECC_DESCRIPTOR_AVB_INTERFACE_OFFSET_MAC_ADDRESS], mac_addr);
+        return mac_addr;
+    }
+    uint16_t STDCALL avb_interface_descriptor_response_imp::interface_flags()
+    {
+        return jdksavdecc_descriptor_avb_interface_get_interface_flags(buffer, position);
+    }
+    uint64_t STDCALL avb_interface_descriptor_response_imp::clock_identity()
+    {
+        return jdksavdecc_uint64_get(buffer, position +
+                                     JDKSAVDECC_DESCRIPTOR_AVB_INTERFACE_OFFSET_CLOCK_IDENTITY);
+    }
+    uint8_t STDCALL avb_interface_descriptor_response_imp::priority1()
+    {
+        return jdksavdecc_descriptor_avb_interface_get_priority1(buffer, position);
+    }
+    uint8_t STDCALL avb_interface_descriptor_response_imp::clock_class()
+    {
+        return jdksavdecc_descriptor_avb_interface_get_clock_class(buffer, position);
+    }
+    uint16_t STDCALL avb_interface_descriptor_response_imp::offset_scaled_log_variance()
+    {
+        return jdksavdecc_descriptor_avb_interface_get_offset_scaled_log_variance(buffer, position);
+    }
+    uint8_t STDCALL avb_interface_descriptor_response_imp::clock_accuracy()
+    {
+        return jdksavdecc_descriptor_avb_interface_get_clock_accuracy(buffer, position);
+    }
+    uint8_t STDCALL avb_interface_descriptor_response_imp::priority2()
+    {
+        return jdksavdecc_descriptor_avb_interface_get_priority2(buffer, position);
+    }
+    uint8_t STDCALL avb_interface_descriptor_response_imp::domain_number()
+    {
+        return jdksavdecc_descriptor_avb_interface_get_domain_number(buffer, position);
+    }
+    uint8_t STDCALL avb_interface_descriptor_response_imp::log_sync_interval()
+    {
+        return jdksavdecc_descriptor_avb_interface_get_log_sync_interval(buffer, position);
+    }
+    uint8_t STDCALL avb_interface_descriptor_response_imp::log_announce_interval()
+    {
+        return jdksavdecc_descriptor_avb_interface_get_log_announce_interval(buffer, position);
+    }
+    uint8_t STDCALL avb_interface_descriptor_response_imp::log_pdelay_interval()
+    {
+        return jdksavdecc_descriptor_avb_interface_get_log_pdelay_interval(buffer, position);
+    }
+    uint16_t STDCALL avb_interface_descriptor_response_imp::port_number()
+    {
+        return jdksavdecc_descriptor_avb_interface_get_port_number(buffer, position);
+    }
+}

--- a/controller/lib/src/avb_interface_descriptor_response_imp.cpp
+++ b/controller/lib/src/avb_interface_descriptor_response_imp.cpp
@@ -36,7 +36,7 @@
 
 namespace avdecc_lib
 {
-    avb_interface_descriptor_response_imp::avb_interface_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos) : descriptor_base_imp(nullptr, frame, frame_len, pos)
+    avb_interface_descriptor_response_imp::avb_interface_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos)
     {
         frame_size = frame_len;
         buffer = (uint8_t *)malloc(frame_size * sizeof(uint8_t));
@@ -44,7 +44,10 @@ namespace avdecc_lib
         position = pos;
     }
     
-    avb_interface_descriptor_response_imp::~avb_interface_descriptor_response_imp() {}
+    avb_interface_descriptor_response_imp::~avb_interface_descriptor_response_imp()
+    {
+        free(buffer);
+    }
     
     uint8_t * STDCALL avb_interface_descriptor_response_imp::object_name()
     {

--- a/controller/lib/src/avb_interface_descriptor_response_imp.h
+++ b/controller/lib/src/avb_interface_descriptor_response_imp.h
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * avb_interface_descriptor_response_imp.h
+ *
+ * avb_interface response implementation class
+ */
+
+#pragma once
+
+#include "descriptor_base_imp.h"
+#include "avb_interface_descriptor_response.h"
+
+namespace avdecc_lib
+{
+    class avb_interface_descriptor_response_imp : public avb_interface_descriptor_response, public virtual descriptor_base_imp
+    {
+    private:
+        uint8_t * buffer;
+        ssize_t position;
+        size_t frame_size;
+        
+    public:
+        avb_interface_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos);
+        virtual ~avb_interface_descriptor_response_imp();
+        
+        uint8_t * STDCALL object_name();
+        uint16_t STDCALL localized_description();
+        uint64_t STDCALL mac_addr();
+        uint16_t STDCALL interface_flags();
+        uint64_t STDCALL clock_identity();
+        uint8_t STDCALL priority1();
+        uint8_t STDCALL clock_class();
+        uint16_t STDCALL offset_scaled_log_variance();
+        uint8_t STDCALL clock_accuracy();
+        uint8_t STDCALL priority2();
+        uint8_t STDCALL domain_number();
+        uint8_t STDCALL log_sync_interval();
+        uint8_t STDCALL log_announce_interval();
+        uint8_t STDCALL log_pdelay_interval();
+        uint16_t STDCALL port_number();
+    };
+}

--- a/controller/lib/src/avb_interface_descriptor_response_imp.h
+++ b/controller/lib/src/avb_interface_descriptor_response_imp.h
@@ -29,12 +29,12 @@
 
 #pragma once
 
-#include "descriptor_base_imp.h"
 #include "avb_interface_descriptor_response.h"
+#include "jdksavdecc_aem_descriptor.h"
 
 namespace avdecc_lib
 {
-    class avb_interface_descriptor_response_imp : public avb_interface_descriptor_response, public virtual descriptor_base_imp
+    class avb_interface_descriptor_response_imp : public avb_interface_descriptor_response
     {
     private:
         uint8_t * buffer;

--- a/controller/lib/src/clock_domain_counters_response_imp.cpp
+++ b/controller/lib/src/clock_domain_counters_response_imp.cpp
@@ -52,7 +52,10 @@ namespace avdecc_lib
         }
     }
     
-    clock_domain_counters_response_imp::~clock_domain_counters_response_imp(){}
+    clock_domain_counters_response_imp::~clock_domain_counters_response_imp()
+    {
+        free(m_frame);
+    }
     
     uint32_t STDCALL clock_domain_counters_response_imp::get_counter_valid(int name)
     {

--- a/controller/lib/src/clock_domain_counters_response_imp.cpp
+++ b/controller/lib/src/clock_domain_counters_response_imp.cpp
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * clock_domain_counters_response_imp.cpp
+ *
+ * clock_domain counters response implementation
+ */
+
+#include "enumeration.h"
+#include "log_imp.h"
+#include "clock_domain_counters_response_imp.h"
+
+namespace avdecc_lib
+{
+    clock_domain_counters_response_imp::clock_domain_counters_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos)
+    {
+        m_position = pos;
+        m_size = frame_len;
+        m_frame = (uint8_t *)malloc(m_size * sizeof(uint8_t));
+        memcpy(m_frame, frame, m_size);
+        
+        m_counters_valid = jdksavdecc_uint32_get(m_frame, ETHER_HDR_SIZE
+                                                 + JDKSAVDECC_AEM_COMMAND_GET_COUNTERS_RESPONSE_OFFSET_COUNTERS_VALID);
+        
+        for(int i = 0; i<31; i++){
+            int r = jdksavdecc_uint32_read(&m_counters_block[i], frame, ETHER_HDR_SIZE
+                                       + JDKSAVDECC_AEM_COMMAND_GET_COUNTERS_RESPONSE_OFFSET_COUNTERS_BLOCK + 4 * i,
+                                       frame_len);
+            if (r < 0)
+                break;
+        }
+    }
+    
+    clock_domain_counters_response_imp::~clock_domain_counters_response_imp(){}
+    
+    uint32_t STDCALL clock_domain_counters_response_imp::get_counter_valid(int name)
+    {
+        switch(name)
+        {
+            case CLOCK_DOMAIN_LOCKED:
+                return m_counters_valid & 0x01;
+            case CLOCK_DOMAIN_UNLOCKED:
+                return m_counters_valid >> 1 & 0x01;
+            default:
+                log_imp_ref->post_log_msg(LOGGING_LEVEL_ERROR, "counter name not found");
+        }
+        return 0;
+    }
+    
+    uint32_t STDCALL clock_domain_counters_response_imp::get_counter_by_name(int name)
+    {
+        switch(name)
+        {
+            case CLOCK_DOMAIN_LOCKED:
+                return m_counters_block[0];
+            case CLOCK_DOMAIN_UNLOCKED:
+                return m_counters_block[1];
+            default:
+                log_imp_ref->post_log_msg(LOGGING_LEVEL_ERROR, "counter name not found");
+        }
+        return 0;
+    }
+}

--- a/controller/lib/src/clock_domain_counters_response_imp.h
+++ b/controller/lib/src/clock_domain_counters_response_imp.h
@@ -47,7 +47,7 @@ namespace avdecc_lib
         clock_domain_counters_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos);
         virtual ~clock_domain_counters_response_imp();
         
-        uint32_t get_counter_valid(int name);
-        uint32_t get_counter_by_name(int name);
+        uint32_t STDCALL get_counter_valid(int name);
+        uint32_t STDCALL get_counter_by_name(int name);
     };
 }

--- a/controller/lib/src/clock_domain_counters_response_imp.h
+++ b/controller/lib/src/clock_domain_counters_response_imp.h
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * clock_domain_counters_response_imp.h
+ *
+ * CLOCK DOMAIN counters response implementation class
+ */
+
+#pragma once
+
+#include "clock_domain_counters_response.h"
+#include "jdksavdecc_aem_command.h"
+
+namespace avdecc_lib
+{
+    class clock_domain_counters_response_imp : public clock_domain_counters_response
+    {
+    private:
+        uint32_t m_counters_valid;
+        uint32_t m_counters_block [31];
+        uint8_t * m_frame;
+        size_t m_size;
+        ssize_t m_position;
+        
+    public:
+        clock_domain_counters_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos);
+        virtual ~clock_domain_counters_response_imp();
+        
+        uint32_t get_counter_valid(int name);
+        uint32_t get_counter_by_name(int name);
+    };
+}

--- a/controller/lib/src/clock_domain_descriptor_imp.cpp
+++ b/controller/lib/src/clock_domain_descriptor_imp.cpp
@@ -47,7 +47,7 @@ namespace avdecc_lib
     }
 
     clock_domain_descriptor_imp::~clock_domain_descriptor_imp() {}
-    
+
     clock_domain_descriptor_response * STDCALL clock_domain_descriptor_imp::get_clock_domain_response()
     {
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
@@ -61,7 +61,7 @@ namespace avdecc_lib
         return counters_resp = new clock_domain_counters_response_imp(resp_ref->get_buffer(),
                                                                       resp_ref->get_size(), resp_ref->get_pos());
     }
-    
+
     clock_domain_get_clock_source_response * STDCALL clock_domain_descriptor_imp::get_clock_domain_get_clock_source_response()
     {
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station

--- a/controller/lib/src/clock_domain_descriptor_imp.cpp
+++ b/controller/lib/src/clock_domain_descriptor_imp.cpp
@@ -27,7 +27,9 @@
  * CLOCK DOMAIN descriptor implementation
  */
 
+#include <mutex>
 #include <vector>
+
 #include "avdecc_error.h"
 #include "enumeration.h"
 #include "log_imp.h"

--- a/controller/lib/src/clock_domain_descriptor_imp.cpp
+++ b/controller/lib/src/clock_domain_descriptor_imp.cpp
@@ -42,9 +42,6 @@ namespace avdecc_lib
     clock_domain_descriptor_imp::clock_domain_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos)
     {
         memset(&aem_cmd_set_clk_src_resp, 0, sizeof(struct jdksavdecc_aem_command_set_clock_source_response));
-
-        m_type = jdksavdecc_descriptor_clock_domain_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
-        m_index = jdksavdecc_descriptor_clock_domain_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 
     clock_domain_descriptor_imp::~clock_domain_descriptor_imp() {}
@@ -73,13 +70,13 @@ namespace avdecc_lib
 
     uint16_t STDCALL clock_domain_descriptor_imp::descriptor_type() const
     {
-        assert(m_type == JDKSAVDECC_DESCRIPTOR_CLOCK_DOMAIN);
-        return m_type;
+        assert(jdksavdecc_descriptor_clock_domain_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos()) == JDKSAVDECC_DESCRIPTOR_CLOCK_DOMAIN);
+        return jdksavdecc_descriptor_clock_domain_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 
     uint16_t STDCALL clock_domain_descriptor_imp::descriptor_index() const
     {
-        return m_index;
+        return jdksavdecc_descriptor_clock_domain_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 
     int STDCALL clock_domain_descriptor_imp::send_set_clock_source_cmd(void *notification_id, uint16_t new_clk_src_index)
@@ -151,13 +148,6 @@ namespace avdecc_lib
         u_field = aem_cmd_set_clk_src_resp.aem_header.command_type >> 15 & 0x01; // u_field = the msb of the uint16_t command_type
 
         aecp_controller_state_machine_ref->update_inflight_for_rcvd_resp(notification_id, msg_type, u_field, &cmd_frame);
-        
-        /*
-        if(status == AEM_STATUS_SUCCESS)
-        {
-            update_clock_source_index(aem_cmd_set_clk_src_resp.clock_source_index);
-        }
-        */
 
         return 0;
     }

--- a/controller/lib/src/clock_domain_descriptor_imp.cpp
+++ b/controller/lib/src/clock_domain_descriptor_imp.cpp
@@ -49,8 +49,8 @@ namespace avdecc_lib
     clock_domain_descriptor_response * STDCALL clock_domain_descriptor_imp::get_clock_domain_response()
     {
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
-        return resp = new clock_domain_descriptor_response_imp(resp_ref->get_buffer(),
-                                                               resp_ref->get_size(), resp_ref->get_pos());
+        return resp = new clock_domain_descriptor_response_imp(resp_ref->get_desc_buffer(),
+                                                               resp_ref->get_desc_size(), resp_ref->get_desc_pos());
     }
 
     clock_domain_counters_response * STDCALL clock_domain_descriptor_imp::get_clock_domain_counters_response()
@@ -65,18 +65,6 @@ namespace avdecc_lib
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
         return clock_source_resp = new clock_domain_get_clock_source_response_imp(resp_ref->get_buffer(),
                                                                                   resp_ref->get_size(), resp_ref->get_pos());
-    }
-
-
-    uint16_t STDCALL clock_domain_descriptor_imp::descriptor_type() const
-    {
-        assert(jdksavdecc_descriptor_clock_domain_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos()) == JDKSAVDECC_DESCRIPTOR_CLOCK_DOMAIN);
-        return jdksavdecc_descriptor_clock_domain_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
-    }
-
-    uint16_t STDCALL clock_domain_descriptor_imp::descriptor_index() const
-    {
-        return jdksavdecc_descriptor_clock_domain_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 
     int STDCALL clock_domain_descriptor_imp::send_set_clock_source_cmd(void *notification_id, uint16_t new_clk_src_index)
@@ -157,7 +145,6 @@ namespace avdecc_lib
         struct jdksavdecc_frame cmd_frame;
         struct jdksavdecc_aem_command_get_clock_source aem_cmd_get_clk_src;
         ssize_t aem_cmd_get_clk_src_returned;
-
         memset(&aem_cmd_get_clk_src,0,sizeof(aem_cmd_get_clk_src));
 
         /***************************************** AECP Common Data ******************************************/
@@ -203,6 +190,7 @@ namespace avdecc_lib
         bool u_field;
 
         memcpy(cmd_frame.payload, frame, frame_len);
+        memset(&aem_cmd_get_clk_src_resp, 0, sizeof(jdksavdecc_aem_command_get_clock_source_response));
 
         aem_cmd_get_clk_src_resp_returned = jdksavdecc_aem_command_get_clock_source_response_read(&aem_cmd_get_clk_src_resp,
                                                                                                   frame,
@@ -277,6 +265,7 @@ namespace avdecc_lib
         bool u_field;
         
         memcpy(cmd_frame.payload, frame, frame_len);
+        memset(&clock_domain_counters_resp, 0, sizeof(jdksavdecc_aem_command_get_counters_response));
 
         aem_cmd_get_counters_resp_returned = jdksavdecc_aem_command_get_counters_response_read(&clock_domain_counters_resp,
                                                                                                frame,

--- a/controller/lib/src/clock_domain_descriptor_imp.h
+++ b/controller/lib/src/clock_domain_descriptor_imp.h
@@ -48,9 +48,7 @@ namespace avdecc_lib
         clock_domain_descriptor_response_imp *resp;
         clock_domain_counters_response_imp *counters_resp;
         clock_domain_get_clock_source_response_imp *clock_source_resp;
-        
-        uint16_t STDCALL descriptor_type() const;
-        uint16_t STDCALL descriptor_index() const;
+
         clock_domain_descriptor_response * STDCALL get_clock_domain_response();
         clock_domain_counters_response * STDCALL get_clock_domain_counters_response();
         clock_domain_get_clock_source_response * STDCALL get_clock_domain_get_clock_source_response();

--- a/controller/lib/src/clock_domain_descriptor_imp.h
+++ b/controller/lib/src/clock_domain_descriptor_imp.h
@@ -41,9 +41,6 @@ namespace avdecc_lib
     {
     private:
         struct jdksavdecc_aem_command_set_clock_source_response aem_cmd_set_clk_src_resp; // Store the response received after sending a SET_CLOCK_SOURCE command
-        uint16_t m_type;
-        uint16_t m_index;
-
     public:
         clock_domain_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
         virtual ~clock_domain_descriptor_imp();

--- a/controller/lib/src/clock_domain_descriptor_imp.h
+++ b/controller/lib/src/clock_domain_descriptor_imp.h
@@ -31,59 +31,37 @@
 
 #include "descriptor_base_imp.h"
 #include "clock_domain_descriptor.h"
+#include "clock_domain_descriptor_response_imp.h"
+#include "clock_domain_counters_response_imp.h"
+#include "clock_domain_get_clock_source_response_imp.h"
 
 namespace avdecc_lib
 {
     class clock_domain_descriptor_imp : public clock_domain_descriptor, public virtual descriptor_base_imp
     {
     private:
-        struct jdksavdecc_descriptor_clock_domain clock_domain_desc; // Store the CLOCK DOMAIN Descriptor fields
-        std::vector<uint16_t> clk_src_vec; // Store clock sources in a vector
-
         struct jdksavdecc_aem_command_set_clock_source_response aem_cmd_set_clk_src_resp; // Store the response received after sending a SET_CLOCK_SOURCE command
-        struct jdksavdecc_aem_command_get_clock_source_response aem_cmd_get_clk_src_resp; // Store the response received after sending a GET_CLOCK_SOURCE command
-        struct jdksavdecc_aem_command_get_counters_response aem_cmd_get_counters_resp;
-        struct get_counters_response_with_block
-        {
-            jdksavdecc_aem_command_get_counters_response aem_cmd_get_counters_response;
-            uint32_t counters_block [31];
-        };
-        
-        struct get_counters_response_with_block counters_response;
+        uint16_t m_type;
+        uint16_t m_index;
 
     public:
         clock_domain_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
         virtual ~clock_domain_descriptor_imp();
-
-		uint16_t STDCALL descriptor_type() const;
+        
+        clock_domain_descriptor_response_imp *resp;
+        clock_domain_counters_response_imp *counters_resp;
+        clock_domain_get_clock_source_response_imp *clock_source_resp;
+        
+        uint16_t STDCALL descriptor_type() const;
         uint16_t STDCALL descriptor_index() const;
-        uint8_t * STDCALL object_name();
-        uint16_t STDCALL localized_description();
-        uint16_t STDCALL clock_source_index();
-        uint16_t clock_sources_offset();
-        uint16_t STDCALL clock_sources_count();
-        uint16_t STDCALL get_clock_source_by_index(size_t clk_src_index);
-        uint16_t STDCALL set_clock_source_clock_source_index();
-        uint16_t STDCALL get_clock_source_clock_source_index();
+        clock_domain_descriptor_response * STDCALL get_clock_domain_response();
+        clock_domain_counters_response * STDCALL get_clock_domain_counters_response();
+        clock_domain_get_clock_source_response * STDCALL get_clock_domain_get_clock_source_response();
         int STDCALL send_set_clock_source_cmd(void *notification_id, uint16_t new_clk_src_index);
         int proc_set_clock_source_resp(void *&notification_id, const uint8_t *frame, size_t frame_len, int &status);
         int STDCALL send_get_clock_source_cmd(void *notification_id);
         int proc_get_clock_source_resp(void *&notification_id, const uint8_t *frame, size_t frame_len, int &status);
-        uint32_t STDCALL get_counter_valid(int name);
-        uint32_t STDCALL get_counter_by_name(int name);
         int STDCALL send_get_counters_cmd(void *notification_id);
         int proc_get_counters_resp(void *&notification_id, const uint8_t *fram, size_t frame_len, int &status);
-
-    private:
-        /**
-        * Store the Clock Sources of the CLOCK DOMAIN object.
-        */
-        void store_clock_sources(const uint8_t *frame, size_t pos);
-
-        /**
-         * Update the internal CLOCK DOMAIN's clock source field.
-         */
-        void update_clock_source_index(uint16_t clock_source_index);
     };
 }
-

--- a/controller/lib/src/clock_domain_descriptor_response_imp.cpp
+++ b/controller/lib/src/clock_domain_descriptor_response_imp.cpp
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * clock_domain_descriptor_response_imp.cpp
+ *
+ * CLOCK DOMAIN descriptor response implementation
+ */
+
+#include <vector>
+#include "clock_domain_descriptor_response_imp.h"
+
+namespace avdecc_lib
+{
+    clock_domain_descriptor_response_imp::clock_domain_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos) : descriptor_base_imp(nullptr, frame, frame_len, pos)
+    {
+        frame_size = frame_len;
+        buffer = (uint8_t *)malloc(frame_size * sizeof(uint8_t));
+        memcpy(buffer, frame, frame_size);
+        position = pos;
+
+        store_clock_sources(frame, pos);
+    }
+    
+    clock_domain_descriptor_response_imp::~clock_domain_descriptor_response_imp() {}
+    
+    uint8_t * STDCALL clock_domain_descriptor_response_imp::object_name()
+    {
+        return (uint8_t *)&buffer[position + JDKSAVDECC_DESCRIPTOR_CLOCK_DOMAIN_OFFSET_OBJECT_NAME];
+    }
+    
+    uint16_t STDCALL clock_domain_descriptor_response_imp::localized_description()
+    {
+        return jdksavdecc_descriptor_clock_domain_get_localized_description(buffer, position);
+    }
+    
+    uint16_t STDCALL clock_domain_descriptor_response_imp::clock_source_index()
+    {
+        return jdksavdecc_descriptor_clock_domain_get_clock_source_index(buffer, position);
+    }
+    
+    uint16_t clock_domain_descriptor_response_imp::clock_sources_offset()
+    {
+        assert(jdksavdecc_descriptor_clock_domain_get_clock_sources_offset(buffer, position) == 76);
+        return jdksavdecc_descriptor_clock_domain_get_clock_sources_offset(buffer, position);
+    }
+    
+    uint16_t STDCALL clock_domain_descriptor_response_imp::clock_sources_count()
+    {
+        assert(jdksavdecc_descriptor_clock_domain_get_clock_sources_count(buffer, position) <= 249);
+        return jdksavdecc_descriptor_clock_domain_get_clock_sources_count(buffer, position);
+    }
+    
+    void clock_domain_descriptor_response_imp::store_clock_sources(const uint8_t *frame, size_t pos)
+    {
+        uint16_t offset = 0;
+        
+        for(uint32_t i = 0; i < clock_sources_count(); i++)
+        {
+            clk_src_vec.push_back(jdksavdecc_uint16_get(frame, clock_sources_offset() + pos + offset));
+            offset += 0x2;
+        }
+    }
+    
+    uint16_t STDCALL clock_domain_descriptor_response_imp::get_clock_source_by_index(size_t clk_src_index)
+    {
+        return clk_src_vec.at(clk_src_index);
+    }
+}

--- a/controller/lib/src/clock_domain_descriptor_response_imp.cpp
+++ b/controller/lib/src/clock_domain_descriptor_response_imp.cpp
@@ -32,17 +32,19 @@
 
 namespace avdecc_lib
 {
-    clock_domain_descriptor_response_imp::clock_domain_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos) : descriptor_base_imp(nullptr, frame, frame_len, pos)
+    clock_domain_descriptor_response_imp::clock_domain_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos)
     {
         frame_size = frame_len;
         buffer = (uint8_t *)malloc(frame_size * sizeof(uint8_t));
         memcpy(buffer, frame, frame_size);
         position = pos;
-
         store_clock_sources(frame, pos);
     }
     
-    clock_domain_descriptor_response_imp::~clock_domain_descriptor_response_imp() {}
+    clock_domain_descriptor_response_imp::~clock_domain_descriptor_response_imp()
+    {
+        free(buffer);
+    }
     
     uint8_t * STDCALL clock_domain_descriptor_response_imp::object_name()
     {

--- a/controller/lib/src/clock_domain_descriptor_response_imp.cpp
+++ b/controller/lib/src/clock_domain_descriptor_response_imp.cpp
@@ -38,7 +38,7 @@ namespace avdecc_lib
         buffer = (uint8_t *)malloc(frame_size * sizeof(uint8_t));
         memcpy(buffer, frame, frame_size);
         position = pos;
-        store_clock_sources(frame, pos);
+        store_clock_sources();
     }
     
     clock_domain_descriptor_response_imp::~clock_domain_descriptor_response_imp()
@@ -73,13 +73,13 @@ namespace avdecc_lib
         return jdksavdecc_descriptor_clock_domain_get_clock_sources_count(buffer, position);
     }
     
-    void clock_domain_descriptor_response_imp::store_clock_sources(const uint8_t *frame, size_t pos)
+    void clock_domain_descriptor_response_imp::store_clock_sources()
     {
         uint16_t offset = 0;
-        
+    
         for(uint32_t i = 0; i < clock_sources_count(); i++)
         {
-            clk_src_vec.push_back(jdksavdecc_uint16_get(frame, clock_sources_offset() + pos + offset));
+            clk_src_vec.push_back(jdksavdecc_uint16_get(buffer, clock_sources_offset() + position + offset));
             offset += 0x2;
         }
     }

--- a/controller/lib/src/clock_domain_descriptor_response_imp.h
+++ b/controller/lib/src/clock_domain_descriptor_response_imp.h
@@ -29,12 +29,12 @@
 
 #pragma once
 
-#include "descriptor_base_imp.h"
 #include "clock_domain_descriptor_response.h"
+#include "jdksavdecc_aem_descriptor.h"
 
 namespace avdecc_lib
 {
-    class clock_domain_descriptor_response_imp : public clock_domain_descriptor_response, public virtual descriptor_base_imp
+    class clock_domain_descriptor_response_imp : public clock_domain_descriptor_response
     {
     private:
         std::vector<uint16_t> clk_src_vec; // Store clock sources in a vector

--- a/controller/lib/src/clock_domain_descriptor_response_imp.h
+++ b/controller/lib/src/clock_domain_descriptor_response_imp.h
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * clock_domain_descriptor_response_imp.h
+ *
+ * CLOCK DOMAIN descriptor response implementation class
+ */
+
+#pragma once
+
+#include "descriptor_base_imp.h"
+#include "clock_domain_descriptor_response.h"
+
+namespace avdecc_lib
+{
+    class clock_domain_descriptor_response_imp : public clock_domain_descriptor_response, public virtual descriptor_base_imp
+    {
+    private:
+        std::vector<uint16_t> clk_src_vec; // Store clock sources in a vector
+        uint8_t * buffer;
+        ssize_t position;
+        size_t frame_size;
+        /**
+         * Store the Clock Sources of the CLOCK DOMAIN object.
+         */
+        void store_clock_sources(const uint8_t *frame, size_t pos);
+
+    public:
+        clock_domain_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos);
+        virtual ~clock_domain_descriptor_response_imp();
+
+        uint8_t * STDCALL object_name();
+        uint16_t STDCALL localized_description();
+        uint16_t STDCALL clock_source_index();
+        uint16_t clock_sources_offset();
+        uint16_t STDCALL clock_sources_count();
+        uint16_t STDCALL get_clock_source_by_index(size_t clk_src_index);
+    };
+}

--- a/controller/lib/src/clock_domain_descriptor_response_imp.h
+++ b/controller/lib/src/clock_domain_descriptor_response_imp.h
@@ -44,7 +44,7 @@ namespace avdecc_lib
         /**
          * Store the Clock Sources of the CLOCK DOMAIN object.
          */
-        void store_clock_sources(const uint8_t *frame, size_t pos);
+        void store_clock_sources();
 
     public:
         clock_domain_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos);

--- a/controller/lib/src/clock_domain_get_clock_source_response_imp.cpp
+++ b/controller/lib/src/clock_domain_get_clock_source_response_imp.cpp
@@ -42,7 +42,10 @@ namespace avdecc_lib
         memcpy(m_frame, frame, m_size);
     }
     
-    clock_domain_get_clock_source_response_imp::~clock_domain_get_clock_source_response_imp(){}
+    clock_domain_get_clock_source_response_imp::~clock_domain_get_clock_source_response_imp()
+    {
+        free(m_frame);
+    }
     
     uint16_t STDCALL clock_domain_get_clock_source_response_imp::get_clock_source_clock_source_index()
     {

--- a/controller/lib/src/clock_domain_get_clock_source_response_imp.cpp
+++ b/controller/lib/src/clock_domain_get_clock_source_response_imp.cpp
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * clock_domain_get_clock_source_response_imp.cpp
+ *
+ * CLOCK DOMAIN get clock source response implementation
+ */
+
+#include "enumeration.h"
+#include "log_imp.h"
+#include "clock_domain_get_clock_source_response_imp.h"
+#include "util.h"
+
+namespace avdecc_lib
+{
+    clock_domain_get_clock_source_response_imp::clock_domain_get_clock_source_response_imp(uint8_t *frame, size_t frame_len, ssize_t pos)
+    {
+        m_position = pos;
+        m_size = frame_len;
+        m_frame = (uint8_t *)malloc(m_size * sizeof(uint8_t));
+        memcpy(m_frame, frame, m_size);
+    }
+    
+    clock_domain_get_clock_source_response_imp::~clock_domain_get_clock_source_response_imp(){}
+    
+    uint16_t STDCALL clock_domain_get_clock_source_response_imp::get_clock_source_clock_source_index()
+    {
+        return jdksavdecc_aem_command_get_clock_source_response_get_clock_source_index(m_frame, m_position);
+    }
+}

--- a/controller/lib/src/clock_domain_get_clock_source_response_imp.h
+++ b/controller/lib/src/clock_domain_get_clock_source_response_imp.h
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * clock_domain_get_clock_source_response_imp.h
+ *
+ * CLOCK DOMAIN get clock source response implementation class
+ */
+
+#pragma once
+
+#include "clock_domain_get_clock_source_response.h"
+#include "jdksavdecc_aem_command.h"
+
+namespace avdecc_lib
+{
+    class clock_domain_get_clock_source_response_imp : public clock_domain_get_clock_source_response
+    {
+    private:
+        uint8_t * m_frame;
+        size_t m_size;
+        ssize_t m_position;
+        
+    public:
+        clock_domain_get_clock_source_response_imp(uint8_t *frame, size_t frame_len, ssize_t pos);
+        virtual ~clock_domain_get_clock_source_response_imp();
+        
+        uint16_t STDCALL get_clock_source_clock_source_index();
+    };
+}

--- a/controller/lib/src/clock_source_descriptor_imp.cpp
+++ b/controller/lib/src/clock_source_descriptor_imp.cpp
@@ -27,6 +27,8 @@
  * Clock Source_ descriptor implementation
  */
 
+#include <mutex>
+
 #include "avdecc_error.h"
 #include "enumeration.h"
 #include "log_imp.h"

--- a/controller/lib/src/clock_source_descriptor_imp.cpp
+++ b/controller/lib/src/clock_source_descriptor_imp.cpp
@@ -35,61 +35,29 @@
 
 namespace avdecc_lib
 {
-    clock_source_descriptor_imp::clock_source_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj)
+    clock_source_descriptor_imp::clock_source_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos)
     {
-        ssize_t ret = jdksavdecc_descriptor_clock_source_read(&clock_source_desc, frame, pos, frame_len);
-
-        if (ret < 0)
-        {
-            throw avdecc_read_descriptor_error("clock_source_desc_read error");
-        }
+        m_type = jdksavdecc_descriptor_clock_source_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
+        m_index = jdksavdecc_descriptor_clock_source_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 
     clock_source_descriptor_imp::~clock_source_descriptor_imp() {}
+    
+    clock_source_descriptor_response * STDCALL clock_source_descriptor_imp::get_clock_source_response()
+    {
+        std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
+        return resp = new clock_source_descriptor_response_imp(resp_ref->get_buffer(),
+                                                               resp_ref->get_size(), resp_ref->get_pos());
+    }
 
     uint16_t STDCALL clock_source_descriptor_imp::descriptor_type() const
     {
-        assert(clock_source_desc.descriptor_type == JDKSAVDECC_DESCRIPTOR_CLOCK_SOURCE);
-        return clock_source_desc.descriptor_type;
+        assert(m_type == JDKSAVDECC_DESCRIPTOR_CLOCK_SOURCE);
+        return m_type;
     }
 
     uint16_t STDCALL clock_source_descriptor_imp::descriptor_index() const
     {
-        return clock_source_desc.descriptor_index;
-    }
-
-    uint8_t * STDCALL clock_source_descriptor_imp::object_name()
-    {
-        return clock_source_desc.object_name.value;
-    }
-
-    uint16_t STDCALL clock_source_descriptor_imp::localized_description()
-    {
-        return clock_source_desc.localized_description;
-    }
-
-    uint16_t STDCALL clock_source_descriptor_imp::clock_source_flags()
-    {
-        return clock_source_desc.clock_source_flags;
-    }
-
-    uint16_t STDCALL clock_source_descriptor_imp::clock_source_type()
-    {
-        return clock_source_desc.clock_source_type;
-    }
-
-    uint64_t STDCALL clock_source_descriptor_imp::clock_source_identifier()
-    {
-        return jdksavdecc_uint64_get(&clock_source_desc.clock_source_identifier, 0);
-    }
-
-    uint16_t STDCALL clock_source_descriptor_imp::clock_source_location_type()
-    {
-        return clock_source_desc.clock_source_location_type;
-    }
-
-    uint16_t STDCALL clock_source_descriptor_imp::clock_source_location_index()
-    {
-        return clock_source_desc.clock_source_location_index;
+        return m_index;
     }
 }

--- a/controller/lib/src/clock_source_descriptor_imp.cpp
+++ b/controller/lib/src/clock_source_descriptor_imp.cpp
@@ -42,18 +42,7 @@ namespace avdecc_lib
     clock_source_descriptor_response * STDCALL clock_source_descriptor_imp::get_clock_source_response()
     {
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
-        return resp = new clock_source_descriptor_response_imp(resp_ref->get_buffer(),
-                                                               resp_ref->get_size(), resp_ref->get_pos());
-    }
-
-    uint16_t STDCALL clock_source_descriptor_imp::descriptor_type() const
-    {
-        assert(jdksavdecc_descriptor_clock_source_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos()) == JDKSAVDECC_DESCRIPTOR_CLOCK_SOURCE);
-        return jdksavdecc_descriptor_clock_source_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
-    }
-
-    uint16_t STDCALL clock_source_descriptor_imp::descriptor_index() const
-    {
-        return jdksavdecc_descriptor_clock_source_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
+        return resp = new clock_source_descriptor_response_imp(resp_ref->get_desc_buffer(),
+                                                               resp_ref->get_desc_size(), resp_ref->get_desc_pos());
     }
 }

--- a/controller/lib/src/clock_source_descriptor_imp.cpp
+++ b/controller/lib/src/clock_source_descriptor_imp.cpp
@@ -35,11 +35,7 @@
 
 namespace avdecc_lib
 {
-    clock_source_descriptor_imp::clock_source_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos)
-    {
-        m_type = jdksavdecc_descriptor_clock_source_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
-        m_index = jdksavdecc_descriptor_clock_source_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
-    }
+    clock_source_descriptor_imp::clock_source_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos) {}
 
     clock_source_descriptor_imp::~clock_source_descriptor_imp() {}
     
@@ -52,12 +48,12 @@ namespace avdecc_lib
 
     uint16_t STDCALL clock_source_descriptor_imp::descriptor_type() const
     {
-        assert(m_type == JDKSAVDECC_DESCRIPTOR_CLOCK_SOURCE);
-        return m_type;
+        assert(jdksavdecc_descriptor_clock_source_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos()) == JDKSAVDECC_DESCRIPTOR_CLOCK_SOURCE);
+        return jdksavdecc_descriptor_clock_source_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 
     uint16_t STDCALL clock_source_descriptor_imp::descriptor_index() const
     {
-        return m_index;
+        return jdksavdecc_descriptor_clock_source_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 }

--- a/controller/lib/src/clock_source_descriptor_imp.h
+++ b/controller/lib/src/clock_source_descriptor_imp.h
@@ -31,27 +31,23 @@
 
 #include "descriptor_base_imp.h"
 #include "clock_source_descriptor.h"
+#include "clock_source_descriptor_response_imp.h"
 
 namespace avdecc_lib
 {
     class clock_source_descriptor_imp : public clock_source_descriptor, public virtual descriptor_base_imp
     {
     private:
-        struct jdksavdecc_descriptor_clock_source clock_source_desc; // Structure containing the clock_source_desc fields
-
+        uint16_t m_type;
+        uint16_t m_index;
     public:
         clock_source_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
         virtual ~clock_source_descriptor_imp();
 
+        clock_source_descriptor_response_imp *resp;
+        
         uint16_t STDCALL descriptor_type() const;
         uint16_t STDCALL descriptor_index() const;
-        uint8_t * STDCALL object_name();
-        uint16_t STDCALL localized_description();
-        uint16_t STDCALL clock_source_flags();
-        uint16_t STDCALL clock_source_type();
-        uint64_t STDCALL clock_source_identifier();
-        uint16_t STDCALL clock_source_location_type();
-        uint16_t STDCALL clock_source_location_index();
+        clock_source_descriptor_response * STDCALL get_clock_source_response();
     };
 }
-

--- a/controller/lib/src/clock_source_descriptor_imp.h
+++ b/controller/lib/src/clock_source_descriptor_imp.h
@@ -37,9 +37,6 @@ namespace avdecc_lib
 {
     class clock_source_descriptor_imp : public clock_source_descriptor, public virtual descriptor_base_imp
     {
-    private:
-        uint16_t m_type;
-        uint16_t m_index;
     public:
         clock_source_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
         virtual ~clock_source_descriptor_imp();

--- a/controller/lib/src/clock_source_descriptor_imp.h
+++ b/controller/lib/src/clock_source_descriptor_imp.h
@@ -42,9 +42,7 @@ namespace avdecc_lib
         virtual ~clock_source_descriptor_imp();
 
         clock_source_descriptor_response_imp *resp;
-        
-        uint16_t STDCALL descriptor_type() const;
-        uint16_t STDCALL descriptor_index() const;
+
         clock_source_descriptor_response * STDCALL get_clock_source_response();
     };
 }

--- a/controller/lib/src/clock_source_descriptor_response_imp.cpp
+++ b/controller/lib/src/clock_source_descriptor_response_imp.cpp
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * clock_source_descriptor_response_imp.cpp
+ *
+ * CLOCK source descriptor response implementation
+ */
+
+#include <vector>
+#include "clock_source_descriptor_response_imp.h"
+#include "util.h"
+
+namespace avdecc_lib
+{
+    clock_source_descriptor_response_imp::clock_source_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos) : descriptor_base_imp(nullptr, frame, frame_len, pos)
+    {
+        frame_size = frame_len;
+        buffer = (uint8_t *)malloc(frame_size * sizeof(uint8_t));
+        memcpy(buffer, frame, frame_size);
+        position = pos;
+    }
+    
+    clock_source_descriptor_response_imp::~clock_source_descriptor_response_imp() {}
+    
+    uint8_t * STDCALL clock_source_descriptor_response_imp::object_name()
+    {
+        return (uint8_t *)&buffer[position + JDKSAVDECC_DESCRIPTOR_CLOCK_SOURCE_OFFSET_OBJECT_NAME];
+    }
+    
+    uint16_t STDCALL clock_source_descriptor_response_imp::localized_description()
+    {
+        return jdksavdecc_descriptor_clock_source_get_localized_description(buffer, position);
+    }
+    
+    uint16_t STDCALL clock_source_descriptor_response_imp::clock_source_flags()
+    {
+        return jdksavdecc_descriptor_clock_source_get_clock_source_flags(buffer, position);
+    }
+    
+    uint16_t STDCALL clock_source_descriptor_response_imp::clock_source_type()
+    {
+        return jdksavdecc_descriptor_clock_source_get_clock_source_type(buffer, position);
+    }
+    
+    uint64_t STDCALL clock_source_descriptor_response_imp::clock_source_identifier()
+    {
+        uint64_t clock_source_identifier;
+        
+        utility::convert_eui48_to_uint64(&buffer[position +
+                                                 JDKSAVDECC_DESCRIPTOR_CLOCK_SOURCE_OFFSET_CLOCK_SOURCE_IDENTIFIER], clock_source_identifier);
+        
+        return clock_source_identifier;
+    }
+    
+    uint16_t STDCALL clock_source_descriptor_response_imp::clock_source_location_type()
+    {
+        return jdksavdecc_descriptor_clock_source_get_clock_source_location_type(buffer, position);
+    }
+    
+    uint16_t STDCALL clock_source_descriptor_response_imp::clock_source_location_index()
+    {
+        return jdksavdecc_descriptor_clock_source_get_clock_source_location_index(buffer, position);
+    }
+}

--- a/controller/lib/src/clock_source_descriptor_response_imp.cpp
+++ b/controller/lib/src/clock_source_descriptor_response_imp.cpp
@@ -33,7 +33,7 @@
 
 namespace avdecc_lib
 {
-    clock_source_descriptor_response_imp::clock_source_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos) : descriptor_base_imp(nullptr, frame, frame_len, pos)
+    clock_source_descriptor_response_imp::clock_source_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos)
     {
         frame_size = frame_len;
         buffer = (uint8_t *)malloc(frame_size * sizeof(uint8_t));
@@ -41,7 +41,10 @@ namespace avdecc_lib
         position = pos;
     }
     
-    clock_source_descriptor_response_imp::~clock_source_descriptor_response_imp() {}
+    clock_source_descriptor_response_imp::~clock_source_descriptor_response_imp()
+    {
+        free(buffer);
+    }
     
     uint8_t * STDCALL clock_source_descriptor_response_imp::object_name()
     {
@@ -69,7 +72,6 @@ namespace avdecc_lib
         
         utility::convert_eui48_to_uint64(&buffer[position +
                                                  JDKSAVDECC_DESCRIPTOR_CLOCK_SOURCE_OFFSET_CLOCK_SOURCE_IDENTIFIER], clock_source_identifier);
-        
         return clock_source_identifier;
     }
     

--- a/controller/lib/src/clock_source_descriptor_response_imp.h
+++ b/controller/lib/src/clock_source_descriptor_response_imp.h
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * clock_source_descriptor_response_imp.h
+ *
+ * CLOCK SOURCE descriptor response implementation class
+ */
+
+#pragma once
+
+#include "descriptor_base_imp.h"
+#include "clock_source_descriptor_response.h"
+
+namespace avdecc_lib
+{
+    class clock_source_descriptor_response_imp : public clock_source_descriptor_response, public virtual descriptor_base_imp
+    {
+    private:
+        uint8_t * buffer;
+        ssize_t position;
+        size_t frame_size;
+    public:
+        clock_source_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos);
+        virtual ~clock_source_descriptor_response_imp();
+        
+        uint8_t * STDCALL object_name();
+        uint16_t STDCALL localized_description();
+        uint16_t STDCALL clock_source_flags();
+        uint16_t STDCALL clock_source_type();
+        uint64_t STDCALL clock_source_identifier();
+        uint16_t STDCALL clock_source_location_type();
+        uint16_t STDCALL clock_source_location_index();
+    };
+}

--- a/controller/lib/src/clock_source_descriptor_response_imp.h
+++ b/controller/lib/src/clock_source_descriptor_response_imp.h
@@ -29,12 +29,12 @@
 
 #pragma once
 
-#include "descriptor_base_imp.h"
 #include "clock_source_descriptor_response.h"
+#include "jdksavdecc_aem_descriptor.h"
 
 namespace avdecc_lib
 {
-    class clock_source_descriptor_response_imp : public clock_source_descriptor_response, public virtual descriptor_base_imp
+    class clock_source_descriptor_response_imp : public clock_source_descriptor_response
     {
     private:
         uint8_t * buffer;

--- a/controller/lib/src/configuration_descriptor_imp.cpp
+++ b/controller/lib/src/configuration_descriptor_imp.cpp
@@ -222,7 +222,7 @@ namespace avdecc_lib
         if (m_all_desc[desc_type][desc_index])
         {
             // exists
-            desc->replace_frame(frame, pos, frame_len);
+            desc->replace_desc_frame(frame, pos, frame_len);
             delete desc;
         }
         else

--- a/controller/lib/src/configuration_descriptor_imp.cpp
+++ b/controller/lib/src/configuration_descriptor_imp.cpp
@@ -487,9 +487,11 @@ namespace avdecc_lib
 
         if(desc)
         {
+            uint8_t * string;
             strings_descriptor_response *strings_resp_ref = desc->get_strings_response();
-            return strings_resp_ref->get_string_by_index(reference & 0x7);
-            free(strings_resp_ref);
+            string = strings_resp_ref->get_string_by_index(reference & 0x7);
+            delete strings_resp_ref;
+            return string;
         }
 
         log_imp_ref->post_log_msg(LOGGING_LEVEL_ERROR,

--- a/controller/lib/src/configuration_descriptor_imp.cpp
+++ b/controller/lib/src/configuration_descriptor_imp.cpp
@@ -39,7 +39,7 @@
 
 namespace avdecc_lib
 {
-    configuration_descriptor_imp::configuration_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj)
+    configuration_descriptor_imp::configuration_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos)
     {
         ssize_t ret = jdksavdecc_descriptor_configuration_read(&config_desc, frame, pos, frame_len);
 
@@ -212,7 +212,7 @@ namespace avdecc_lib
     }
     */
 
-    void configuration_descriptor_imp::update_desc_database(descriptor_base_imp *desc)
+    void configuration_descriptor_imp::update_desc_database(descriptor_base_imp *desc, const uint8_t *frame, ssize_t pos, size_t frame_len)
     {
         uint16_t desc_type = desc->descriptor_type();
         uint16_t desc_index = desc->descriptor_index();
@@ -220,103 +220,111 @@ namespace avdecc_lib
         if (m_all_desc[desc_type].size() <= desc_index)
             m_all_desc[desc_type].resize(desc_index + 1);
         if (m_all_desc[desc_type][desc_index])
-            delete m_all_desc[desc_type][desc_index];
-        m_all_desc[desc_type][desc_index] = desc;
+        {
+            // exists
+            desc->replace_frame(frame, pos, frame_len);
+            delete desc;
+        }
+        else
+        {
+            // does not exist
+            m_all_desc[desc_type][desc_index] = desc;
+        }
     }
 
     void configuration_descriptor_imp::store_entity_desc(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len)
     {
-        update_desc_database(new entity_descriptor_imp(end_station_obj, frame, pos, frame_len));
+        update_desc_database(new entity_descriptor_imp(end_station_obj, frame, pos, frame_len), frame, pos, frame_len);
     }
 
     void configuration_descriptor_imp::store_audio_unit_desc(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len)
     {
-        update_desc_database(new audio_unit_descriptor_imp(end_station_obj, frame, pos, frame_len));
+        update_desc_database(new audio_unit_descriptor_imp(end_station_obj, frame, pos, frame_len), frame, pos, frame_len);
     }
 
     void configuration_descriptor_imp::store_stream_input_desc(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len)
     {
-        update_desc_database(new stream_input_descriptor_imp(end_station_obj, frame, pos, frame_len));
+        update_desc_database(new stream_input_descriptor_imp(end_station_obj, frame, pos, frame_len), frame, pos, frame_len);
     }
 
     void configuration_descriptor_imp::store_stream_output_desc(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len)
     {
-        update_desc_database(new stream_output_descriptor_imp(end_station_obj, frame, pos, frame_len));
+        update_desc_database(new stream_output_descriptor_imp(end_station_obj, frame, pos, frame_len), frame, pos, frame_len);
     }
 
     void configuration_descriptor_imp::store_jack_input_desc(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len)
     {
-        update_desc_database(new jack_input_descriptor_imp(end_station_obj, frame, pos, frame_len));
+        update_desc_database(new jack_input_descriptor_imp(end_station_obj, frame, pos, frame_len), frame, pos, frame_len);
     }
 
     void configuration_descriptor_imp::store_jack_output_desc(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len)
     {
-        update_desc_database(new jack_output_descriptor_imp(end_station_obj, frame, pos, frame_len));
+        update_desc_database(new jack_output_descriptor_imp(end_station_obj, frame, pos, frame_len), frame, pos, frame_len);
     }
 
     void configuration_descriptor_imp::store_avb_interface_desc(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len)
     {
-        update_desc_database(new avb_interface_descriptor_imp(end_station_obj, frame, pos, frame_len));
+        update_desc_database(new avb_interface_descriptor_imp(end_station_obj, frame, pos, frame_len), frame, pos, frame_len);
     }
 
     void configuration_descriptor_imp::store_clock_source_desc(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len)
     {
-        update_desc_database(new clock_source_descriptor_imp(end_station_obj, frame, pos, frame_len));
+        update_desc_database(new clock_source_descriptor_imp(end_station_obj, frame, pos, frame_len), frame, pos, frame_len);
     }
 
     void configuration_descriptor_imp::store_memory_object_desc(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len)
     {
-        update_desc_database(new memory_object_descriptor_imp(end_station_obj, frame, pos, frame_len));
+        update_desc_database(new memory_object_descriptor_imp(end_station_obj, frame, pos, frame_len), frame, pos, frame_len);
     }
 
     void configuration_descriptor_imp::store_locale_desc(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len)
     {
-        update_desc_database(new locale_descriptor_imp(end_station_obj, frame, pos, frame_len));
+        update_desc_database(new locale_descriptor_imp(end_station_obj, frame, pos, frame_len), frame, pos, frame_len);
     }
 
     void configuration_descriptor_imp::store_strings_desc(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len)
     {
-        update_desc_database(new strings_descriptor_imp(end_station_obj, frame, pos, frame_len));
+        update_desc_database(new strings_descriptor_imp(end_station_obj, frame, pos, frame_len), frame, pos, frame_len);
     }
 
     void configuration_descriptor_imp::store_stream_port_input_desc(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len)
     {
-        update_desc_database(new stream_port_input_descriptor_imp(end_station_obj, frame, pos, frame_len));
+        update_desc_database(new stream_port_input_descriptor_imp(end_station_obj, frame, pos, frame_len), frame, pos, frame_len);
     }
 
     void configuration_descriptor_imp::store_stream_port_output_desc(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len)
     {
-        update_desc_database(new stream_port_output_descriptor_imp(end_station_obj, frame, pos, frame_len));
+        update_desc_database(new stream_port_output_descriptor_imp(end_station_obj, frame, pos, frame_len), frame, pos, frame_len);
     }
 
     void configuration_descriptor_imp::store_audio_cluster_desc(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len)
     {
-        update_desc_database(new audio_cluster_descriptor_imp(end_station_obj, frame, pos, frame_len));
+        update_desc_database(new audio_cluster_descriptor_imp(end_station_obj, frame, pos, frame_len), frame, pos, frame_len);
     }
 
     void configuration_descriptor_imp::store_audio_map_desc(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len)
     {
-        update_desc_database(new audio_map_descriptor_imp(end_station_obj, frame, pos, frame_len));
+        update_desc_database(new audio_map_descriptor_imp(end_station_obj, frame, pos, frame_len), frame, pos, frame_len);
     }
 
     void configuration_descriptor_imp::store_clock_domain_desc(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len)
     {
-        update_desc_database(new clock_domain_descriptor_imp(end_station_obj, frame, pos, frame_len));
+        update_desc_database(new clock_domain_descriptor_imp(end_station_obj, frame, pos, frame_len), frame, pos, frame_len);
     }
 
     void configuration_descriptor_imp::store_control_desc(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len)
     {
-        update_desc_database(new control_descriptor_imp(end_station_obj, frame, pos, frame_len));
+        update_desc_database(new control_descriptor_imp(end_station_obj, frame, pos, frame_len), frame, pos, frame_len);
     }
 
     void configuration_descriptor_imp::store_external_port_input_desc(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len)
     {
-        update_desc_database(new external_port_input_descriptor_imp(end_station_obj, frame, pos, frame_len));
+        update_desc_database(new external_port_input_descriptor_imp(end_station_obj, frame, pos, frame_len), frame, pos, frame_len);
     }
 
     void configuration_descriptor_imp::store_external_port_output_desc(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len)
     {
-        update_desc_database(new external_port_output_descriptor_imp(end_station_obj, frame, pos, frame_len));
+        update_desc_database(new external_port_output_descriptor_imp(end_station_obj, frame, pos, frame_len), frame, pos, frame_len);
     }
     
     size_t STDCALL configuration_descriptor_imp::entity_desc_count()
@@ -479,7 +487,9 @@ namespace avdecc_lib
 
         if(desc)
         {
-            return desc->get_string_by_index(reference & 0x7);
+            strings_descriptor_response *strings_resp_ref = desc->get_strings_response();
+            return strings_resp_ref->get_string_by_index(reference & 0x7);
+            free(strings_resp_ref);
         }
 
         log_imp_ref->post_log_msg(LOGGING_LEVEL_ERROR,

--- a/controller/lib/src/configuration_descriptor_imp.h
+++ b/controller/lib/src/configuration_descriptor_imp.h
@@ -57,7 +57,6 @@ namespace avdecc_lib
     {
     private:
         typedef std::vector<descriptor_base_imp *> DITEM;
-
         struct jdksavdecc_descriptor_configuration config_desc; // Structure containing the config_desc fields
 
         std::vector<uint16_t> desc_type_vec; // Store descriptor types present in the CONFIGURATION descriptor
@@ -66,11 +65,10 @@ namespace avdecc_lib
 
         size_t desc_count(uint16_t type);
         descriptor_base_imp *lookup_desc(uint16_t desc_type, size_t index);
-        void update_desc_database(descriptor_base_imp *desc);
+        void update_desc_database(descriptor_base_imp *desc, const uint8_t *frame, ssize_t pos, size_t frame_len);
 
-	public:
+    public:
         configuration_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
-
         virtual ~configuration_descriptor_imp();
 
         uint16_t STDCALL descriptor_type() const;

--- a/controller/lib/src/control_descriptor_imp.cpp
+++ b/controller/lib/src/control_descriptor_imp.cpp
@@ -35,12 +35,7 @@
 
 namespace avdecc_lib
 {
-    control_descriptor_imp::control_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos)
-    {
-        m_type = jdksavdecc_descriptor_control_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
-        m_index = jdksavdecc_descriptor_control_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
-    }
-
+    control_descriptor_imp::control_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos) {}
 
     control_descriptor_imp::~control_descriptor_imp(){}
     
@@ -53,12 +48,13 @@ namespace avdecc_lib
 
     uint16_t STDCALL control_descriptor_imp::descriptor_type() const
     {
-        assert(m_type == JDKSAVDECC_DESCRIPTOR_CONTROL);
-        return m_type;
+        assert(jdksavdecc_descriptor_control_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos())
+               == JDKSAVDECC_DESCRIPTOR_CONTROL);
+        return jdksavdecc_descriptor_control_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 
     uint16_t STDCALL control_descriptor_imp::descriptor_index() const
     {
-        return m_index;
+        return jdksavdecc_descriptor_control_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 }

--- a/controller/lib/src/control_descriptor_imp.cpp
+++ b/controller/lib/src/control_descriptor_imp.cpp
@@ -42,19 +42,7 @@ namespace avdecc_lib
     control_descriptor_response * STDCALL control_descriptor_imp::get_control_response()
     {
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
-        return resp = new control_descriptor_response_imp(resp_ref->get_buffer(),
-                                                               resp_ref->get_size(), resp_ref->get_pos());
-    }
-
-    uint16_t STDCALL control_descriptor_imp::descriptor_type() const
-    {
-        assert(jdksavdecc_descriptor_control_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos())
-               == JDKSAVDECC_DESCRIPTOR_CONTROL);
-        return jdksavdecc_descriptor_control_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
-    }
-
-    uint16_t STDCALL control_descriptor_imp::descriptor_index() const
-    {
-        return jdksavdecc_descriptor_control_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
+        return resp = new control_descriptor_response_imp(resp_ref->get_desc_buffer(),
+                                                          resp_ref->get_desc_size(), resp_ref->get_desc_pos());
     }
 }

--- a/controller/lib/src/control_descriptor_imp.cpp
+++ b/controller/lib/src/control_descriptor_imp.cpp
@@ -27,6 +27,8 @@
  * CONTROL descriptor implementation
  */
 
+#include <mutex>
+
 #include "avdecc_error.h"
 #include "enumeration.h"
 #include "log_imp.h"

--- a/controller/lib/src/control_descriptor_imp.cpp
+++ b/controller/lib/src/control_descriptor_imp.cpp
@@ -35,94 +35,30 @@
 
 namespace avdecc_lib
 {
-    control_descriptor_imp::control_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj)
+    control_descriptor_imp::control_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos)
     {
-        ssize_t ret = jdksavdecc_descriptor_control_read(&control_desc, frame, pos, frame_len);
-
-        if (ret < 0)
-        {
-            throw avdecc_read_descriptor_error("control_desc_read error");
-        }
+        m_type = jdksavdecc_descriptor_control_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
+        m_index = jdksavdecc_descriptor_control_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 
 
-    control_descriptor_imp::~control_descriptor_imp()
+    control_descriptor_imp::~control_descriptor_imp(){}
+    
+    control_descriptor_response * STDCALL control_descriptor_imp::get_control_response()
     {
+        std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
+        return resp = new control_descriptor_response_imp(resp_ref->get_buffer(),
+                                                               resp_ref->get_size(), resp_ref->get_pos());
     }
 
     uint16_t STDCALL control_descriptor_imp::descriptor_type() const
     {
-        assert(control_desc.descriptor_type == JDKSAVDECC_DESCRIPTOR_CONTROL);
-        return control_desc.descriptor_type;
+        assert(m_type == JDKSAVDECC_DESCRIPTOR_CONTROL);
+        return m_type;
     }
 
     uint16_t STDCALL control_descriptor_imp::descriptor_index() const
     {
-        return control_desc.descriptor_index;
-    }
-
-    uint8_t * STDCALL control_descriptor_imp::object_name()
-    {
-        return control_desc.object_name.value;
-    }
-
-    uint16_t STDCALL control_descriptor_imp::localized_description()
-    {
-        return control_desc.localized_description;
-    }
-
-    uint32_t STDCALL control_descriptor_imp::block_latency()
-    {
-        return control_desc.block_latency;
-    }
-
-    uint32_t STDCALL control_descriptor_imp::control_latency()
-    {
-        return control_desc.control_latency;
-    }
-
-    uint16_t STDCALL control_descriptor_imp::control_domain()
-    {
-        return control_desc.control_domain;
-    }
-
-    uint16_t STDCALL control_descriptor_imp::control_value_type()
-    {
-        return control_desc.control_value_type;
-    }
-
-    uint64_t STDCALL control_descriptor_imp::control_type()
-    {
-        return jdksavdecc_uint64_get(&control_desc.control_type, 0);
-    }
-
-    uint32_t STDCALL control_descriptor_imp::reset_time()
-    {
-        return control_desc.reset_time;
-    }
-
-    uint16_t STDCALL control_descriptor_imp::values_offset()
-    {
-        return control_desc.values_offset;
-    }
-
-    uint16_t STDCALL control_descriptor_imp::number_of_values()
-    {
-        return control_desc.number_of_values;
-    }
-
-    uint16_t STDCALL control_descriptor_imp::signal_type()
-    {
-        return control_desc.signal_type;
-    }
-
-    uint16_t STDCALL control_descriptor_imp::signal_index()
-    {
-        return control_desc.signal_index;
-    }
-
-    uint16_t STDCALL control_descriptor_imp::signal_output()
-    {
-        return control_desc.signal_output;
+        return m_index;
     }
 }

--- a/controller/lib/src/control_descriptor_imp.h
+++ b/controller/lib/src/control_descriptor_imp.h
@@ -38,10 +38,6 @@ namespace avdecc_lib
 {
     class control_descriptor_imp : public control_descriptor, public virtual descriptor_base_imp
     {
-    private:
-        uint16_t m_type;
-        uint16_t m_index;
-
     public:
         control_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
         virtual ~control_descriptor_imp();

--- a/controller/lib/src/control_descriptor_imp.h
+++ b/controller/lib/src/control_descriptor_imp.h
@@ -42,9 +42,7 @@ namespace avdecc_lib
         control_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
         virtual ~control_descriptor_imp();
         control_descriptor_response_imp *resp;
-        
-        uint16_t STDCALL descriptor_type() const;
-        uint16_t STDCALL descriptor_index() const;
+
         control_descriptor_response * STDCALL get_control_response();
     };
 }

--- a/controller/lib/src/control_descriptor_imp.h
+++ b/controller/lib/src/control_descriptor_imp.h
@@ -32,37 +32,24 @@
 
 #include "descriptor_base_imp.h"
 #include "control_descriptor.h"
+#include "control_descriptor_response_imp.h"
 
 namespace avdecc_lib
 {
     class control_descriptor_imp : public control_descriptor, public virtual descriptor_base_imp
     {
     private:
-        struct jdksavdecc_descriptor_control control_desc; // Structure containing the control_desc fields
+        uint16_t m_type;
+        uint16_t m_index;
 
     public:
         control_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
         virtual ~control_descriptor_imp();
-
-        //descriptor_base
+        control_descriptor_response_imp *resp;
+        
         uint16_t STDCALL descriptor_type() const;
         uint16_t STDCALL descriptor_index() const;
-        uint8_t * STDCALL object_name();
-        uint16_t STDCALL localized_description();
-
-        //control-specific
-        uint32_t STDCALL block_latency();
-        uint32_t STDCALL control_latency();
-        uint16_t STDCALL control_domain();
-        uint16_t STDCALL control_value_type();
-        uint64_t STDCALL control_type();
-        uint32_t STDCALL reset_time();
-        uint16_t STDCALL values_offset();
-        uint16_t STDCALL number_of_values();
-        uint16_t STDCALL signal_type();
-        uint16_t STDCALL signal_index();
-        uint16_t STDCALL signal_output();
-
+        control_descriptor_response * STDCALL get_control_response();
     };
 }
 

--- a/controller/lib/src/control_descriptor_response_imp.cpp
+++ b/controller/lib/src/control_descriptor_response_imp.cpp
@@ -1,0 +1,115 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * control_descriptor_response_imp.cpp
+ *
+ * control descriptor response implementation
+ */
+
+#include <vector>
+#include "control_descriptor_response_imp.h"
+#include "util.h"
+
+namespace avdecc_lib
+{
+    control_descriptor_response_imp::control_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos) : descriptor_base_imp(nullptr, frame, frame_len, pos)
+    {
+        frame_size = frame_len;
+        buffer = (uint8_t *)malloc(frame_size * sizeof(uint8_t));
+        memcpy(buffer, frame, frame_size);
+        position = pos;
+    }
+    
+    control_descriptor_response_imp::~control_descriptor_response_imp() {}
+    
+    uint8_t * STDCALL control_descriptor_response_imp::object_name()
+    {
+        return (uint8_t *)&buffer[position + JDKSAVDECC_DESCRIPTOR_CONTROL_OFFSET_OBJECT_NAME];
+    }
+    
+    uint16_t STDCALL control_descriptor_response_imp::localized_description()
+    {
+        return jdksavdecc_descriptor_control_get_localized_description(buffer, position);
+    }
+    
+    uint32_t STDCALL control_descriptor_response_imp::block_latency()
+    {
+        return jdksavdecc_descriptor_control_get_block_latency(buffer, position);
+    }
+    
+    uint32_t STDCALL control_descriptor_response_imp::control_latency()
+    {
+        return jdksavdecc_descriptor_control_get_control_latency(buffer, position);
+    }
+    
+    uint16_t STDCALL control_descriptor_response_imp::control_domain()
+    {
+        return jdksavdecc_descriptor_control_get_control_domain(buffer, position);
+    }
+    
+    uint16_t STDCALL control_descriptor_response_imp::control_value_type()
+    {
+        return jdksavdecc_descriptor_control_get_control_value_type(buffer, position);
+    }
+    
+    uint64_t STDCALL control_descriptor_response_imp::control_type()
+    {
+        uint64_t control_type;
+        
+        utility::convert_eui48_to_uint64(&buffer[position +
+                                                 JDKSAVDECC_DESCRIPTOR_CONTROL_OFFSET_CONTROL_TYPE], control_type);
+        
+        return control_type;
+    }
+    
+    uint32_t STDCALL control_descriptor_response_imp::reset_time()
+    {
+        return jdksavdecc_descriptor_control_get_reset_time(buffer, position);
+    }
+    
+    uint16_t STDCALL control_descriptor_response_imp::values_offset()
+    {
+        return jdksavdecc_descriptor_control_get_values_offset(buffer, position);
+    }
+    
+    uint16_t STDCALL control_descriptor_response_imp::number_of_values()
+    {
+        return jdksavdecc_descriptor_control_get_number_of_values(buffer, position);
+    }
+    
+    uint16_t STDCALL control_descriptor_response_imp::signal_type()
+    {
+        return jdksavdecc_descriptor_control_get_signal_type(buffer, position);
+    }
+    
+    uint16_t STDCALL control_descriptor_response_imp::signal_index()
+    {
+        return jdksavdecc_descriptor_control_get_signal_index(buffer, position);
+    }
+    
+    uint16_t STDCALL control_descriptor_response_imp::signal_output()
+    {
+        return jdksavdecc_descriptor_control_get_signal_output(buffer, position);
+    }
+}

--- a/controller/lib/src/control_descriptor_response_imp.cpp
+++ b/controller/lib/src/control_descriptor_response_imp.cpp
@@ -33,7 +33,7 @@
 
 namespace avdecc_lib
 {
-    control_descriptor_response_imp::control_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos) : descriptor_base_imp(nullptr, frame, frame_len, pos)
+    control_descriptor_response_imp::control_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos)
     {
         frame_size = frame_len;
         buffer = (uint8_t *)malloc(frame_size * sizeof(uint8_t));
@@ -41,7 +41,10 @@ namespace avdecc_lib
         position = pos;
     }
     
-    control_descriptor_response_imp::~control_descriptor_response_imp() {}
+    control_descriptor_response_imp::~control_descriptor_response_imp()
+    {
+        free(buffer);
+    }
     
     uint8_t * STDCALL control_descriptor_response_imp::object_name()
     {
@@ -79,7 +82,6 @@ namespace avdecc_lib
         
         utility::convert_eui48_to_uint64(&buffer[position +
                                                  JDKSAVDECC_DESCRIPTOR_CONTROL_OFFSET_CONTROL_TYPE], control_type);
-        
         return control_type;
     }
     

--- a/controller/lib/src/control_descriptor_response_imp.h
+++ b/controller/lib/src/control_descriptor_response_imp.h
@@ -29,12 +29,12 @@
 
 #pragma once
 
-#include "descriptor_base_imp.h"
 #include "control_descriptor_response.h"
+#include "jdksavdecc_aem_descriptor.h"
 
 namespace avdecc_lib
 {
-    class control_descriptor_response_imp : public control_descriptor_response, public virtual descriptor_base_imp
+    class control_descriptor_response_imp : public control_descriptor_response
     {
     private:
         uint8_t * buffer;

--- a/controller/lib/src/control_descriptor_response_imp.h
+++ b/controller/lib/src/control_descriptor_response_imp.h
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * control_descriptor_response_imp.h
+ *
+ * Control descriptor response implementation class
+ */
+
+#pragma once
+
+#include "descriptor_base_imp.h"
+#include "control_descriptor_response.h"
+
+namespace avdecc_lib
+{
+    class control_descriptor_response_imp : public control_descriptor_response, public virtual descriptor_base_imp
+    {
+    private:
+        uint8_t * buffer;
+        ssize_t position;
+        size_t frame_size;
+        
+    public:
+        control_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos);
+        virtual ~control_descriptor_response_imp();
+        
+        uint8_t * STDCALL object_name();
+        uint16_t STDCALL localized_description();
+        uint32_t STDCALL block_latency();
+        uint32_t STDCALL control_latency();
+        uint16_t STDCALL control_domain();
+        uint16_t STDCALL control_value_type();
+        uint64_t STDCALL control_type();
+        uint32_t STDCALL reset_time();
+        uint16_t STDCALL values_offset();
+        uint16_t STDCALL number_of_values();
+        uint16_t STDCALL signal_type();
+        uint16_t STDCALL signal_index();
+        uint16_t STDCALL signal_output();
+    };
+}

--- a/controller/lib/src/controller_imp.cpp
+++ b/controller/lib/src/controller_imp.cpp
@@ -589,8 +589,8 @@ namespace avdecc_lib
         uint32_t msg_type = 0;
         bool u_field = false;
 
-        memset(&aem_cmd_controller_avail_resp, 0, sizeof(aem_cmd_controller_avail_resp));
         memcpy(cmd_frame.payload, frame, frame_len);
+        memset(&aem_cmd_controller_avail_resp, 0, sizeof(aem_cmd_controller_avail_resp));
 
         aem_cmd_controller_avail_resp_returned = jdksavdecc_aem_command_controller_available_response_read(&aem_cmd_controller_avail_resp,
                                                                                                            frame,

--- a/controller/lib/src/controller_imp.cpp
+++ b/controller/lib/src/controller_imp.cpp
@@ -201,11 +201,12 @@ namespace avdecc_lib
     {
         for (uint32_t i = 0; i < end_station_array->size(); i++)
         {
+            entity_descriptor_response *entity_resp_ref = end_station_array->at(i)->get_entity_desc_by_index(entity_index)->get_entity_response();
             uint64_t end_station_entity_id = end_station_array->at(i)->entity_id();
             if(end_station_entity_id == entity_entity_id)
             {
                 bool is_valid = ((entity_index < end_station_array->at(i)->entity_desc_count()) &&
-                                 (config_index < end_station_array->at(i)->get_entity_desc_by_index(entity_index)->configurations_count()));
+                                 (config_index < entity_resp_ref->configurations_count()));
                 if(is_valid)
                 {
                     configuration_descriptor * configuration;
@@ -218,8 +219,8 @@ namespace avdecc_lib
                     log_imp_ref->post_log_msg(LOGGING_LEVEL_ERROR, "get_config_desc_by_entity_id error");
                 }
             }
+            free(entity_resp_ref);
         }
-
         return NULL;
     }
 

--- a/controller/lib/src/controller_imp.cpp
+++ b/controller/lib/src/controller_imp.cpp
@@ -219,7 +219,7 @@ namespace avdecc_lib
                     log_imp_ref->post_log_msg(LOGGING_LEVEL_ERROR, "get_config_desc_by_entity_id error");
                 }
             }
-            free(entity_resp_ref);
+            delete entity_resp_ref;
         }
         return NULL;
     }

--- a/controller/lib/src/descriptor_base_imp.cpp
+++ b/controller/lib/src/descriptor_base_imp.cpp
@@ -43,15 +43,17 @@ namespace avdecc_lib
 	{
 		delete f;
 	}
-	descriptor_base_imp::descriptor_base_imp(end_station_imp *base)
+	descriptor_base_imp::descriptor_base_imp(end_station_imp *base, const uint8_t *frame, size_t size, ssize_t pos)
     {
         base_end_station_imp_ref = base;
+        resp_ref = new response_frame(frame, size, pos);
     }
 
     descriptor_base_imp::~descriptor_base_imp()
 	{
 		std::for_each(m_fields.begin(), m_fields.end(), delete_field);
 		m_fields.clear();
+        delete resp_ref;
 	}
 
     bool operator== (const descriptor_base_imp &n1, const descriptor_base_imp &n2)
@@ -62,6 +64,12 @@ namespace avdecc_lib
     bool operator< (const descriptor_base_imp &n1, const descriptor_base_imp &n2)
     {
         return n1.descriptor_index() < n2.descriptor_index();
+    }
+    
+    void STDCALL descriptor_base_imp::replace_frame(const uint8_t *frame, ssize_t pos, size_t size)
+    {
+        std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock the end station
+        resp_ref->replace_frame(frame, pos, size);
     }
 
     uint16_t STDCALL descriptor_base_imp::descriptor_type() const

--- a/controller/lib/src/descriptor_base_imp.cpp
+++ b/controller/lib/src/descriptor_base_imp.cpp
@@ -47,6 +47,8 @@ namespace avdecc_lib
     {
         base_end_station_imp_ref = base;
         resp_ref = new response_frame(frame, size, pos);
+        desc_type = jdksavdecc_uint16_get(frame, ETHER_HDR_SIZE + JDKSAVDECC_AEM_COMMAND_READ_DESCRIPTOR_RESPONSE_OFFSET_DESCRIPTOR);
+        desc_index = jdksavdecc_uint16_get(frame, ETHER_HDR_SIZE + JDKSAVDECC_AEM_COMMAND_READ_DESCRIPTOR_RESPONSE_OFFSET_DESCRIPTOR + 2);
     }
 
     descriptor_base_imp::~descriptor_base_imp()
@@ -71,15 +73,21 @@ namespace avdecc_lib
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock the end station
         resp_ref->replace_frame(frame, pos, size);
     }
+    
+    void STDCALL descriptor_base_imp::replace_desc_frame(const uint8_t *frame, ssize_t pos, size_t size)
+    {
+        std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock the end station
+        resp_ref->replace_desc_frame(frame, pos, size);
+    }
 
     uint16_t STDCALL descriptor_base_imp::descriptor_type() const
     {
-        return 0;
+        return desc_type;
     }
 
     uint16_t STDCALL descriptor_base_imp::descriptor_index() const
     {
-        return 0;
+        return desc_index;
     }
 
     uint8_t * STDCALL descriptor_base_imp::object_name()

--- a/controller/lib/src/descriptor_base_imp.cpp
+++ b/controller/lib/src/descriptor_base_imp.cpp
@@ -27,8 +27,10 @@
  * Descriptor base implementation
  */
 
+#include <mutex>
 #include <algorithm>
 #include <iostream>
+
 #include "enumeration.h"
 #include "log_imp.h"
 #include "adp.h"

--- a/controller/lib/src/descriptor_base_imp.h
+++ b/controller/lib/src/descriptor_base_imp.h
@@ -50,13 +50,15 @@ namespace avdecc_lib
         end_station_imp *base_end_station_imp_ref;
         std::vector<descriptor_field_imp *>m_fields;
         response_frame *resp_ref;
+        uint16_t desc_type;
+        uint16_t desc_index;
 
     public:
         descriptor_base_imp(end_station_imp *base, const uint8_t *frame, size_t size, ssize_t pos);
         virtual ~descriptor_base_imp();
 
-        virtual uint16_t STDCALL descriptor_type() const;
-        virtual uint16_t STDCALL descriptor_index() const;
+        uint16_t STDCALL descriptor_type() const;
+        uint16_t STDCALL descriptor_index() const;
         virtual uint8_t * STDCALL object_name();
         virtual uint16_t STDCALL localized_description();
 
@@ -73,10 +75,14 @@ namespace avdecc_lib
                 return nullptr;
         };
         /**
-         * Replace the frame stored in response_frame on descriptor construction and whenenver descriptor type
-         * and index are already in the internal database
+         * Replace the frame for counters/commands.
          */
         virtual void STDCALL replace_frame(const uint8_t *frame, ssize_t pos, size_t size);
+        
+        /**
+         * Replace the frame for descriptors.
+         */
+        virtual void STDCALL replace_desc_frame(const uint8_t *frame, ssize_t pos, size_t size);
 
         /**
          * Get the flags after sending a ACQUIRE_ENTITY command and receiving a response back for the command.

--- a/controller/lib/src/descriptor_base_imp.h
+++ b/controller/lib/src/descriptor_base_imp.h
@@ -42,15 +42,17 @@
 namespace avdecc_lib
 {
     class end_station_imp;
+    class response_frame;
 
     class descriptor_base_imp : public virtual descriptor_base
     {
     protected:
         end_station_imp *base_end_station_imp_ref;
         std::vector<descriptor_field_imp *>m_fields;
+        response_frame *resp_ref;
 
     public:
-        descriptor_base_imp(end_station_imp *base);
+        descriptor_base_imp(end_station_imp *base, const uint8_t *frame, size_t size, ssize_t pos);
         virtual ~descriptor_base_imp();
 
         virtual uint16_t STDCALL descriptor_type() const;
@@ -70,6 +72,11 @@ namespace avdecc_lib
             else
                 return nullptr;
         };
+        /**
+         * Replace the frame stored in response_frame on descriptor construction and whenenver descriptor type
+         * and index are already in the internal database
+         */
+        virtual void STDCALL replace_frame(const uint8_t *frame, ssize_t pos, size_t size);
 
         /**
          * Get the flags after sending a ACQUIRE_ENTITY command and receiving a response back for the command.

--- a/controller/lib/src/end_station_imp.cpp
+++ b/controller/lib/src/end_station_imp.cpp
@@ -274,75 +274,93 @@ namespace avdecc_lib
                         break;
 
                     case JDKSAVDECC_DESCRIPTOR_AUDIO_UNIT:
-                        config_desc_imp_ref->store_audio_unit_desc(this, frame, read_desc_offset, frame_len);
+                        if(config_desc_imp_ref != nullptr)
+                            config_desc_imp_ref->store_audio_unit_desc(this, frame, read_desc_offset, frame_len);
                         break;
 
                     case JDKSAVDECC_DESCRIPTOR_STREAM_INPUT:
-                        config_desc_imp_ref->store_stream_input_desc(this, frame, read_desc_offset, frame_len);
+                        if(config_desc_imp_ref != nullptr)
+                            config_desc_imp_ref->store_stream_input_desc(this, frame, read_desc_offset, frame_len);
                         break;
 
                     case JDKSAVDECC_DESCRIPTOR_STREAM_OUTPUT:
-                        config_desc_imp_ref->store_stream_output_desc(this, frame, read_desc_offset, frame_len);
+                        if(config_desc_imp_ref != nullptr)
+                            config_desc_imp_ref->store_stream_output_desc(this, frame, read_desc_offset, frame_len);
                         break;
 
                     case JDKSAVDECC_DESCRIPTOR_JACK_INPUT:
-                        config_desc_imp_ref->store_jack_input_desc(this, frame, read_desc_offset, frame_len);
+                        if(config_desc_imp_ref != nullptr)
+                            config_desc_imp_ref->store_jack_input_desc(this, frame, read_desc_offset, frame_len);
                         break;
 
                     case JDKSAVDECC_DESCRIPTOR_JACK_OUTPUT:
-                        config_desc_imp_ref->store_jack_output_desc(this, frame, read_desc_offset, frame_len);
+                        if(config_desc_imp_ref != nullptr)
+                            config_desc_imp_ref->store_jack_output_desc(this, frame, read_desc_offset, frame_len);
                         break;
 
                     case JDKSAVDECC_DESCRIPTOR_AVB_INTERFACE:
-                        config_desc_imp_ref->store_avb_interface_desc(this, frame, read_desc_offset, frame_len);
+                        if(config_desc_imp_ref != nullptr)
+                            config_desc_imp_ref->store_avb_interface_desc(this, frame, read_desc_offset, frame_len);
                         break;
 
                     case JDKSAVDECC_DESCRIPTOR_CLOCK_SOURCE:
-                        config_desc_imp_ref->store_clock_source_desc(this, frame, read_desc_offset, frame_len);
+                        if(config_desc_imp_ref != nullptr)
+                            config_desc_imp_ref->store_clock_source_desc(this, frame, read_desc_offset, frame_len);
                         break;
 
                     case JDKSAVDECC_DESCRIPTOR_MEMORY_OBJECT:
-                        config_desc_imp_ref->store_memory_object_desc(this, frame, read_desc_offset, frame_len);
+                        if(config_desc_imp_ref != nullptr)
+                            config_desc_imp_ref->store_memory_object_desc(this, frame, read_desc_offset, frame_len);
                         break;
 
                     case JDKSAVDECC_DESCRIPTOR_LOCALE:
-                        config_desc_imp_ref->store_locale_desc(this, frame, read_desc_offset, frame_len);
+                        if(config_desc_imp_ref != nullptr)
+                            config_desc_imp_ref->store_locale_desc(this, frame, read_desc_offset, frame_len);
                         break;
 
                     case JDKSAVDECC_DESCRIPTOR_STRINGS:
-                        config_desc_imp_ref->store_strings_desc(this, frame, read_desc_offset, frame_len);
+                        if(config_desc_imp_ref != nullptr)
+                            config_desc_imp_ref->store_strings_desc(this, frame, read_desc_offset, frame_len);
                         break;
 
                     case JDKSAVDECC_DESCRIPTOR_STREAM_PORT_INPUT:
-                        config_desc_imp_ref->store_stream_port_input_desc(this, frame, read_desc_offset, frame_len);
+                        if(config_desc_imp_ref != nullptr)
+                            config_desc_imp_ref->store_stream_port_input_desc(this, frame, read_desc_offset, frame_len);
                         break;
 
                     case JDKSAVDECC_DESCRIPTOR_STREAM_PORT_OUTPUT:
-                        config_desc_imp_ref->store_stream_port_output_desc(this, frame, read_desc_offset, frame_len);
+                        if(config_desc_imp_ref != nullptr)
+                            config_desc_imp_ref->store_stream_port_output_desc(this, frame, read_desc_offset, frame_len);
                         break;
 
                     case JDKSAVDECC_DESCRIPTOR_AUDIO_CLUSTER:
-                        config_desc_imp_ref->store_audio_cluster_desc(this, frame, read_desc_offset, frame_len);
+                        if(config_desc_imp_ref != nullptr)
+                            config_desc_imp_ref->store_audio_cluster_desc(this, frame, read_desc_offset, frame_len);
                         break;
 
                     case JDKSAVDECC_DESCRIPTOR_AUDIO_MAP:
-                        config_desc_imp_ref->store_audio_map_desc(this, frame, read_desc_offset, frame_len);
+                        if(config_desc_imp_ref != nullptr)
+                            config_desc_imp_ref->store_audio_map_desc(this, frame, read_desc_offset, frame_len);
                         break;
 
                     case JDKSAVDECC_DESCRIPTOR_CLOCK_DOMAIN:
-                        config_desc_imp_ref->store_clock_domain_desc(this, frame, read_desc_offset, frame_len);
+                        if(config_desc_imp_ref != nullptr)
+                            config_desc_imp_ref->store_clock_domain_desc(this, frame, read_desc_offset, frame_len);
                         break;
 
                     case JDKSAVDECC_DESCRIPTOR_CONTROL:
-                        config_desc_imp_ref->store_control_desc(this, frame, read_desc_offset, frame_len);
+                        if(config_desc_imp_ref != nullptr)
+                            config_desc_imp_ref->store_control_desc(this, frame, read_desc_offset, frame_len);
                         break;
 
                     case JDKSAVDECC_DESCRIPTOR_EXTERNAL_PORT_INPUT:
-                        config_desc_imp_ref->store_external_port_input_desc(this, frame, read_desc_offset, frame_len);
+                        if(config_desc_imp_ref != nullptr)
+                            config_desc_imp_ref->store_external_port_input_desc(this, frame, read_desc_offset, frame_len);
                         break;
 
                     case JDKSAVDECC_DESCRIPTOR_EXTERNAL_PORT_OUTPUT:
-                        config_desc_imp_ref->store_external_port_output_desc(this, frame, read_desc_offset, frame_len);
+                        if(config_desc_imp_ref != nullptr)
+                            config_desc_imp_ref->store_external_port_output_desc(this, frame, read_desc_offset, frame_len);
                         break;
 
                     default:
@@ -715,9 +733,9 @@ namespace avdecc_lib
         ssize_t aem_cmd_entity_avail_resp_returned = 0;
         uint32_t msg_type = 0;
         bool u_field = false;
-        memset(&aem_cmd_entity_avail_resp,0,sizeof(aem_cmd_entity_avail_resp));
 
         memcpy(cmd_frame.payload, frame, frame_len);
+        memset(&aem_cmd_entity_avail_resp,0,sizeof(aem_cmd_entity_avail_resp));
 
         aem_cmd_entity_avail_resp_returned = jdksavdecc_aem_command_entity_available_response_read(&aem_cmd_entity_avail_resp,
                                                                                                    frame,
@@ -1022,15 +1040,15 @@ namespace avdecc_lib
                 break;
 
             case JDKSAVDECC_AEM_COMMAND_SET_NAME:
-                desc_type = jdksavdecc_aem_command_set_name_response_get_descriptor_type(frame, ETHER_HDR_SIZE);
-                desc_index = jdksavdecc_aem_command_set_name_response_get_descriptor_index(frame, ETHER_HDR_SIZE);
+                //desc_type = jdksavdecc_aem_command_set_name_response_get_descriptor_type(frame, ETHER_HDR_SIZE);
+                //desc_index = jdksavdecc_aem_command_set_name_response_get_descriptor_index(frame, ETHER_HDR_SIZE);
                 log_imp_ref->post_log_msg(LOGGING_LEVEL_ERROR, "Need to implement SET_NAME command.");
 
                 break;
 
             case JDKSAVDECC_AEM_COMMAND_GET_NAME:
-                desc_type = jdksavdecc_aem_command_get_name_response_get_descriptor_type(frame, ETHER_HDR_SIZE);
-                desc_index = jdksavdecc_aem_command_get_name_response_get_descriptor_index(frame, ETHER_HDR_SIZE);
+                //desc_type = jdksavdecc_aem_command_get_name_response_get_descriptor_type(frame, ETHER_HDR_SIZE);
+                //desc_index = jdksavdecc_aem_command_get_name_response_get_descriptor_index(frame, ETHER_HDR_SIZE);
                 log_imp_ref->post_log_msg(LOGGING_LEVEL_ERROR, "Need to implement GET_NAME command.");
 
                 break;
@@ -1136,7 +1154,7 @@ namespace avdecc_lib
 
             case JDKSAVDECC_AEM_COMMAND_SET_CLOCK_SOURCE:
                 {
-                    desc_type = jdksavdecc_aem_command_set_clock_source_response_get_descriptor_type(frame, ETHER_HDR_SIZE);
+                    //desc_type = jdksavdecc_aem_command_set_clock_source_response_get_descriptor_type(frame, ETHER_HDR_SIZE);
                     desc_index = jdksavdecc_aem_command_set_clock_source_response_get_descriptor_index(frame, ETHER_HDR_SIZE);
 
                     clock_domain_descriptor_imp *clock_domain_desc_imp_ref =
@@ -1155,7 +1173,7 @@ namespace avdecc_lib
 
             case JDKSAVDECC_AEM_COMMAND_GET_CLOCK_SOURCE:
                 {
-                    desc_type = jdksavdecc_aem_command_get_clock_source_response_get_descriptor_type(frame, ETHER_HDR_SIZE);
+                    //desc_type = jdksavdecc_aem_command_get_clock_source_response_get_descriptor_type(frame, ETHER_HDR_SIZE);
                     desc_index = jdksavdecc_aem_command_get_clock_source_response_get_descriptor_index(frame, ETHER_HDR_SIZE);
 
                     clock_domain_descriptor_imp *clock_domain_desc_imp_ref =
@@ -1247,7 +1265,7 @@ namespace avdecc_lib
             case JDKSAVDECC_AEM_COMMAND_REBOOT:
                 {
                     desc_type = jdksavdecc_aem_command_reboot_get_descriptor_type(frame, ETHER_HDR_SIZE);
-                    desc_index = jdksavdecc_aem_command_reboot_get_descriptor_index(frame, ETHER_HDR_SIZE);
+                    //desc_index = jdksavdecc_aem_command_reboot_get_descriptor_index(frame, ETHER_HDR_SIZE);
 
                     if(desc_type == JDKSAVDECC_DESCRIPTOR_ENTITY)
                     {
@@ -1518,8 +1536,8 @@ namespace avdecc_lib
         uint32_t msg_type = 0;
         bool u_field = false;
         
-        memset(&aem_cmd_dereg_unsolicited_resp, 0, sizeof(aem_cmd_dereg_unsolicited_resp));
         memcpy(cmd_frame.payload, frame, frame_len);
+        memset(&aem_cmd_dereg_unsolicited_resp, 0, sizeof(aem_cmd_dereg_unsolicited_resp));
         
         aem_cmd_dereg_unsolicited_returned = jdksavdecc_aem_command_deregister_unsolicited_notification_response_read(&aem_cmd_dereg_unsolicited_resp,
                                                                                                                   frame,

--- a/controller/lib/src/end_station_imp.cpp
+++ b/controller/lib/src/end_station_imp.cpp
@@ -586,7 +586,7 @@ namespace avdecc_lib
                     JDKSAVDECC_DESCRIPTOR_STRINGS,
                     0,
                     ldr->number_of_strings());
-                free(ldr);
+                delete ldr;
                 break;
 
             case JDKSAVDECC_DESCRIPTOR_AUDIO_UNIT:
@@ -617,7 +617,7 @@ namespace avdecc_lib
                     aud->base_control_block(),
                     aud->number_of_control_blocks());
                 // TODO: other descriptor types in AUDIO_UNIT
-                free(aud);
+                delete aud;
                 break;
 
             case JDKSAVDECC_DESCRIPTOR_STREAM_PORT_INPUT:
@@ -637,7 +637,7 @@ namespace avdecc_lib
                     JDKSAVDECC_DESCRIPTOR_AUDIO_MAP,
                     spid->base_map(),
                     spid->number_of_maps());
-                free(spid);
+                delete spid;
                 break;
 
             case JDKSAVDECC_DESCRIPTOR_STREAM_PORT_OUTPUT:
@@ -657,7 +657,7 @@ namespace avdecc_lib
                     JDKSAVDECC_DESCRIPTOR_AUDIO_MAP,
                     spod->base_map(),
                     spod->number_of_maps());
-                free(spod);
+                delete spod;
                 break;
         }
     }

--- a/controller/lib/src/end_station_imp.h
+++ b/controller/lib/src/end_station_imp.h
@@ -28,6 +28,7 @@
  */
 
 #pragma once
+#include <mutex>
 #include <list>
 
 #include "entity_descriptor_imp.h"

--- a/controller/lib/src/end_station_imp.h
+++ b/controller/lib/src/end_station_imp.h
@@ -76,6 +76,7 @@ namespace avdecc_lib
         end_station_imp(const uint8_t *frame, size_t frame_len);
         virtual ~end_station_imp();
 
+        std::mutex locker;
         const char STDCALL get_connection_status() const;
 
         /**

--- a/controller/lib/src/entity_descriptor_imp.cpp
+++ b/controller/lib/src/entity_descriptor_imp.cpp
@@ -35,15 +35,10 @@
 #include "aecp_controller_state_machine.h"
 #include "adp.h"
 #include "system_tx_queue.h"
-#include "util.h"
 
 namespace avdecc_lib
 {
-    entity_descriptor_imp::entity_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos)
-    {
-        m_type = jdksavdecc_descriptor_entity_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
-        m_index = jdksavdecc_descriptor_entity_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
-    }
+    entity_descriptor_imp::entity_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos) {}
 
     entity_descriptor_imp::~entity_descriptor_imp()
     {
@@ -55,14 +50,14 @@ namespace avdecc_lib
 
     uint16_t STDCALL entity_descriptor_imp::descriptor_type() const
     {
-        assert(m_type == JDKSAVDECC_DESCRIPTOR_ENTITY);
-        return m_type;
+        assert(jdksavdecc_descriptor_entity_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos()) == JDKSAVDECC_DESCRIPTOR_ENTITY);
+        return jdksavdecc_descriptor_entity_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 
     uint16_t STDCALL entity_descriptor_imp::descriptor_index() const
     {
-        assert(m_index == 0);
-        return m_index;
+        assert(jdksavdecc_descriptor_entity_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos()) == 0);
+        return jdksavdecc_descriptor_entity_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
     }
     
     uint16_t STDCALL entity_descriptor_imp::current_configuration()
@@ -74,7 +69,7 @@ namespace avdecc_lib
     {
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
         return resp = new entity_descriptor_response_imp(resp_ref->get_buffer(),
-                                                                resp_ref->get_size(), resp_ref->get_pos());
+                                                         resp_ref->get_size(), resp_ref->get_pos());
     }
 
     void entity_descriptor_imp::store_config_desc(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len)

--- a/controller/lib/src/entity_descriptor_imp.cpp
+++ b/controller/lib/src/entity_descriptor_imp.cpp
@@ -27,7 +27,9 @@
  * ENTITY descriptor implementation
  */
 
+#include <mutex>
 #include <vector>
+
 #include "enumeration.h"
 #include "log_imp.h"
 #include "end_station_imp.h"

--- a/controller/lib/src/entity_descriptor_imp.cpp
+++ b/controller/lib/src/entity_descriptor_imp.cpp
@@ -48,18 +48,6 @@ namespace avdecc_lib
         }
     }
 
-    uint16_t STDCALL entity_descriptor_imp::descriptor_type() const
-    {
-        assert(jdksavdecc_descriptor_entity_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos()) == JDKSAVDECC_DESCRIPTOR_ENTITY);
-        return jdksavdecc_descriptor_entity_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
-    }
-
-    uint16_t STDCALL entity_descriptor_imp::descriptor_index() const
-    {
-        assert(jdksavdecc_descriptor_entity_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos()) == 0);
-        return jdksavdecc_descriptor_entity_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
-    }
-    
     uint16_t STDCALL entity_descriptor_imp::current_configuration()
     {
         return jdksavdecc_descriptor_entity_get_current_configuration(resp_ref->get_buffer(), resp_ref->get_pos());
@@ -68,8 +56,8 @@ namespace avdecc_lib
     entity_descriptor_response * STDCALL entity_descriptor_imp::get_entity_response()
     {
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
-        return resp = new entity_descriptor_response_imp(resp_ref->get_buffer(),
-                                                         resp_ref->get_size(), resp_ref->get_pos());
+        return resp = new entity_descriptor_response_imp(resp_ref->get_desc_buffer(),
+                                                         resp_ref->get_desc_size(), resp_ref->get_desc_pos());
     }
 
     void entity_descriptor_imp::store_config_desc(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len)

--- a/controller/lib/src/entity_descriptor_imp.h
+++ b/controller/lib/src/entity_descriptor_imp.h
@@ -43,8 +43,6 @@ namespace avdecc_lib
         struct jdksavdecc_aem_command_acquire_entity_response aem_cmd_acquire_entity_resp; // Store the response received after sending a ACQUIRE_ENTITY command.
         struct jdksavdecc_aem_command_lock_entity_response aem_cmd_lock_entity_resp; // Store the response received after sending a LOCK_ENTITY command.
         struct jdksavdecc_aem_command_reboot_response aem_cmd_reboot_resp;
-        uint16_t m_type;
-        uint16_t m_index;
     public:
         entity_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
         virtual ~entity_descriptor_imp();

--- a/controller/lib/src/entity_descriptor_imp.h
+++ b/controller/lib/src/entity_descriptor_imp.h
@@ -32,48 +32,32 @@
 #include "descriptor_base_imp.h"
 #include "configuration_descriptor_imp.h"
 #include "entity_descriptor.h"
+#include "entity_descriptor_response_imp.h"
 
 namespace avdecc_lib
 {
     class entity_descriptor_imp : public entity_descriptor, public virtual descriptor_base_imp
     {
     private:
-        struct jdksavdecc_descriptor_entity entity_desc; // Structure containing the entity_desc fields
-        ssize_t desc_entity_read_returned; // Status of extracting ENTITY descriptor information from a network buffer
         std::vector<configuration_descriptor_imp *> config_desc_vec; // Store a list of CONFIGURATION descriptor objects
-
         struct jdksavdecc_aem_command_acquire_entity_response aem_cmd_acquire_entity_resp; // Store the response received after sending a ACQUIRE_ENTITY command.
         struct jdksavdecc_aem_command_lock_entity_response aem_cmd_lock_entity_resp; // Store the response received after sending a LOCK_ENTITY command.
         struct jdksavdecc_aem_command_reboot_response aem_cmd_reboot_resp;
-
+        uint16_t m_type;
+        uint16_t m_index;
     public:
         entity_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
         virtual ~entity_descriptor_imp();
+        
+        entity_descriptor_response_imp *resp;
 
         uint16_t STDCALL descriptor_type() const;
         uint16_t STDCALL descriptor_index() const;
-        uint64_t STDCALL entity_id();
-        uint32_t STDCALL vendor_id();
-        uint32_t STDCALL entity_model_id();
-        uint32_t STDCALL entity_capabilities();
-        uint16_t STDCALL talker_stream_sources();
-        uint16_t STDCALL talker_capabilities();
-        uint16_t STDCALL listener_stream_sinks();
-        uint16_t STDCALL listener_capabilities();
-        uint32_t STDCALL controller_capabilities();
-        uint32_t STDCALL available_index();
-        uint64_t STDCALL association_id();
-        uint8_t * STDCALL entity_name();
-        uint16_t STDCALL vendor_name_string();
-        uint16_t STDCALL model_name_string();
-        uint8_t * STDCALL firmware_version();
-        uint8_t * STDCALL group_name();
-        uint8_t * STDCALL serial_number();
-        uint16_t STDCALL configurations_count();
         uint16_t STDCALL current_configuration();
         void store_config_desc(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
         size_t STDCALL config_desc_count();
         configuration_descriptor * STDCALL get_config_desc_by_index(uint16_t config_desc_index);
+        entity_descriptor_response * STDCALL get_entity_response();
         uint32_t STDCALL acquire_entity_flags();
         uint64_t STDCALL acquire_entity_owner_entity_id();
         uint32_t STDCALL lock_entity_flags();
@@ -95,4 +79,3 @@ namespace avdecc_lib
         int proc_get_config_resp();
     };
 }
-

--- a/controller/lib/src/entity_descriptor_imp.h
+++ b/controller/lib/src/entity_descriptor_imp.h
@@ -49,8 +49,6 @@ namespace avdecc_lib
         
         entity_descriptor_response_imp *resp;
 
-        uint16_t STDCALL descriptor_type() const;
-        uint16_t STDCALL descriptor_index() const;
         uint16_t STDCALL current_configuration();
         void store_config_desc(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
         size_t STDCALL config_desc_count();

--- a/controller/lib/src/entity_descriptor_response_imp.cpp
+++ b/controller/lib/src/entity_descriptor_response_imp.cpp
@@ -1,0 +1,158 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * entity_descriptor_response_imp.cpp
+ *
+ * ENTITY descriptor response implementation
+ */
+
+#include <vector>
+#include "enumeration.h"
+#include "log_imp.h"
+#include "end_station_imp.h"
+#include "entity_descriptor_response_imp.h"
+#include "aecp_controller_state_machine.h"
+#include "adp.h"
+#include "system_tx_queue.h"
+#include "util.h"
+
+namespace avdecc_lib
+{
+    entity_descriptor_response_imp::entity_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos) : descriptor_base_imp(nullptr, frame, frame_len, pos)
+    {
+        frame_size = frame_len;
+        buffer = (uint8_t *)malloc(frame_size * sizeof(uint8_t));
+        memcpy(buffer, frame, frame_size);
+        position = pos;
+    }
+    
+    entity_descriptor_response_imp::~entity_descriptor_response_imp() {}
+
+    uint64_t STDCALL entity_descriptor_response_imp::entity_id()
+    {
+        uint64_t entity_id;
+        return entity_id = jdksavdecc_uint64_get(&buffer[position +
+                                                JDKSAVDECC_DESCRIPTOR_ENTITY_OFFSET_ENTITY_ENTITY_ID], 0);
+    }
+    
+    uint32_t STDCALL entity_descriptor_response_imp::vendor_id()
+    {
+        return jdksavdecc_descriptor_entity_get_vendor_id(buffer, position);
+    }
+    
+    uint32_t STDCALL entity_descriptor_response_imp::entity_model_id()
+    {
+        return jdksavdecc_descriptor_entity_get_entity_model_id(buffer, position);
+    }
+    
+    uint32_t STDCALL entity_descriptor_response_imp::entity_capabilities()
+    {
+        return jdksavdecc_descriptor_entity_get_entity_capabilities(buffer, position);
+    }
+    
+    uint16_t STDCALL entity_descriptor_response_imp::talker_stream_sources()
+    {
+        return jdksavdecc_descriptor_entity_get_talker_stream_sources(buffer, position);
+    }
+    
+    uint16_t STDCALL entity_descriptor_response_imp::talker_capabilities()
+    {
+        return jdksavdecc_descriptor_entity_get_talker_capabilities(buffer, position);
+    }
+    
+    uint16_t STDCALL entity_descriptor_response_imp::listener_stream_sinks()
+    {
+        return jdksavdecc_descriptor_entity_get_listener_stream_sinks(buffer, position);
+    }
+    
+    uint16_t STDCALL entity_descriptor_response_imp::listener_capabilities()
+    {
+        return jdksavdecc_descriptor_entity_get_listener_capabilities(buffer, position);
+    }
+    
+    uint32_t STDCALL entity_descriptor_response_imp::controller_capabilities()
+    {
+        return jdksavdecc_descriptor_entity_get_controller_capabilities(buffer, position);
+    }
+    
+    uint32_t STDCALL entity_descriptor_response_imp::available_index()
+    {
+        return jdksavdecc_descriptor_entity_get_available_index(buffer, position);
+    }
+    
+    uint64_t STDCALL entity_descriptor_response_imp::association_id()
+    {
+        uint64_t association_id;
+        
+        utility::convert_eui48_to_uint64(&buffer[position +
+                                                 JDKSAVDECC_DESCRIPTOR_ENTITY_OFFSET_ASSOCIATION_ID], association_id);
+        
+        return association_id;
+
+    }
+    
+    uint8_t * STDCALL entity_descriptor_response_imp::entity_name()
+    {
+        return (uint8_t *)&buffer[position + JDKSAVDECC_DESCRIPTOR_ENTITY_OFFSET_ENTITY_NAME];
+    }
+    
+    uint16_t STDCALL entity_descriptor_response_imp::vendor_name_string()
+    {
+        return jdksavdecc_descriptor_entity_get_vendor_name_string(buffer, position);
+    }
+    
+    uint16_t STDCALL entity_descriptor_response_imp::model_name_string()
+    {
+        return jdksavdecc_descriptor_entity_get_model_name_string(buffer, position);
+    }
+    
+    uint8_t * STDCALL entity_descriptor_response_imp::firmware_version()
+    {
+        return (uint8_t *)&buffer[position + JDKSAVDECC_DESCRIPTOR_ENTITY_OFFSET_FIRMWARE_VERSION];
+    }
+    
+    uint8_t * STDCALL entity_descriptor_response_imp::group_name()
+    {
+        return (uint8_t *)&buffer[position + JDKSAVDECC_DESCRIPTOR_ENTITY_OFFSET_GROUP_NAME];
+    }
+    
+    uint8_t * STDCALL entity_descriptor_response_imp::serial_number()
+    {
+        return (uint8_t *)&buffer[position + JDKSAVDECC_DESCRIPTOR_ENTITY_OFFSET_SERIAL_NUMBER];
+    }
+    
+    uint16_t STDCALL entity_descriptor_response_imp::configurations_count()
+    {
+        uint16_t configurations_count;
+        
+        configurations_count = jdksavdecc_descriptor_entity_get_configurations_count(buffer, position);
+        assert(configurations_count >= 1);
+        return configurations_count;
+    }
+    
+    uint16_t STDCALL entity_descriptor_response_imp::current_configuration()
+    {
+        return jdksavdecc_descriptor_entity_get_current_configuration(buffer, position);
+    }
+}

--- a/controller/lib/src/entity_descriptor_response_imp.cpp
+++ b/controller/lib/src/entity_descriptor_response_imp.cpp
@@ -39,7 +39,7 @@
 
 namespace avdecc_lib
 {
-    entity_descriptor_response_imp::entity_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos) : descriptor_base_imp(nullptr, frame, frame_len, pos)
+    entity_descriptor_response_imp::entity_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos)
     {
         frame_size = frame_len;
         buffer = (uint8_t *)malloc(frame_size * sizeof(uint8_t));
@@ -47,7 +47,10 @@ namespace avdecc_lib
         position = pos;
     }
     
-    entity_descriptor_response_imp::~entity_descriptor_response_imp() {}
+    entity_descriptor_response_imp::~entity_descriptor_response_imp()
+    {
+        free(buffer);
+    }
 
     uint64_t STDCALL entity_descriptor_response_imp::entity_id()
     {
@@ -107,9 +110,7 @@ namespace avdecc_lib
         
         utility::convert_eui48_to_uint64(&buffer[position +
                                                  JDKSAVDECC_DESCRIPTOR_ENTITY_OFFSET_ASSOCIATION_ID], association_id);
-        
         return association_id;
-
     }
     
     uint8_t * STDCALL entity_descriptor_response_imp::entity_name()

--- a/controller/lib/src/entity_descriptor_response_imp.h
+++ b/controller/lib/src/entity_descriptor_response_imp.h
@@ -29,13 +29,13 @@
 
 #pragma once
 
-#include "descriptor_base_imp.h"
 #include "configuration_descriptor_imp.h"
 #include "entity_descriptor_response.h"
+#include "jdksavdecc_aem_descriptor.h"
 
 namespace avdecc_lib
 {
-    class entity_descriptor_response_imp : public entity_descriptor_response, public virtual descriptor_base_imp
+    class entity_descriptor_response_imp : public entity_descriptor_response
     {
     private:
         uint8_t * buffer;

--- a/controller/lib/src/entity_descriptor_response_imp.h
+++ b/controller/lib/src/entity_descriptor_response_imp.h
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * entity_descriptor_response_imp.h
+ *
+ * ENTITY descriptor repsonse implementation class
+ */
+
+#pragma once
+
+#include "descriptor_base_imp.h"
+#include "configuration_descriptor_imp.h"
+#include "entity_descriptor_response.h"
+
+namespace avdecc_lib
+{
+    class entity_descriptor_response_imp : public entity_descriptor_response, public virtual descriptor_base_imp
+    {
+    private:
+        uint8_t * buffer;
+        ssize_t position;
+        size_t frame_size;
+    public:
+        entity_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos);
+        virtual ~entity_descriptor_response_imp();
+
+        uint64_t STDCALL entity_id();
+        uint32_t STDCALL vendor_id();
+        uint32_t STDCALL entity_model_id();
+        uint32_t STDCALL entity_capabilities();
+        uint16_t STDCALL talker_stream_sources();
+        uint16_t STDCALL talker_capabilities();
+        uint16_t STDCALL listener_stream_sinks();
+        uint16_t STDCALL listener_capabilities();
+        uint32_t STDCALL controller_capabilities();
+        uint32_t STDCALL available_index();
+        uint64_t STDCALL association_id();
+        uint8_t * STDCALL entity_name();
+        uint16_t STDCALL vendor_name_string();
+        uint16_t STDCALL model_name_string();
+        uint8_t * STDCALL firmware_version();
+        uint8_t * STDCALL group_name();
+        uint8_t * STDCALL serial_number();
+        uint16_t STDCALL configurations_count();
+        uint16_t STDCALL current_configuration();
+    };
+}
+

--- a/controller/lib/src/external_port_input_descriptor_imp.cpp
+++ b/controller/lib/src/external_port_input_descriptor_imp.cpp
@@ -36,14 +36,10 @@
 
 namespace avdecc_lib
 {
-    external_port_input_descriptor_imp::external_port_input_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos)
-    {
-        m_type = jdksavdecc_descriptor_external_port_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
-        m_index = jdksavdecc_descriptor_external_port_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
-    }
+    external_port_input_descriptor_imp::external_port_input_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos) {}
 
     external_port_input_descriptor_imp::~external_port_input_descriptor_imp() {}
-    
+
     external_port_input_descriptor_response * STDCALL external_port_input_descriptor_imp::get_external_port_input_response()
     {
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
@@ -53,12 +49,12 @@ namespace avdecc_lib
 
     uint16_t STDCALL external_port_input_descriptor_imp::descriptor_type() const
     {
-        assert(m_type == JDKSAVDECC_DESCRIPTOR_EXTERNAL_PORT_INPUT);
-        return m_type;
+        assert(jdksavdecc_descriptor_external_port_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos()) == JDKSAVDECC_DESCRIPTOR_EXTERNAL_PORT_INPUT);
+        return jdksavdecc_descriptor_external_port_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 
     uint16_t STDCALL external_port_input_descriptor_imp::descriptor_index() const
     {
-        return m_index;
+        return jdksavdecc_descriptor_external_port_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 }

--- a/controller/lib/src/external_port_input_descriptor_imp.cpp
+++ b/controller/lib/src/external_port_input_descriptor_imp.cpp
@@ -36,86 +36,29 @@
 
 namespace avdecc_lib
 {
-    external_port_input_descriptor_imp::external_port_input_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj)
+    external_port_input_descriptor_imp::external_port_input_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos)
     {
-        ssize_t ret = jdksavdecc_descriptor_external_port_read(&desc, frame, pos, frame_len);
-
-        if (ret < 0)
-        {
-            throw avdecc_read_descriptor_error("jdksavdecc_descriptor_external_port_read error");
-        }
-
-		// fields
-		descriptor_field_imp *f;
-
-		m_fields.push_back(new descriptor_field_imp("clock_domain_index", descriptor_field::TYPE_UINT16, &desc.clock_domain_index));
-
-		f = new descriptor_field_imp("port_flags", descriptor_field::TYPE_FLAGS16, &desc.port_flags);
-		f->append_field(new descriptor_field_flags_imp("CLOCK_SYNC_SOURCE", 1 << 15));
-		f->append_field(new descriptor_field_flags_imp("ASYNC_SAMPLE_RATE_CONVERTER", 1 << 14));
-		f->append_field(new descriptor_field_flags_imp("SYNC_SAMPLE_RATE_CONVERTER", 1 << 13));
-		m_fields.push_back(f);
-
-		m_fields.push_back(new descriptor_field_imp("number_of_controls", descriptor_field::TYPE_UINT16, &desc.number_of_controls));
-		m_fields.push_back(new descriptor_field_imp("base_control", descriptor_field::TYPE_UINT16, &desc.base_control));
-
-		m_fields.push_back(new descriptor_field_imp("signal_type", descriptor_field::TYPE_UINT16, &desc.signal_type));
-		m_fields.push_back(new descriptor_field_imp("signal_index", descriptor_field::TYPE_UINT16, &desc.signal_index));
-		m_fields.push_back(new descriptor_field_imp("signal_output", descriptor_field::TYPE_UINT16, &desc.signal_output));
-
-		m_fields.push_back(new descriptor_field_imp("block_latency", descriptor_field::TYPE_UINT16, &desc.block_latency));
-		m_fields.push_back(new descriptor_field_imp("jack_index", descriptor_field::TYPE_UINT16, &desc.jack_index));
- }
+        m_type = jdksavdecc_descriptor_external_port_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
+        m_index = jdksavdecc_descriptor_external_port_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
+    }
 
     external_port_input_descriptor_imp::~external_port_input_descriptor_imp() {}
+    
+    external_port_input_descriptor_response * STDCALL external_port_input_descriptor_imp::get_external_port_input_response()
+    {
+        std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
+        return resp = new external_port_input_descriptor_response_imp(resp_ref->get_buffer(),
+                                                         resp_ref->get_size(), resp_ref->get_pos());
+    }
 
     uint16_t STDCALL external_port_input_descriptor_imp::descriptor_type() const
     {
-        assert(desc.descriptor_type == JDKSAVDECC_DESCRIPTOR_EXTERNAL_PORT_INPUT);
-        return desc.descriptor_type;
+        assert(m_type == JDKSAVDECC_DESCRIPTOR_EXTERNAL_PORT_INPUT);
+        return m_type;
     }
 
     uint16_t STDCALL external_port_input_descriptor_imp::descriptor_index() const
     {
-        return desc.descriptor_index;
+        return m_index;
     }
-
-    uint16_t STDCALL external_port_input_descriptor_imp::port_flags()
-    {
-        return desc.port_flags;
-    }
-    uint16_t STDCALL external_port_input_descriptor_imp::clock_domain_index()
-    {
-        return desc.clock_domain_index;
-    }
-    uint16_t STDCALL external_port_input_descriptor_imp::number_of_controls()
-    {
-        return desc.number_of_controls;
-    }
-    uint16_t STDCALL external_port_input_descriptor_imp::base_control()
-    {
-        return desc.base_control;
-    }
-    uint16_t STDCALL external_port_input_descriptor_imp::signal_type()
-    {
-        return desc.signal_type;
-    }
-    uint16_t STDCALL external_port_input_descriptor_imp::signal_index()
-    {
-        return desc.signal_index;
-    }
-    uint16_t STDCALL external_port_input_descriptor_imp::signal_output()
-    {
-        return desc.signal_output;
-    }
-    uint32_t STDCALL external_port_input_descriptor_imp::block_latency()
-    {
-        return desc.block_latency;
-    }
-    uint16_t STDCALL external_port_input_descriptor_imp::jack_index()
-    {
-        return desc.jack_index;
-    }
-
-
 }

--- a/controller/lib/src/external_port_input_descriptor_imp.cpp
+++ b/controller/lib/src/external_port_input_descriptor_imp.cpp
@@ -43,18 +43,7 @@ namespace avdecc_lib
     external_port_input_descriptor_response * STDCALL external_port_input_descriptor_imp::get_external_port_input_response()
     {
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
-        return resp = new external_port_input_descriptor_response_imp(resp_ref->get_buffer(),
-                                                         resp_ref->get_size(), resp_ref->get_pos());
-    }
-
-    uint16_t STDCALL external_port_input_descriptor_imp::descriptor_type() const
-    {
-        assert(jdksavdecc_descriptor_external_port_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos()) == JDKSAVDECC_DESCRIPTOR_EXTERNAL_PORT_INPUT);
-        return jdksavdecc_descriptor_external_port_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
-    }
-
-    uint16_t STDCALL external_port_input_descriptor_imp::descriptor_index() const
-    {
-        return jdksavdecc_descriptor_external_port_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
+        return resp = new external_port_input_descriptor_response_imp(resp_ref->get_desc_buffer(),
+                                                                      resp_ref->get_desc_size(), resp_ref->get_desc_pos());
     }
 }

--- a/controller/lib/src/external_port_input_descriptor_imp.cpp
+++ b/controller/lib/src/external_port_input_descriptor_imp.cpp
@@ -27,6 +27,8 @@
  * EXTERNAL_PORT_INPUT descriptor implementation
  */
 
+#include <mutex>
+
 #include "avdecc_error.h"
 #include "enumeration.h"
 #include "log_imp.h"

--- a/controller/lib/src/external_port_input_descriptor_imp.h
+++ b/controller/lib/src/external_port_input_descriptor_imp.h
@@ -44,9 +44,7 @@ namespace avdecc_lib
         virtual ~external_port_input_descriptor_imp();
 
         external_port_input_descriptor_response_imp *resp;
-        
-        uint16_t STDCALL descriptor_type() const;
-        uint16_t STDCALL descriptor_index() const;
+
         external_port_input_descriptor_response * STDCALL get_external_port_input_response();
     };
 }

--- a/controller/lib/src/external_port_input_descriptor_imp.h
+++ b/controller/lib/src/external_port_input_descriptor_imp.h
@@ -39,9 +39,6 @@ namespace avdecc_lib
 {
     class external_port_input_descriptor_imp : public external_port_input_descriptor, public virtual descriptor_base_imp
     {
-    private:
-        uint16_t m_type;
-        uint16_t m_index;
     public:
         external_port_input_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
         virtual ~external_port_input_descriptor_imp();

--- a/controller/lib/src/external_port_input_descriptor_imp.h
+++ b/controller/lib/src/external_port_input_descriptor_imp.h
@@ -33,29 +33,24 @@
 #include "build.h"
 #include "descriptor_base_imp.h"
 #include "external_port_input_descriptor.h"
+#include "external_port_input_descriptor_response_imp.h"
 
 namespace avdecc_lib
 {
     class external_port_input_descriptor_imp : public external_port_input_descriptor, public virtual descriptor_base_imp
     {
     private:
-        struct jdksavdecc_descriptor_external_port desc;
+        uint16_t m_type;
+        uint16_t m_index;
     public:
         external_port_input_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
         virtual ~external_port_input_descriptor_imp();
 
+        external_port_input_descriptor_response_imp *resp;
+        
         uint16_t STDCALL descriptor_type() const;
         uint16_t STDCALL descriptor_index() const;
-
-        uint16_t STDCALL port_flags();
-        uint16_t STDCALL clock_domain_index();
-        uint16_t STDCALL number_of_controls();
-        uint16_t STDCALL base_control();
-        uint16_t STDCALL signal_type();
-        uint16_t STDCALL signal_index();
-        uint16_t STDCALL signal_output();
-        uint32_t STDCALL block_latency();
-        uint16_t STDCALL jack_index();
+        external_port_input_descriptor_response * STDCALL get_external_port_input_response();
     };
 }
 

--- a/controller/lib/src/external_port_input_descriptor_response_imp.cpp
+++ b/controller/lib/src/external_port_input_descriptor_response_imp.cpp
@@ -72,7 +72,10 @@ namespace avdecc_lib
         m_fields.push_back(new descriptor_field_imp("jack_index", descriptor_field::TYPE_UINT16, &desc.jack_index));
     }
     
-    external_port_input_descriptor_response_imp::~external_port_input_descriptor_response_imp() {}
+    external_port_input_descriptor_response_imp::~external_port_input_descriptor_response_imp()
+    {
+        free(buffer);
+    }
     
     uint16_t STDCALL external_port_input_descriptor_response_imp::clock_domain_index()
     {

--- a/controller/lib/src/external_port_input_descriptor_response_imp.cpp
+++ b/controller/lib/src/external_port_input_descriptor_response_imp.cpp
@@ -1,0 +1,121 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * external_port_input_descriptor_response_imp.cpp
+ *
+ * EXTERNAL_PORT_INPUT descriptor response implementation
+ */
+
+#include "avdecc_error.h"
+#include "enumeration.h"
+#include "log_imp.h"
+#include "end_station_imp.h"
+#include "external_port_input_descriptor_response_imp.h"
+#include "descriptor_field_imp.h"
+
+namespace avdecc_lib
+{
+    external_port_input_descriptor_response_imp::external_port_input_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos) : descriptor_base_imp(nullptr, frame, frame_len, pos)
+    {
+        ssize_t ret = jdksavdecc_descriptor_external_port_read(&desc, frame, pos, frame_len);
+        
+        if (ret < 0)
+        {
+            throw avdecc_read_descriptor_error("jdksavdecc_descriptor_external_port_read error");
+        }
+
+        frame_size = frame_len;
+        buffer = (uint8_t *)malloc(frame_size * sizeof(uint8_t));
+        memcpy(buffer, frame, frame_size);
+        position = pos;
+        
+        // fields
+        descriptor_field_imp *f;
+        
+        m_fields.push_back(new descriptor_field_imp("clock_domain_index", descriptor_field::TYPE_UINT16, &desc.clock_domain_index));
+        
+        f = new descriptor_field_imp("port_flags", descriptor_field::TYPE_FLAGS16, &desc.port_flags);
+        f->append_field(new descriptor_field_flags_imp("CLOCK_SYNC_SOURCE", 1 << 15));
+        f->append_field(new descriptor_field_flags_imp("ASYNC_SAMPLE_RATE_CONVERTER", 1 << 14));
+        f->append_field(new descriptor_field_flags_imp("SYNC_SAMPLE_RATE_CONVERTER", 1 << 13));
+        m_fields.push_back(f);
+        
+        m_fields.push_back(new descriptor_field_imp("number_of_controls", descriptor_field::TYPE_UINT16, &desc.number_of_controls));
+        m_fields.push_back(new descriptor_field_imp("base_control", descriptor_field::TYPE_UINT16, &desc.base_control));
+        
+        m_fields.push_back(new descriptor_field_imp("signal_type", descriptor_field::TYPE_UINT16, &desc.signal_type));
+        m_fields.push_back(new descriptor_field_imp("signal_index", descriptor_field::TYPE_UINT16, &desc.signal_index));
+        m_fields.push_back(new descriptor_field_imp("signal_output", descriptor_field::TYPE_UINT16, &desc.signal_output));
+        
+        m_fields.push_back(new descriptor_field_imp("block_latency", descriptor_field::TYPE_UINT16, &desc.block_latency));
+        m_fields.push_back(new descriptor_field_imp("jack_index", descriptor_field::TYPE_UINT16, &desc.jack_index));
+    }
+    
+    external_port_input_descriptor_response_imp::~external_port_input_descriptor_response_imp() {}
+    
+    uint16_t STDCALL external_port_input_descriptor_response_imp::clock_domain_index()
+    {
+        return jdksavdecc_descriptor_external_port_get_clock_domain_index(buffer, position);
+    }
+    
+    uint16_t STDCALL external_port_input_descriptor_response_imp::port_flags()
+    {
+        return jdksavdecc_descriptor_external_port_get_port_flags(buffer, position);
+    }
+    
+    uint16_t STDCALL external_port_input_descriptor_response_imp::number_of_controls()
+    {
+        return jdksavdecc_descriptor_external_port_get_number_of_controls(buffer, position);
+    }
+    
+    uint16_t STDCALL external_port_input_descriptor_response_imp::base_control()
+    {
+        return jdksavdecc_descriptor_external_port_get_base_control(buffer, position);
+    }
+    
+    uint16_t STDCALL external_port_input_descriptor_response_imp::signal_type()
+    {
+        return jdksavdecc_descriptor_external_port_get_signal_type(buffer, position);
+    }
+    
+    uint16_t STDCALL external_port_input_descriptor_response_imp::signal_index()
+    {
+        return jdksavdecc_descriptor_external_port_get_signal_index(buffer, position);
+    }
+    
+    uint16_t STDCALL external_port_input_descriptor_response_imp::signal_output()
+    {
+        return jdksavdecc_descriptor_external_port_get_signal_output(buffer, position);
+    }
+    
+    uint32_t STDCALL external_port_input_descriptor_response_imp::block_latency()
+    {
+        return jdksavdecc_descriptor_external_port_get_block_latency(buffer, position);
+    }
+    
+    uint16_t STDCALL external_port_input_descriptor_response_imp::jack_index()
+    {
+        return jdksavdecc_descriptor_external_port_get_jack_index(buffer, position);
+    }
+}

--- a/controller/lib/src/external_port_input_descriptor_response_imp.h
+++ b/controller/lib/src/external_port_input_descriptor_response_imp.h
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * external_port_input_descriptor_response_imp.h
+ *
+ * Public EXTERNAL PORT INPUT descriptor response implementation class
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "build.h"
+#include "descriptor_base_imp.h"
+#include "external_port_input_descriptor_response.h"
+
+namespace avdecc_lib
+{
+    class external_port_input_descriptor_response_imp : public external_port_input_descriptor_response, public virtual descriptor_base_imp
+    {
+    private:
+        struct jdksavdecc_descriptor_external_port desc;
+        uint8_t * buffer;
+        ssize_t position;
+        size_t frame_size;
+    public:
+        external_port_input_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos);
+        virtual ~external_port_input_descriptor_response_imp();
+        
+        uint16_t STDCALL port_flags();
+        uint16_t STDCALL clock_domain_index();
+        uint16_t STDCALL number_of_controls();
+        uint16_t STDCALL base_control();
+        uint16_t STDCALL signal_type();
+        uint16_t STDCALL signal_index();
+        uint16_t STDCALL signal_output();
+        uint32_t STDCALL block_latency();
+        uint16_t STDCALL jack_index();
+    };
+}

--- a/controller/lib/src/external_port_input_descriptor_response_imp.h
+++ b/controller/lib/src/external_port_input_descriptor_response_imp.h
@@ -33,6 +33,7 @@
 #include "build.h"
 #include "descriptor_base_imp.h"
 #include "external_port_input_descriptor_response.h"
+#include "jdksavdecc_aem_descriptor.h"
 
 namespace avdecc_lib
 {

--- a/controller/lib/src/external_port_output_descriptor_imp.cpp
+++ b/controller/lib/src/external_port_output_descriptor_imp.cpp
@@ -27,6 +27,8 @@
  * EXTERNAL_PORT_OUTPUT descriptor implementation
  */
 
+#include <mutex>
+
 #include "avdecc_error.h"
 #include "enumeration.h"
 #include "log_imp.h"

--- a/controller/lib/src/external_port_output_descriptor_imp.cpp
+++ b/controller/lib/src/external_port_output_descriptor_imp.cpp
@@ -35,14 +35,10 @@
 
 namespace avdecc_lib
 {
-    external_port_output_descriptor_imp::external_port_output_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos)
-    {
-        m_type = jdksavdecc_descriptor_external_port_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
-        m_index = jdksavdecc_descriptor_external_port_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
-    }
+    external_port_output_descriptor_imp::external_port_output_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos) {}
 
     external_port_output_descriptor_imp::~external_port_output_descriptor_imp() {}
-    
+
     external_port_output_descriptor_response * STDCALL external_port_output_descriptor_imp::get_external_port_output_response()
     {
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
@@ -52,12 +48,12 @@ namespace avdecc_lib
 
     uint16_t STDCALL external_port_output_descriptor_imp::descriptor_type() const
     {
-        assert(m_type == JDKSAVDECC_DESCRIPTOR_EXTERNAL_PORT_OUTPUT);
-        return m_type;
+        assert(jdksavdecc_descriptor_external_port_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos()) == JDKSAVDECC_DESCRIPTOR_EXTERNAL_PORT_OUTPUT);
+        return jdksavdecc_descriptor_external_port_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 
     uint16_t STDCALL external_port_output_descriptor_imp::descriptor_index() const
     {
-        return m_index;
+        return jdksavdecc_descriptor_external_port_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 }

--- a/controller/lib/src/external_port_output_descriptor_imp.cpp
+++ b/controller/lib/src/external_port_output_descriptor_imp.cpp
@@ -35,65 +35,29 @@
 
 namespace avdecc_lib
 {
-    external_port_output_descriptor_imp::external_port_output_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj)
+    external_port_output_descriptor_imp::external_port_output_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos)
     {
-        ssize_t ret = jdksavdecc_descriptor_external_port_read(&desc, frame, pos, frame_len);
-
-        if (ret < 0)
-        {
-            throw avdecc_read_descriptor_error("jdksavdecc_descriptor_external_port_read error");
-        }
+        m_type = jdksavdecc_descriptor_external_port_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
+        m_index = jdksavdecc_descriptor_external_port_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 
     external_port_output_descriptor_imp::~external_port_output_descriptor_imp() {}
+    
+    external_port_output_descriptor_response * STDCALL external_port_output_descriptor_imp::get_external_port_output_response()
+    {
+        std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
+        return resp = new external_port_output_descriptor_response_imp(resp_ref->get_buffer(),
+                                                                      resp_ref->get_size(), resp_ref->get_pos());
+    }
 
     uint16_t STDCALL external_port_output_descriptor_imp::descriptor_type() const
     {
-        assert(desc.descriptor_type == JDKSAVDECC_DESCRIPTOR_EXTERNAL_PORT_OUTPUT);
-        return desc.descriptor_type;
+        assert(m_type == JDKSAVDECC_DESCRIPTOR_EXTERNAL_PORT_OUTPUT);
+        return m_type;
     }
 
     uint16_t STDCALL external_port_output_descriptor_imp::descriptor_index() const
     {
-        return desc.descriptor_index;
+        return m_index;
     }
-
-    uint16_t STDCALL external_port_output_descriptor_imp::port_flags()
-    {
-        return desc.port_flags;
-    }
-    uint16_t STDCALL external_port_output_descriptor_imp::clock_domain_index()
-    {
-        return desc.clock_domain_index;
-    }
-    uint16_t STDCALL external_port_output_descriptor_imp::number_of_controls()
-    {
-        return desc.number_of_controls;
-    }
-    uint16_t STDCALL external_port_output_descriptor_imp::base_control()
-    {
-        return desc.base_control;
-    }
-    uint16_t STDCALL external_port_output_descriptor_imp::signal_type()
-    {
-        return desc.signal_type;
-    }
-    uint16_t STDCALL external_port_output_descriptor_imp::signal_index()
-    {
-        return desc.signal_index;
-    }
-    uint16_t STDCALL external_port_output_descriptor_imp::signal_output()
-    {
-        return desc.signal_output;
-    }
-    uint32_t STDCALL external_port_output_descriptor_imp::block_latency()
-    {
-        return desc.block_latency;
-    }
-    uint16_t STDCALL external_port_output_descriptor_imp::jack_index()
-    {
-        return desc.jack_index;
-    }
-
-
 }

--- a/controller/lib/src/external_port_output_descriptor_imp.cpp
+++ b/controller/lib/src/external_port_output_descriptor_imp.cpp
@@ -42,18 +42,7 @@ namespace avdecc_lib
     external_port_output_descriptor_response * STDCALL external_port_output_descriptor_imp::get_external_port_output_response()
     {
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
-        return resp = new external_port_output_descriptor_response_imp(resp_ref->get_buffer(),
-                                                                      resp_ref->get_size(), resp_ref->get_pos());
-    }
-
-    uint16_t STDCALL external_port_output_descriptor_imp::descriptor_type() const
-    {
-        assert(jdksavdecc_descriptor_external_port_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos()) == JDKSAVDECC_DESCRIPTOR_EXTERNAL_PORT_OUTPUT);
-        return jdksavdecc_descriptor_external_port_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
-    }
-
-    uint16_t STDCALL external_port_output_descriptor_imp::descriptor_index() const
-    {
-        return jdksavdecc_descriptor_external_port_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
+        return resp = new external_port_output_descriptor_response_imp(resp_ref->get_desc_buffer(),
+                                                                       resp_ref->get_desc_size(), resp_ref->get_desc_pos());
     }
 }

--- a/controller/lib/src/external_port_output_descriptor_imp.h
+++ b/controller/lib/src/external_port_output_descriptor_imp.h
@@ -45,8 +45,6 @@ namespace avdecc_lib
         
         external_port_output_descriptor_response_imp *resp;
 
-        uint16_t STDCALL descriptor_type() const;
-        uint16_t STDCALL descriptor_index() const;
         external_port_output_descriptor_response * STDCALL get_external_port_output_response();
     };
 }

--- a/controller/lib/src/external_port_output_descriptor_imp.h
+++ b/controller/lib/src/external_port_output_descriptor_imp.h
@@ -39,9 +39,6 @@ namespace avdecc_lib
 {
     class external_port_output_descriptor_imp : public external_port_output_descriptor, public virtual descriptor_base_imp
     {
-    private:
-        uint16_t m_type;
-        uint16_t m_index;
     public:
         external_port_output_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
         virtual ~external_port_output_descriptor_imp();

--- a/controller/lib/src/external_port_output_descriptor_imp.h
+++ b/controller/lib/src/external_port_output_descriptor_imp.h
@@ -31,31 +31,25 @@
 
 #include <stdint.h>
 #include "build.h"
-#include "descriptor_base.h"
+#include "descriptor_base_imp.h"
 #include "external_port_output_descriptor.h"
+#include "external_port_output_descriptor_response_imp.h"
 
 namespace avdecc_lib
 {
     class external_port_output_descriptor_imp : public external_port_output_descriptor, public virtual descriptor_base_imp
     {
     private:
-        struct jdksavdecc_descriptor_external_port desc;
+        uint16_t m_type;
+        uint16_t m_index;
     public:
         external_port_output_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
         virtual ~external_port_output_descriptor_imp();
+        
+        external_port_output_descriptor_response_imp *resp;
 
         uint16_t STDCALL descriptor_type() const;
         uint16_t STDCALL descriptor_index() const;
-
-        uint16_t STDCALL port_flags();
-        uint16_t STDCALL clock_domain_index();
-        uint16_t STDCALL number_of_controls();
-        uint16_t STDCALL base_control();
-        uint16_t STDCALL signal_type();
-        uint16_t STDCALL signal_index();
-        uint16_t STDCALL signal_output();
-        uint32_t STDCALL block_latency();
-        uint16_t STDCALL jack_index();
+        external_port_output_descriptor_response * STDCALL get_external_port_output_response();
     };
 }
-

--- a/controller/lib/src/external_port_output_descriptor_response_imp.cpp
+++ b/controller/lib/src/external_port_output_descriptor_response_imp.cpp
@@ -35,7 +35,7 @@
 
 namespace avdecc_lib
 {
-    external_port_output_descriptor_response_imp::external_port_output_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos) : descriptor_base_imp(nullptr, frame, frame_len, pos)
+    external_port_output_descriptor_response_imp::external_port_output_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos)
     {
         frame_size = frame_len;
         buffer = (uint8_t *)malloc(frame_size * sizeof(uint8_t));
@@ -43,7 +43,10 @@ namespace avdecc_lib
         position = pos;
     }
     
-    external_port_output_descriptor_response_imp::~external_port_output_descriptor_response_imp() {}
+    external_port_output_descriptor_response_imp::~external_port_output_descriptor_response_imp()
+    {
+        free(buffer);
+    }
     
     uint16_t STDCALL external_port_output_descriptor_response_imp::port_flags()
     {

--- a/controller/lib/src/external_port_output_descriptor_response_imp.cpp
+++ b/controller/lib/src/external_port_output_descriptor_response_imp.cpp
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * external_port_output_descriptor_response_imp.cpp
+ *
+ * EXTERNAL_PORT_OUTPUT descriptor response implementation
+ */
+
+#include "avdecc_error.h"
+#include "enumeration.h"
+#include "log_imp.h"
+#include "end_station_imp.h"
+#include "external_port_output_descriptor_response_imp.h"
+
+namespace avdecc_lib
+{
+    external_port_output_descriptor_response_imp::external_port_output_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos) : descriptor_base_imp(nullptr, frame, frame_len, pos)
+    {
+        frame_size = frame_len;
+        buffer = (uint8_t *)malloc(frame_size * sizeof(uint8_t));
+        memcpy(buffer, frame, frame_size);
+        position = pos;
+    }
+    
+    external_port_output_descriptor_response_imp::~external_port_output_descriptor_response_imp() {}
+    
+    uint16_t STDCALL external_port_output_descriptor_response_imp::port_flags()
+    {
+        return jdksavdecc_descriptor_external_port_get_port_flags(buffer, position);
+    }
+    
+    uint16_t STDCALL external_port_output_descriptor_response_imp::clock_domain_index()
+    {
+        return jdksavdecc_descriptor_external_port_get_clock_domain_index(buffer, position);
+    }
+    
+    uint16_t STDCALL external_port_output_descriptor_response_imp::number_of_controls()
+    {
+        return jdksavdecc_descriptor_external_port_get_number_of_controls(buffer, position);
+    }
+    
+    uint16_t STDCALL external_port_output_descriptor_response_imp::base_control()
+    {
+        return jdksavdecc_descriptor_external_port_get_base_control(buffer, position);
+    }
+    
+    uint16_t STDCALL external_port_output_descriptor_response_imp::signal_type()
+    {
+        return jdksavdecc_descriptor_external_port_get_signal_type(buffer, position);
+    }
+    
+    uint16_t STDCALL external_port_output_descriptor_response_imp::signal_index()
+    {
+        return jdksavdecc_descriptor_external_port_get_signal_index(buffer, position);
+    }
+    
+    uint16_t STDCALL external_port_output_descriptor_response_imp::signal_output()
+    {
+        return jdksavdecc_descriptor_external_port_get_signal_output(buffer, position);
+    }
+    
+    uint32_t STDCALL external_port_output_descriptor_response_imp::block_latency()
+    {
+        return jdksavdecc_descriptor_external_port_get_block_latency(buffer, position);
+    }
+    
+    uint16_t STDCALL external_port_output_descriptor_response_imp::jack_index()
+    {
+        return jdksavdecc_descriptor_external_port_get_jack_index(buffer, position);
+    }
+}

--- a/controller/lib/src/external_port_output_descriptor_response_imp.h
+++ b/controller/lib/src/external_port_output_descriptor_response_imp.h
@@ -31,12 +31,12 @@
 
 #include <stdint.h>
 #include "build.h"
-#include "descriptor_base_imp.h"
 #include "external_port_output_descriptor_response.h"
+#include "jdksavdecc_aem_descriptor.h"
 
 namespace avdecc_lib
 {
-    class external_port_output_descriptor_response_imp : public external_port_output_descriptor_response, public virtual descriptor_base_imp
+    class external_port_output_descriptor_response_imp : public external_port_output_descriptor_response
     {
     private:
         uint8_t * buffer;

--- a/controller/lib/src/external_port_output_descriptor_response_imp.h
+++ b/controller/lib/src/external_port_output_descriptor_response_imp.h
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * external_port_output_descriptor_response_imp.h
+ *
+ * Public EXTERNAL PORT OUTPUT descriptor response implementation class
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "build.h"
+#include "descriptor_base_imp.h"
+#include "external_port_output_descriptor_response.h"
+
+namespace avdecc_lib
+{
+    class external_port_output_descriptor_response_imp : public external_port_output_descriptor_response, public virtual descriptor_base_imp
+    {
+    private:
+        uint8_t * buffer;
+        ssize_t position;
+        size_t frame_size;
+    public:
+        external_port_output_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos);
+        virtual ~external_port_output_descriptor_response_imp();
+
+        uint16_t STDCALL port_flags();
+        uint16_t STDCALL clock_domain_index();
+        uint16_t STDCALL number_of_controls();
+        uint16_t STDCALL base_control();
+        uint16_t STDCALL signal_type();
+        uint16_t STDCALL signal_index();
+        uint16_t STDCALL signal_output();
+        uint32_t STDCALL block_latency();
+        uint16_t STDCALL jack_index();
+    };
+}

--- a/controller/lib/src/jack_input_descriptor_imp.cpp
+++ b/controller/lib/src/jack_input_descriptor_imp.cpp
@@ -42,18 +42,7 @@ namespace avdecc_lib
     jack_input_descriptor_response * STDCALL jack_input_descriptor_imp::get_jack_input_response()
     {
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
-        return resp = new jack_input_descriptor_response_imp(resp_ref->get_buffer(),
-                                                             resp_ref->get_size(), resp_ref->get_pos());
-    }
-
-    uint16_t STDCALL jack_input_descriptor_imp::descriptor_type() const
-    {
-        assert(jdksavdecc_descriptor_jack_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos()) == JDKSAVDECC_DESCRIPTOR_JACK_INPUT);
-        return jdksavdecc_descriptor_jack_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
-    }
-
-    uint16_t STDCALL jack_input_descriptor_imp::descriptor_index() const
-    {
-        return jdksavdecc_descriptor_jack_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
+        return resp = new jack_input_descriptor_response_imp(resp_ref->get_desc_buffer(),
+                                                             resp_ref->get_desc_size(), resp_ref->get_desc_pos());
     }
 }

--- a/controller/lib/src/jack_input_descriptor_imp.cpp
+++ b/controller/lib/src/jack_input_descriptor_imp.cpp
@@ -35,29 +35,25 @@
 
 namespace avdecc_lib
 {
-    jack_input_descriptor_imp::jack_input_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos)
-    {
-        m_type = jdksavdecc_descriptor_jack_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
-        m_index = jdksavdecc_descriptor_jack_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
-    }
+    jack_input_descriptor_imp::jack_input_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos) {}
 
     jack_input_descriptor_imp::~jack_input_descriptor_imp() {}
-    
+
     jack_input_descriptor_response * STDCALL jack_input_descriptor_imp::get_jack_input_response()
     {
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
         return resp = new jack_input_descriptor_response_imp(resp_ref->get_buffer(),
-                                                                       resp_ref->get_size(), resp_ref->get_pos());
+                                                             resp_ref->get_size(), resp_ref->get_pos());
     }
 
     uint16_t STDCALL jack_input_descriptor_imp::descriptor_type() const
     {
-        assert(m_type == JDKSAVDECC_DESCRIPTOR_JACK_INPUT);
-        return m_type;
+        assert(jdksavdecc_descriptor_jack_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos()) == JDKSAVDECC_DESCRIPTOR_JACK_INPUT);
+        return jdksavdecc_descriptor_jack_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 
     uint16_t STDCALL jack_input_descriptor_imp::descriptor_index() const
     {
-        return m_index;
+        return jdksavdecc_descriptor_jack_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 }

--- a/controller/lib/src/jack_input_descriptor_imp.cpp
+++ b/controller/lib/src/jack_input_descriptor_imp.cpp
@@ -27,6 +27,8 @@
  * JACK INPUT descriptor implementation
  */
 
+#include <mutex>
+
 #include "avdecc_error.h"
 #include "enumeration.h"
 #include "log_imp.h"

--- a/controller/lib/src/jack_input_descriptor_imp.cpp
+++ b/controller/lib/src/jack_input_descriptor_imp.cpp
@@ -35,74 +35,29 @@
 
 namespace avdecc_lib
 {
-    jack_input_descriptor_imp::jack_input_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj)
+    jack_input_descriptor_imp::jack_input_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos)
     {
-        ssize_t ret = jdksavdecc_descriptor_jack_read(&jack_input_desc, frame, pos, frame_len);
-
-        if (ret < 0)
-        {
-            throw avdecc_read_descriptor_error("jack_input_desc_read error");
-        }
-
-        jack_flags_init();
+        m_type = jdksavdecc_descriptor_jack_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
+        m_index = jdksavdecc_descriptor_jack_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 
     jack_input_descriptor_imp::~jack_input_descriptor_imp() {}
-
-    void jack_input_descriptor_imp::jack_flags_init()
+    
+    jack_input_descriptor_response * STDCALL jack_input_descriptor_imp::get_jack_input_response()
     {
-        jack_input_flags.clock_sync_source = jack_input_desc.jack_flags >> 1 & 0x01;
-        jack_input_flags.captive = jack_input_desc.jack_flags >> 2 & 0x01;
+        std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
+        return resp = new jack_input_descriptor_response_imp(resp_ref->get_buffer(),
+                                                                       resp_ref->get_size(), resp_ref->get_pos());
     }
 
     uint16_t STDCALL jack_input_descriptor_imp::descriptor_type() const
     {
-        assert(jack_input_desc.descriptor_type == JDKSAVDECC_DESCRIPTOR_JACK_INPUT);
-        return jack_input_desc.descriptor_type;
+        assert(m_type == JDKSAVDECC_DESCRIPTOR_JACK_INPUT);
+        return m_type;
     }
 
     uint16_t STDCALL jack_input_descriptor_imp::descriptor_index() const
     {
-        return jack_input_desc.descriptor_index;
-    }
-
-    uint8_t * STDCALL jack_input_descriptor_imp::object_name()
-    {
-        return jack_input_desc.object_name.value;
-    }
-
-    uint16_t STDCALL jack_input_descriptor_imp::localized_description()
-    {
-        return jack_input_desc.localized_description;
-    }
-
-    uint16_t STDCALL jack_input_descriptor_imp::jack_flags()
-    {
-        return jack_input_desc.jack_flags;
-    }
-
-    uint16_t STDCALL jack_input_descriptor_imp::jack_flag_clock_sync_source()
-    {
-        return jack_input_flags.clock_sync_source;
-    }
-
-    uint16_t STDCALL jack_input_descriptor_imp::jack_flag_captive()
-    {
-        return jack_input_flags.captive;
-    }
-
-    uint16_t STDCALL jack_input_descriptor_imp::jack_type()
-    {
-        return jack_input_desc.jack_type;
-    }
-
-    uint16_t STDCALL jack_input_descriptor_imp::number_of_controls()
-    {
-        return jack_input_desc.number_of_controls;
-    }
-
-    uint16_t STDCALL jack_input_descriptor_imp::base_control()
-    {
-        return jack_input_desc.base_control;
+        return m_index;
     }
 }

--- a/controller/lib/src/jack_input_descriptor_imp.h
+++ b/controller/lib/src/jack_input_descriptor_imp.h
@@ -43,8 +43,6 @@ namespace avdecc_lib
         
         jack_input_descriptor_response_imp *resp;
 
-        uint16_t STDCALL descriptor_type() const;
-        uint16_t STDCALL descriptor_index() const;
         jack_input_descriptor_response * STDCALL get_jack_input_response();
     private:
         /**

--- a/controller/lib/src/jack_input_descriptor_imp.h
+++ b/controller/lib/src/jack_input_descriptor_imp.h
@@ -37,9 +37,6 @@ namespace avdecc_lib
 {
     class jack_input_descriptor_imp : public jack_input_descriptor, public virtual descriptor_base_imp
     {
-    private:
-        uint16_t m_type;
-        uint16_t m_index;
     public:
         jack_input_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
         virtual ~jack_input_descriptor_imp();

--- a/controller/lib/src/jack_input_descriptor_imp.h
+++ b/controller/lib/src/jack_input_descriptor_imp.h
@@ -31,38 +31,24 @@
 
 #include "descriptor_base_imp.h"
 #include "jack_input_descriptor.h"
+#include "jack_input_descriptor_response_imp.h"
 
 namespace avdecc_lib
 {
     class jack_input_descriptor_imp : public jack_input_descriptor, public virtual descriptor_base_imp
     {
     private:
-        struct jdksavdecc_descriptor_jack jack_input_desc; // Structure containing the jack_input_desc fields
-
-        struct jack_input_desc_jack_flags
-        {
-            bool clock_sync_source;
-            bool captive;
-        };
-
-        struct jack_input_desc_jack_flags jack_input_flags;
-
+        uint16_t m_type;
+        uint16_t m_index;
     public:
         jack_input_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
         virtual ~jack_input_descriptor_imp();
+        
+        jack_input_descriptor_response_imp *resp;
 
         uint16_t STDCALL descriptor_type() const;
         uint16_t STDCALL descriptor_index() const;
-        uint8_t * STDCALL object_name();
-        uint16_t STDCALL localized_description();
-
-		uint16_t STDCALL jack_flags();
-        uint16_t STDCALL jack_flag_clock_sync_source();
-        uint16_t STDCALL jack_flag_captive();
-        uint16_t STDCALL jack_type();
-        uint16_t STDCALL number_of_controls();
-        uint16_t STDCALL base_control();
-    
+        jack_input_descriptor_response * STDCALL get_jack_input_response();
     private:
         /**
          * Store the jack flags componenets of the JACK INPUT descriptor object in a vector.

--- a/controller/lib/src/jack_input_descriptor_response_imp.cpp
+++ b/controller/lib/src/jack_input_descriptor_response_imp.cpp
@@ -1,0 +1,95 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2013 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * jack_input_descriptor_imp.cpp
+ *
+ * JACK INPUT descriptor implementation
+ */
+
+#include "avdecc_error.h"
+#include "enumeration.h"
+#include "log_imp.h"
+#include "end_station_imp.h"
+#include "jack_input_descriptor_imp.h"
+
+namespace avdecc_lib
+{
+    jack_input_descriptor_response_imp::jack_input_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos) : descriptor_base_imp(nullptr, frame, frame_len, pos)
+    {
+        frame_size = frame_len;
+        buffer = (uint8_t *)malloc(frame_size * sizeof(uint8_t));
+        memcpy(buffer, frame, frame_size);
+        position = pos;
+        
+        jack_flags_init();
+    }
+    
+    jack_input_descriptor_response_imp::~jack_input_descriptor_response_imp() {}
+    
+    void jack_input_descriptor_response_imp::jack_flags_init()
+    {
+        jack_input_flags.clock_sync_source = jack_flags() >> 1 & 0x01;
+        jack_input_flags.captive = jack_flags() >> 2 & 0x01;
+    }
+    
+    uint8_t * STDCALL jack_input_descriptor_response_imp::object_name()
+    {
+        return (uint8_t *)&buffer[position + JDKSAVDECC_DESCRIPTOR_JACK_OFFSET_OBJECT_NAME];
+    }
+    
+    uint16_t STDCALL jack_input_descriptor_response_imp::localized_description()
+    {
+        return jdksavdecc_descriptor_jack_get_localized_description(buffer, position);
+    }
+    
+    uint16_t STDCALL jack_input_descriptor_response_imp::jack_flags()
+    {
+        return jdksavdecc_descriptor_jack_get_jack_flags(buffer, position);
+    }
+    
+    uint16_t STDCALL jack_input_descriptor_response_imp::jack_flag_clock_sync_source()
+    {
+        return jack_input_flags.clock_sync_source;
+    }
+    
+    uint16_t STDCALL jack_input_descriptor_response_imp::jack_flag_captive()
+    {
+        return jack_input_flags.captive;
+    }
+    
+    uint16_t STDCALL jack_input_descriptor_response_imp::jack_type()
+    {
+        return jdksavdecc_descriptor_jack_get_jack_type(buffer, position);
+    }
+    
+    uint16_t STDCALL jack_input_descriptor_response_imp::number_of_controls()
+    {
+        return jdksavdecc_descriptor_jack_get_number_of_controls(buffer, position);
+    }
+    
+    uint16_t STDCALL jack_input_descriptor_response_imp::base_control()
+    {
+        return jdksavdecc_descriptor_jack_get_base_control(buffer, position);
+    }
+}

--- a/controller/lib/src/jack_input_descriptor_response_imp.cpp
+++ b/controller/lib/src/jack_input_descriptor_response_imp.cpp
@@ -35,7 +35,7 @@
 
 namespace avdecc_lib
 {
-    jack_input_descriptor_response_imp::jack_input_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos) : descriptor_base_imp(nullptr, frame, frame_len, pos)
+    jack_input_descriptor_response_imp::jack_input_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos)
     {
         frame_size = frame_len;
         buffer = (uint8_t *)malloc(frame_size * sizeof(uint8_t));
@@ -45,7 +45,10 @@ namespace avdecc_lib
         jack_flags_init();
     }
     
-    jack_input_descriptor_response_imp::~jack_input_descriptor_response_imp() {}
+    jack_input_descriptor_response_imp::~jack_input_descriptor_response_imp()
+    {
+        free(buffer);
+    }
     
     void jack_input_descriptor_response_imp::jack_flags_init()
     {

--- a/controller/lib/src/jack_input_descriptor_response_imp.h
+++ b/controller/lib/src/jack_input_descriptor_response_imp.h
@@ -29,12 +29,12 @@
 
 #pragma once
 
-#include "descriptor_base_imp.h"
 #include "jack_input_descriptor_response.h"
+#include "jdksavdecc_aem_descriptor.h"
 
 namespace avdecc_lib
 {
-    class jack_input_descriptor_response_imp : public jack_input_descriptor_response, public virtual descriptor_base_imp
+    class jack_input_descriptor_response_imp : public jack_input_descriptor_response
     {
     private:
         uint8_t * buffer;

--- a/controller/lib/src/jack_input_descriptor_response_imp.h
+++ b/controller/lib/src/jack_input_descriptor_response_imp.h
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2013 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * jack_input_descriptor_response_imp.h
+ *
+ * JACK INPUT descriptor response implementation class
+ */
+
+#pragma once
+
+#include "descriptor_base_imp.h"
+#include "jack_input_descriptor_response.h"
+
+namespace avdecc_lib
+{
+    class jack_input_descriptor_response_imp : public jack_input_descriptor_response, public virtual descriptor_base_imp
+    {
+    private:
+        uint8_t * buffer;
+        ssize_t position;
+        size_t frame_size;
+        
+        struct jack_input_desc_jack_flags
+        {
+            bool clock_sync_source;
+            bool captive;
+        };
+        
+        struct jack_input_desc_jack_flags jack_input_flags;
+    public:
+        jack_input_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos);
+        virtual ~jack_input_descriptor_response_imp();
+        
+        uint8_t * STDCALL object_name();
+        uint16_t STDCALL localized_description();
+        
+        uint16_t STDCALL jack_flags();
+        uint16_t STDCALL jack_flag_clock_sync_source();
+        uint16_t STDCALL jack_flag_captive();
+        uint16_t STDCALL jack_type();
+        uint16_t STDCALL number_of_controls();
+        uint16_t STDCALL base_control();
+    private:
+        /**
+         * Store the jack flags componenets of the JACK INPUT descriptor object in a vector.
+         */
+        void jack_flags_init();
+    };
+}
+

--- a/controller/lib/src/jack_output_descriptor_imp.cpp
+++ b/controller/lib/src/jack_output_descriptor_imp.cpp
@@ -27,6 +27,8 @@
  * JACK OUTPUT descriptor implementation
  */
 
+#include <mutex>
+
 #include "avdecc_error.h"
 #include "enumeration.h"
 #include "log_imp.h"

--- a/controller/lib/src/jack_output_descriptor_imp.cpp
+++ b/controller/lib/src/jack_output_descriptor_imp.cpp
@@ -42,18 +42,7 @@ namespace avdecc_lib
     jack_output_descriptor_response * STDCALL jack_output_descriptor_imp::get_jack_output_response()
     {
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
-        return resp = new jack_output_descriptor_response_imp(resp_ref->get_buffer(),
-                                                             resp_ref->get_size(), resp_ref->get_pos());
-    }
-
-    uint16_t STDCALL jack_output_descriptor_imp::descriptor_type() const
-    {
-        assert(jdksavdecc_descriptor_jack_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos()) == JDKSAVDECC_DESCRIPTOR_JACK_OUTPUT);
-        return jdksavdecc_descriptor_jack_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
-    }
-
-    uint16_t STDCALL jack_output_descriptor_imp::descriptor_index() const
-    {
-        return jdksavdecc_descriptor_jack_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
+        return resp = new jack_output_descriptor_response_imp(resp_ref->get_desc_buffer(),
+                                                             resp_ref->get_desc_size(), resp_ref->get_desc_pos());
     }
 }

--- a/controller/lib/src/jack_output_descriptor_imp.cpp
+++ b/controller/lib/src/jack_output_descriptor_imp.cpp
@@ -35,14 +35,10 @@
 
 namespace avdecc_lib
 {
-    jack_output_descriptor_imp::jack_output_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos)
-    {
-        m_type = jdksavdecc_descriptor_jack_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
-        m_index = jdksavdecc_descriptor_jack_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
-    }
+    jack_output_descriptor_imp::jack_output_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos) {}
 
     jack_output_descriptor_imp::~jack_output_descriptor_imp() {}
-    
+
     jack_output_descriptor_response * STDCALL jack_output_descriptor_imp::get_jack_output_response()
     {
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
@@ -52,12 +48,12 @@ namespace avdecc_lib
 
     uint16_t STDCALL jack_output_descriptor_imp::descriptor_type() const
     {
-        assert(m_type == JDKSAVDECC_DESCRIPTOR_JACK_OUTPUT);
-        return m_type;
+        assert(jdksavdecc_descriptor_jack_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos()) == JDKSAVDECC_DESCRIPTOR_JACK_OUTPUT);
+        return jdksavdecc_descriptor_jack_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 
     uint16_t STDCALL jack_output_descriptor_imp::descriptor_index() const
     {
-        return m_index;
+        return jdksavdecc_descriptor_jack_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 }

--- a/controller/lib/src/jack_output_descriptor_imp.cpp
+++ b/controller/lib/src/jack_output_descriptor_imp.cpp
@@ -35,74 +35,29 @@
 
 namespace avdecc_lib
 {
-    jack_output_descriptor_imp::jack_output_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj)
+    jack_output_descriptor_imp::jack_output_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos)
     {
-        ssize_t ret = jdksavdecc_descriptor_jack_read(&jack_output_desc, frame, pos, frame_len);
-
-        if (ret < 0)
-        {
-            throw avdecc_read_descriptor_error("jack_output_desc_read error");
-        }
-
-        jack_flags_init();
+        m_type = jdksavdecc_descriptor_jack_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
+        m_index = jdksavdecc_descriptor_jack_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 
     jack_output_descriptor_imp::~jack_output_descriptor_imp() {}
-
-    void jack_output_descriptor_imp::jack_flags_init()
+    
+    jack_output_descriptor_response * STDCALL jack_output_descriptor_imp::get_jack_output_response()
     {
-        jack_output_flags.clock_sync_source = jack_output_desc.jack_flags >> 1 & 0x01;
-        jack_output_flags.captive = jack_output_desc.jack_flags >> 2 & 0x01;
+        std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
+        return resp = new jack_output_descriptor_response_imp(resp_ref->get_buffer(),
+                                                             resp_ref->get_size(), resp_ref->get_pos());
     }
 
     uint16_t STDCALL jack_output_descriptor_imp::descriptor_type() const
     {
-        assert(jack_output_desc.descriptor_type == JDKSAVDECC_DESCRIPTOR_JACK_OUTPUT);
-        return jack_output_desc.descriptor_type;
+        assert(m_type == JDKSAVDECC_DESCRIPTOR_JACK_OUTPUT);
+        return m_type;
     }
 
     uint16_t STDCALL jack_output_descriptor_imp::descriptor_index() const
     {
-        return jack_output_desc.descriptor_index;
-    }
-
-    uint8_t * STDCALL jack_output_descriptor_imp::object_name()
-    {
-        return jack_output_desc.object_name.value;
-    }
-
-    uint16_t STDCALL jack_output_descriptor_imp::localized_description()
-    {
-        return jack_output_desc.localized_description;
-    }
-
-    uint16_t STDCALL jack_output_descriptor_imp::jack_flags()
-    {
-        return jack_output_desc.jack_flags;
-    }
-
-    uint16_t STDCALL jack_output_descriptor_imp::jack_flag_clock_sync_source()
-    {
-        return jack_output_flags.clock_sync_source;
-    }
-
-    uint16_t STDCALL jack_output_descriptor_imp::jack_flag_captive()
-    {
-        return jack_output_flags.captive;
-    }
-
-    uint16_t STDCALL jack_output_descriptor_imp::jack_type()
-    {
-        return jack_output_desc.jack_type;
-    }
-
-    uint16_t STDCALL jack_output_descriptor_imp::number_of_controls()
-    {
-        return jack_output_desc.number_of_controls;
-    }
-
-    uint16_t STDCALL jack_output_descriptor_imp::base_control()
-    {
-        return jack_output_desc.base_control;
+        return m_index;
     }
 }

--- a/controller/lib/src/jack_output_descriptor_imp.h
+++ b/controller/lib/src/jack_output_descriptor_imp.h
@@ -37,9 +37,6 @@ namespace avdecc_lib
 {
     class jack_output_descriptor_imp : public jack_output_descriptor, public virtual descriptor_base_imp
     {
-    private:
-        uint16_t m_type;
-        uint16_t m_index;
     public:
         jack_output_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
         virtual ~jack_output_descriptor_imp();

--- a/controller/lib/src/jack_output_descriptor_imp.h
+++ b/controller/lib/src/jack_output_descriptor_imp.h
@@ -43,8 +43,6 @@ namespace avdecc_lib
         
         jack_output_descriptor_response_imp *resp;
 
-        uint16_t STDCALL descriptor_type() const;
-        uint16_t STDCALL descriptor_index() const;
         jack_output_descriptor_response * STDCALL get_jack_output_response();
     private:
         /**

--- a/controller/lib/src/jack_output_descriptor_imp.h
+++ b/controller/lib/src/jack_output_descriptor_imp.h
@@ -31,38 +31,24 @@
 
 #include "descriptor_base_imp.h"
 #include "jack_output_descriptor.h"
+#include "jack_output_descriptor_response_imp.h"
 
 namespace avdecc_lib
 {
     class jack_output_descriptor_imp : public jack_output_descriptor, public virtual descriptor_base_imp
     {
     private:
-        struct jdksavdecc_descriptor_jack jack_output_desc; // Structure containing the jack_output_desc fields
-
-        struct jack_input_desc_jack_flags
-        {
-            bool clock_sync_source;
-            bool captive;
-        };
-
-        struct jack_input_desc_jack_flags jack_output_flags;
-
+        uint16_t m_type;
+        uint16_t m_index;
     public:
         jack_output_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
         virtual ~jack_output_descriptor_imp();
+        
+        jack_output_descriptor_response_imp *resp;
 
         uint16_t STDCALL descriptor_type() const;
         uint16_t STDCALL descriptor_index() const;
-        uint8_t * STDCALL object_name();
-        uint16_t STDCALL localized_description();
-
-        uint16_t STDCALL jack_flags();
-        uint16_t STDCALL jack_flag_clock_sync_source();
-        uint16_t STDCALL jack_flag_captive();
-        uint16_t STDCALL jack_type();
-        uint16_t STDCALL number_of_controls();
-        uint16_t STDCALL base_control();
-
+        jack_output_descriptor_response * STDCALL get_jack_output_response();
     private:
         /**
          * Store the jack flags componenets of the JACK INPUT descriptor object in a vector.
@@ -70,4 +56,3 @@ namespace avdecc_lib
         void jack_flags_init();
     };
 }
-

--- a/controller/lib/src/jack_output_descriptor_response_imp.cpp
+++ b/controller/lib/src/jack_output_descriptor_response_imp.cpp
@@ -1,0 +1,95 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * jack_output_descriptor_response_imp.cpp
+ *
+ * JACK OUTPUT descriptor response implementation
+ */
+
+#include "avdecc_error.h"
+#include "enumeration.h"
+#include "log_imp.h"
+#include "end_station_imp.h"
+#include "jack_output_descriptor_response_imp.h"
+
+namespace avdecc_lib
+{
+    jack_output_descriptor_response_imp::jack_output_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos) : descriptor_base_imp(nullptr, frame, frame_len, pos)
+    {
+        frame_size = frame_len;
+        buffer = (uint8_t *)malloc(frame_size * sizeof(uint8_t));
+        memcpy(buffer, frame, frame_size);
+        position = pos;
+        
+        jack_flags_init();
+    }
+    
+    jack_output_descriptor_response_imp::~jack_output_descriptor_response_imp() {}
+    
+    void jack_output_descriptor_response_imp::jack_flags_init()
+    {
+        jack_output_flags.clock_sync_source = jack_flags() >> 1 & 0x01;
+        jack_output_flags.captive = jack_flags() >> 2 & 0x01;
+    }
+    
+    uint8_t * STDCALL jack_output_descriptor_response_imp::object_name()
+    {
+        return (uint8_t *)&buffer[position + JDKSAVDECC_DESCRIPTOR_JACK_OFFSET_OBJECT_NAME];
+    }
+    
+    uint16_t STDCALL jack_output_descriptor_response_imp::localized_description()
+    {
+        return jdksavdecc_descriptor_jack_get_localized_description(buffer, position);
+    }
+    
+    uint16_t STDCALL jack_output_descriptor_response_imp::jack_flags()
+    {
+        return jdksavdecc_descriptor_jack_get_jack_flags(buffer, position);
+    }
+    
+    uint16_t STDCALL jack_output_descriptor_response_imp::jack_flag_clock_sync_source()
+    {
+        return jack_output_flags.clock_sync_source;
+    }
+    
+    uint16_t STDCALL jack_output_descriptor_response_imp::jack_flag_captive()
+    {
+        return jack_output_flags.captive;
+    }
+    
+    uint16_t STDCALL jack_output_descriptor_response_imp::jack_type()
+    {
+        return jdksavdecc_descriptor_jack_get_jack_type(buffer, position);
+    }
+    
+    uint16_t STDCALL jack_output_descriptor_response_imp::number_of_controls()
+    {
+        return jdksavdecc_descriptor_jack_get_number_of_controls(buffer, position);
+    }
+    
+    uint16_t STDCALL jack_output_descriptor_response_imp::base_control()
+    {
+        return jdksavdecc_descriptor_jack_get_base_control(buffer, position);
+    }
+}

--- a/controller/lib/src/jack_output_descriptor_response_imp.cpp
+++ b/controller/lib/src/jack_output_descriptor_response_imp.cpp
@@ -35,7 +35,7 @@
 
 namespace avdecc_lib
 {
-    jack_output_descriptor_response_imp::jack_output_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos) : descriptor_base_imp(nullptr, frame, frame_len, pos)
+    jack_output_descriptor_response_imp::jack_output_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos)
     {
         frame_size = frame_len;
         buffer = (uint8_t *)malloc(frame_size * sizeof(uint8_t));
@@ -45,7 +45,10 @@ namespace avdecc_lib
         jack_flags_init();
     }
     
-    jack_output_descriptor_response_imp::~jack_output_descriptor_response_imp() {}
+    jack_output_descriptor_response_imp::~jack_output_descriptor_response_imp()
+    {
+        free(buffer);
+    }
     
     void jack_output_descriptor_response_imp::jack_flags_init()
     {

--- a/controller/lib/src/jack_output_descriptor_response_imp.h
+++ b/controller/lib/src/jack_output_descriptor_response_imp.h
@@ -29,12 +29,12 @@
 
 #pragma once
 
-#include "descriptor_base_imp.h"
 #include "jack_output_descriptor_response.h"
+#include "jdksavdecc_aem_descriptor.h"
 
 namespace avdecc_lib
 {
-    class jack_output_descriptor_response_imp : public jack_output_descriptor_response, public virtual descriptor_base_imp
+    class jack_output_descriptor_response_imp : public jack_output_descriptor_response
     {
     private:
         uint8_t * buffer;

--- a/controller/lib/src/jack_output_descriptor_response_imp.h
+++ b/controller/lib/src/jack_output_descriptor_response_imp.h
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * jack_output_descriptor_response_imp.h
+ *
+ * JACK OUTPUT descriptor response implementation class
+ */
+
+#pragma once
+
+#include "descriptor_base_imp.h"
+#include "jack_output_descriptor_response.h"
+
+namespace avdecc_lib
+{
+    class jack_output_descriptor_response_imp : public jack_output_descriptor_response, public virtual descriptor_base_imp
+    {
+    private:
+        uint8_t * buffer;
+        ssize_t position;
+        size_t frame_size;
+        
+        struct jack_input_desc_jack_flags
+        {
+            bool clock_sync_source;
+            bool captive;
+        };
+        
+        struct jack_input_desc_jack_flags jack_output_flags;
+    public:
+        jack_output_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos);
+        virtual ~jack_output_descriptor_response_imp();
+        
+        uint8_t * STDCALL object_name();
+        uint16_t STDCALL localized_description();
+        
+        uint16_t STDCALL jack_flags();
+        uint16_t STDCALL jack_flag_clock_sync_source();
+        uint16_t STDCALL jack_flag_captive();
+        uint16_t STDCALL jack_type();
+        uint16_t STDCALL number_of_controls();
+        uint16_t STDCALL base_control();
+    private:
+        /**
+         * Store the jack flags componenets of the JACK INPUT descriptor object in a vector.
+         */
+        void jack_flags_init();
+    };
+}

--- a/controller/lib/src/locale_descriptor_imp.cpp
+++ b/controller/lib/src/locale_descriptor_imp.cpp
@@ -41,17 +41,6 @@ namespace avdecc_lib
     locale_descriptor_response * STDCALL locale_descriptor_imp::get_locale_response()
     {
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
-        return resp = new locale_descriptor_response_imp(resp_ref->get_buffer(), resp_ref->get_size(), resp_ref->get_pos());
-    }
-
-    uint16_t STDCALL locale_descriptor_imp::descriptor_type() const
-    {
-        return jdksavdecc_descriptor_locale_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
-    }
-
-    uint16_t STDCALL locale_descriptor_imp::descriptor_index() const
-    {
-        return jdksavdecc_descriptor_locale_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
-
+        return resp = new locale_descriptor_response_imp(resp_ref->get_desc_buffer(), resp_ref->get_desc_size(), resp_ref->get_desc_pos());
     }
 }

--- a/controller/lib/src/locale_descriptor_imp.cpp
+++ b/controller/lib/src/locale_descriptor_imp.cpp
@@ -34,41 +34,28 @@
 
 namespace avdecc_lib
 {
-    locale_descriptor_imp::locale_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj)
+    locale_descriptor_imp::locale_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos)
     {
-        ssize_t ret = jdksavdecc_descriptor_locale_read(&locale_desc, frame, pos, frame_len);
-
-        if (ret < 0)
-        {
-            throw avdecc_read_descriptor_error("locale_desc_read error");
-        }
+        m_type = jdksavdecc_descriptor_locale_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
+        m_index = jdksavdecc_descriptor_locale_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 
-    locale_descriptor_imp::~locale_descriptor_imp() {}
+    locale_descriptor_imp::~locale_descriptor_imp(){}
+
+    locale_descriptor_response * STDCALL locale_descriptor_imp::get_locale_response()
+    {
+        std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
+        return resp = new locale_descriptor_response_imp(resp_ref->get_buffer(), resp_ref->get_size(), resp_ref->get_pos());
+    }
 
     uint16_t STDCALL locale_descriptor_imp::descriptor_type() const
     {
-        assert(locale_desc.descriptor_type == JDKSAVDECC_DESCRIPTOR_LOCALE);
-        return locale_desc.descriptor_type;
+        return m_type;
     }
 
     uint16_t STDCALL locale_descriptor_imp::descriptor_index() const
     {
-        return locale_desc.descriptor_index;
-    }
+        return m_index;
 
-    uint8_t * STDCALL locale_descriptor_imp::locale_identifier()
-    {
-        return locale_desc.locale_identifier.value;
-    }
-
-    uint16_t STDCALL locale_descriptor_imp::number_of_strings()
-    {
-        return locale_desc.number_of_strings;
-    }
-
-    uint16_t STDCALL locale_descriptor_imp::base_strings()
-    {
-        return locale_desc.base_strings;
     }
 }

--- a/controller/lib/src/locale_descriptor_imp.cpp
+++ b/controller/lib/src/locale_descriptor_imp.cpp
@@ -26,6 +26,9 @@
  *
  * LOCALE descriptor implementation
  */
+
+#include <mutex>
+
 #include "avdecc_error.h"
 #include "enumeration.h"
 #include "log_imp.h"

--- a/controller/lib/src/locale_descriptor_imp.cpp
+++ b/controller/lib/src/locale_descriptor_imp.cpp
@@ -34,11 +34,7 @@
 
 namespace avdecc_lib
 {
-    locale_descriptor_imp::locale_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos)
-    {
-        m_type = jdksavdecc_descriptor_locale_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
-        m_index = jdksavdecc_descriptor_locale_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
-    }
+    locale_descriptor_imp::locale_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos) {}
 
     locale_descriptor_imp::~locale_descriptor_imp(){}
 
@@ -50,12 +46,12 @@ namespace avdecc_lib
 
     uint16_t STDCALL locale_descriptor_imp::descriptor_type() const
     {
-        return m_type;
+        return jdksavdecc_descriptor_locale_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 
     uint16_t STDCALL locale_descriptor_imp::descriptor_index() const
     {
-        return m_index;
+        return jdksavdecc_descriptor_locale_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
 
     }
 }

--- a/controller/lib/src/locale_descriptor_imp.h
+++ b/controller/lib/src/locale_descriptor_imp.h
@@ -43,9 +43,7 @@ namespace avdecc_lib
         virtual ~locale_descriptor_imp();
         
         locale_descriptor_response_imp *resp;
-        
-        uint16_t STDCALL descriptor_type() const;
-        uint16_t STDCALL descriptor_index() const;
+
         locale_descriptor_response * STDCALL get_locale_response();
     };
 }

--- a/controller/lib/src/locale_descriptor_imp.h
+++ b/controller/lib/src/locale_descriptor_imp.h
@@ -32,24 +32,24 @@
 
 #include "descriptor_base_imp.h"
 #include "locale_descriptor.h"
+#include "locale_descriptor_response_imp.h"
 
 namespace avdecc_lib
 {
     class locale_descriptor_imp : public locale_descriptor, public virtual descriptor_base_imp
     {
     private:
-        struct jdksavdecc_descriptor_locale locale_desc; // Structure containing the locale_desc fields
-
+        uint16_t m_type;
+        uint16_t m_index;
+        
     public:
         locale_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
         virtual ~locale_descriptor_imp();
-
+        
+        locale_descriptor_response_imp *resp;
+        
         uint16_t STDCALL descriptor_type() const;
         uint16_t STDCALL descriptor_index() const;
-        uint8_t * STDCALL locale_identifier();
-
-        uint16_t STDCALL number_of_strings();
-        uint16_t STDCALL base_strings();
+        locale_descriptor_response * STDCALL get_locale_response();
     };
 }
-

--- a/controller/lib/src/locale_descriptor_imp.h
+++ b/controller/lib/src/locale_descriptor_imp.h
@@ -38,10 +38,6 @@ namespace avdecc_lib
 {
     class locale_descriptor_imp : public locale_descriptor, public virtual descriptor_base_imp
     {
-    private:
-        uint16_t m_type;
-        uint16_t m_index;
-        
     public:
         locale_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
         virtual ~locale_descriptor_imp();

--- a/controller/lib/src/locale_descriptor_response_imp.cpp
+++ b/controller/lib/src/locale_descriptor_response_imp.cpp
@@ -34,7 +34,7 @@
 
 namespace avdecc_lib
 {
-    locale_descriptor_response_imp::locale_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos) : descriptor_base_imp(nullptr, frame, frame_len, pos)
+    locale_descriptor_response_imp::locale_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos)
     {
         frame_size = frame_len;
         buffer = (uint8_t *)malloc(frame_size * sizeof(uint8_t));
@@ -42,7 +42,10 @@ namespace avdecc_lib
         position = pos;
     }
 
-    locale_descriptor_response_imp::~locale_descriptor_response_imp() {}
+    locale_descriptor_response_imp::~locale_descriptor_response_imp()
+    {
+        free(buffer);
+    }
 
     uint8_t * STDCALL locale_descriptor_response_imp::locale_identifier()
     {

--- a/controller/lib/src/locale_descriptor_response_imp.cpp
+++ b/controller/lib/src/locale_descriptor_response_imp.cpp
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * locale_descriptor_response_imp.cpp
+ *
+ * LOCALE descriptor response implementation
+ */
+#include "avdecc_error.h"
+#include "enumeration.h"
+#include "log_imp.h"
+#include "locale_descriptor_response_imp.h"
+#include "end_station_imp.h"
+
+namespace avdecc_lib
+{
+    locale_descriptor_response_imp::locale_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos) : descriptor_base_imp(nullptr, frame, frame_len, pos)
+    {
+        frame_size = frame_len;
+        buffer = (uint8_t *)malloc(frame_size * sizeof(uint8_t));
+        memcpy(buffer, frame, frame_size);
+        position = pos;
+    }
+
+    locale_descriptor_response_imp::~locale_descriptor_response_imp() {}
+
+    uint8_t * STDCALL locale_descriptor_response_imp::locale_identifier()
+    {
+        return (uint8_t *)&buffer[position + JDKSAVDECC_DESCRIPTOR_LOCALE_OFFSET_LOCALE_IDENTIFIER];
+    }
+
+    uint16_t STDCALL locale_descriptor_response_imp::number_of_strings()
+    {
+        return jdksavdecc_descriptor_locale_get_number_of_strings(buffer, position);
+    }
+
+    uint16_t STDCALL locale_descriptor_response_imp::base_strings()
+    {
+        return jdksavdecc_descriptor_locale_get_base_strings(buffer, position);
+    }
+}

--- a/controller/lib/src/locale_descriptor_response_imp.h
+++ b/controller/lib/src/locale_descriptor_response_imp.h
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * locale_descriptor_response_imp.h
+ *
+ * LOCALE descriptor implementation class
+ */
+
+#pragma once
+
+#include "descriptor_base_imp.h"
+#include "locale_descriptor_response.h"
+#include "jdksavdecc_aem_command.h"
+
+namespace avdecc_lib
+{
+    class locale_descriptor_response_imp : public locale_descriptor_response, public virtual descriptor_base_imp
+    {
+    private:
+        uint8_t * buffer;
+        ssize_t position;
+        size_t frame_size;
+    public:
+        locale_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos);
+        virtual ~locale_descriptor_response_imp();
+
+        uint8_t * STDCALL locale_identifier();
+        uint16_t STDCALL number_of_strings();
+        uint16_t STDCALL base_strings();
+    };
+}

--- a/controller/lib/src/locale_descriptor_response_imp.h
+++ b/controller/lib/src/locale_descriptor_response_imp.h
@@ -24,18 +24,18 @@
 /**
  * locale_descriptor_response_imp.h
  *
- * LOCALE descriptor implementation class
+ * LOCALE descriptor response implementation class
  */
 
 #pragma once
 
-#include "descriptor_base_imp.h"
 #include "locale_descriptor_response.h"
 #include "jdksavdecc_aem_command.h"
+#include "jdksavdecc_aem_descriptor.h"
 
 namespace avdecc_lib
 {
-    class locale_descriptor_response_imp : public locale_descriptor_response, public virtual descriptor_base_imp
+    class locale_descriptor_response_imp : public locale_descriptor_response
     {
     private:
         uint8_t * buffer;

--- a/controller/lib/src/memory_object_descriptor_imp.cpp
+++ b/controller/lib/src/memory_object_descriptor_imp.cpp
@@ -47,19 +47,8 @@ namespace avdecc_lib
     memory_object_descriptor_response * STDCALL memory_object_descriptor_imp::get_memory_object_response()
     {
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
-        return resp = new memory_object_descriptor_response_imp(resp_ref->get_buffer(),
-                                                              resp_ref->get_size(), resp_ref->get_pos());
-    }
-
-    uint16_t STDCALL memory_object_descriptor_imp::descriptor_type() const
-    {
-        assert(jdksavdecc_descriptor_jack_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos()) == JDKSAVDECC_DESCRIPTOR_MEMORY_OBJECT);
-        return jdksavdecc_descriptor_jack_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
-    }
-
-    uint16_t STDCALL memory_object_descriptor_imp::descriptor_index() const
-    {
-        return jdksavdecc_descriptor_jack_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
+        return resp = new memory_object_descriptor_response_imp(resp_ref->get_desc_buffer(),
+                                                                resp_ref->get_desc_size(), resp_ref->get_desc_pos());
     }
 
     int STDCALL memory_object_descriptor_imp::start_operation_cmd(void *notification_id, uint16_t operation_type)
@@ -114,9 +103,9 @@ namespace avdecc_lib
     {
         struct jdksavdecc_frame cmd_frame;
         struct jdksavdecc_aem_command_start_operation_response aem_cmd_start_operation_resp;
-        memset(&aem_cmd_start_operation_resp,0,sizeof(aem_cmd_start_operation_resp));
 
         memcpy(cmd_frame.payload, frame, frame_len);
+        memset(&aem_cmd_start_operation_resp,0,sizeof(aem_cmd_start_operation_resp));
 
         ssize_t aem_cmd_start_operation_resp_returned = jdksavdecc_aem_command_start_operation_response_read(&aem_cmd_start_operation_resp,
                                                                                                              frame,

--- a/controller/lib/src/memory_object_descriptor_imp.cpp
+++ b/controller/lib/src/memory_object_descriptor_imp.cpp
@@ -40,11 +40,7 @@
 
 namespace avdecc_lib
 {
-    memory_object_descriptor_imp::memory_object_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos)
-    {
-        m_type = jdksavdecc_descriptor_jack_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
-        m_index = jdksavdecc_descriptor_jack_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
-    }
+    memory_object_descriptor_imp::memory_object_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos) {}
 
     memory_object_descriptor_imp::~memory_object_descriptor_imp() {}
     
@@ -57,13 +53,13 @@ namespace avdecc_lib
 
     uint16_t STDCALL memory_object_descriptor_imp::descriptor_type() const
     {
-        assert(m_type == JDKSAVDECC_DESCRIPTOR_MEMORY_OBJECT);
-        return m_type;
+        assert(jdksavdecc_descriptor_jack_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos()) == JDKSAVDECC_DESCRIPTOR_MEMORY_OBJECT);
+        return jdksavdecc_descriptor_jack_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 
     uint16_t STDCALL memory_object_descriptor_imp::descriptor_index() const
     {
-        return m_index;
+        return jdksavdecc_descriptor_jack_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 
     int STDCALL memory_object_descriptor_imp::start_operation_cmd(void *notification_id, uint16_t operation_type)

--- a/controller/lib/src/memory_object_descriptor_imp.cpp
+++ b/controller/lib/src/memory_object_descriptor_imp.cpp
@@ -27,6 +27,8 @@
  * MEMORY OBJECT descriptor implementation
  */
 
+#include <mutex>
+
 #include "avdecc_error.h"
 #include "enumeration.h"
 #include "log_imp.h"

--- a/controller/lib/src/memory_object_descriptor_imp.h
+++ b/controller/lib/src/memory_object_descriptor_imp.h
@@ -31,35 +31,28 @@
 
 #include "descriptor_base_imp.h"
 #include "memory_object_descriptor.h"
+#include "memory_object_descriptor_response_imp.h"
 
 namespace avdecc_lib
 {
     class memory_object_descriptor_imp : public memory_object_descriptor, public virtual descriptor_base_imp
     {
     private:
-        struct jdksavdecc_descriptor_memory_object memory_object_desc; // Structure containing the memory_object_desc fields
+        uint16_t m_type;
+        uint16_t m_index;
 
     public:
         memory_object_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
         virtual ~memory_object_descriptor_imp();
+        
+        memory_object_descriptor_response_imp *resp;
 
         uint16_t STDCALL descriptor_type() const;
         uint16_t STDCALL descriptor_index() const;
-        uint8_t * STDCALL object_name();
-        uint16_t STDCALL localized_description();
+        memory_object_descriptor_response * STDCALL get_memory_object_response();
 
-        uint16_t STDCALL memory_object_type();
-        uint16_t STDCALL target_descriptor_type();
-        uint16_t STDCALL target_descriptor_index();
-        uint64_t STDCALL start_address();
-        uint64_t STDCALL maximum_length();
-        uint64_t STDCALL length();
-        const char * STDCALL memory_object_type_to_str();
         int STDCALL start_operation_cmd(void *notification_id, uint16_t operation_type);
         int proc_start_operation_resp(void *&notification_id, const uint8_t *frame, size_t frame_len, int &status, uint16_t &operation_id, uint16_t &operation_type);
         int proc_operation_status_resp(void *&notification_id, const uint8_t *frame, size_t frame_len, int &status, uint16_t &operation_id, bool &is_operation_id_valid);
-
-    private:
     };
 }
-

--- a/controller/lib/src/memory_object_descriptor_imp.h
+++ b/controller/lib/src/memory_object_descriptor_imp.h
@@ -37,10 +37,6 @@ namespace avdecc_lib
 {
     class memory_object_descriptor_imp : public memory_object_descriptor, public virtual descriptor_base_imp
     {
-    private:
-        uint16_t m_type;
-        uint16_t m_index;
-
     public:
         memory_object_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
         virtual ~memory_object_descriptor_imp();

--- a/controller/lib/src/memory_object_descriptor_imp.h
+++ b/controller/lib/src/memory_object_descriptor_imp.h
@@ -43,8 +43,6 @@ namespace avdecc_lib
         
         memory_object_descriptor_response_imp *resp;
 
-        uint16_t STDCALL descriptor_type() const;
-        uint16_t STDCALL descriptor_index() const;
         memory_object_descriptor_response * STDCALL get_memory_object_response();
 
         int STDCALL start_operation_cmd(void *notification_id, uint16_t operation_type);

--- a/controller/lib/src/memory_object_descriptor_response_imp.cpp
+++ b/controller/lib/src/memory_object_descriptor_response_imp.cpp
@@ -22,9 +22,9 @@
  */
 
 /**
- * memory_object_descriptor_response_imp::.cpp
+ * memory_object_descriptor_response_imp.cpp
  *
- * MEMORY OBJECT descriptor implementation
+ * MEMORY OBJECT descriptor response implementation
  */
 
 #include "avdecc_error.h"
@@ -51,7 +51,7 @@ namespace avdecc_lib
         "SNAPSHOT_SETTINGS"
     };
     
-    memory_object_descriptor_response_imp::memory_object_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos) : descriptor_base_imp(nullptr, frame, frame_len, pos)
+    memory_object_descriptor_response_imp::memory_object_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos)
     {
         frame_size = frame_len;
         buffer = (uint8_t *)malloc(frame_size * sizeof(uint8_t));
@@ -59,7 +59,10 @@ namespace avdecc_lib
         position = pos;
     }
     
-    memory_object_descriptor_response_imp::~memory_object_descriptor_response_imp() {}
+    memory_object_descriptor_response_imp::~memory_object_descriptor_response_imp()
+    {
+        free(buffer);
+    }
     
     uint8_t * STDCALL memory_object_descriptor_response_imp::object_name()
     {

--- a/controller/lib/src/memory_object_descriptor_response_imp.cpp
+++ b/controller/lib/src/memory_object_descriptor_response_imp.cpp
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2013 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * memory_object_descriptor_response_imp::.cpp
+ *
+ * MEMORY OBJECT descriptor implementation
+ */
+
+#include "avdecc_error.h"
+#include "enumeration.h"
+#include "log_imp.h"
+#include "end_station_imp.h"
+#include "adp.h"
+#include "end_station_imp.h"
+#include "system_tx_queue.h"
+#include "acmp_controller_state_machine.h"
+#include "aecp_controller_state_machine.h"
+#include "memory_object_descriptor_response_imp.h"
+
+namespace avdecc_lib
+{
+#define MEMORY_OBJECT_NUM_STRINGS 6
+    const char *memory_object_type_str[] =
+    {
+        "FIRMWARE_IMAGE",
+        "VENDOR_SPECIFIC",
+        "CRASH_DUMP",
+        "LOG_OBJECT",
+        "AUTOSTART_SETTINGS",
+        "SNAPSHOT_SETTINGS"
+    };
+    
+    memory_object_descriptor_response_imp::memory_object_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos) : descriptor_base_imp(nullptr, frame, frame_len, pos)
+    {
+        frame_size = frame_len;
+        buffer = (uint8_t *)malloc(frame_size * sizeof(uint8_t));
+        memcpy(buffer, frame, frame_size);
+        position = pos;
+    }
+    
+    memory_object_descriptor_response_imp::~memory_object_descriptor_response_imp() {}
+    
+    uint8_t * STDCALL memory_object_descriptor_response_imp::object_name()
+    {
+        return (uint8_t *)&buffer[position + JDKSAVDECC_DESCRIPTOR_MEMORY_OBJECT_OFFSET_OBJECT_NAME];
+    }
+    
+    uint16_t STDCALL memory_object_descriptor_response_imp::localized_description()
+    {
+        return jdksavdecc_descriptor_memory_object_get_localized_description(buffer, position);
+    }
+    
+    uint16_t STDCALL memory_object_descriptor_response_imp::memory_object_type()
+    {
+        return jdksavdecc_descriptor_memory_object_get_memory_object_type(buffer, position);
+    }
+    
+    uint16_t STDCALL memory_object_descriptor_response_imp::target_descriptor_type()
+    {
+        return jdksavdecc_descriptor_memory_object_get_target_descriptor_type(buffer, position);
+    }
+    
+    uint16_t STDCALL memory_object_descriptor_response_imp::target_descriptor_index()
+    {
+        return jdksavdecc_descriptor_memory_object_get_target_descriptor_index(buffer, position);
+    }
+    
+    uint64_t STDCALL memory_object_descriptor_response_imp::start_address()
+    {
+        return jdksavdecc_descriptor_memory_object_get_start_address(buffer, position);
+    }
+    
+    uint64_t STDCALL memory_object_descriptor_response_imp::maximum_length()
+    {
+        return jdksavdecc_descriptor_memory_object_get_maximum_length(buffer, position);
+    }
+    
+    uint64_t STDCALL memory_object_descriptor_response_imp::length()
+    {
+        return jdksavdecc_descriptor_memory_object_get_length(buffer, position);
+    }
+    
+    const char * STDCALL memory_object_descriptor_response_imp::memory_object_type_to_str()
+    {
+        if(memory_object_type() < MEMORY_OBJECT_NUM_STRINGS)
+        {
+            return memory_object_type_str[memory_object_type()];
+        }
+        
+        return "UNKNOWN";
+    }
+}

--- a/controller/lib/src/memory_object_descriptor_response_imp.h
+++ b/controller/lib/src/memory_object_descriptor_response_imp.h
@@ -29,12 +29,12 @@
 
 #pragma once
 
-#include "descriptor_base_imp.h"
 #include "memory_object_descriptor_response.h"
+#include "jdksavdecc_aem_descriptor.h"
 
 namespace avdecc_lib
 {
-    class memory_object_descriptor_response_imp : public memory_object_descriptor_response, public virtual descriptor_base_imp
+    class memory_object_descriptor_response_imp : public memory_object_descriptor_response
     {
     private:
         uint8_t* buffer;

--- a/controller/lib/src/memory_object_descriptor_response_imp.h
+++ b/controller/lib/src/memory_object_descriptor_response_imp.h
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * memory_object_descriptor_response_imp.h
+ *
+ * MEMORY_OBJECT descriptor response implementation class
+ */
+
+#pragma once
+
+#include "descriptor_base_imp.h"
+#include "memory_object_descriptor_response.h"
+
+namespace avdecc_lib
+{
+    class memory_object_descriptor_response_imp : public memory_object_descriptor_response, public virtual descriptor_base_imp
+    {
+    private:
+        uint8_t* buffer;
+        ssize_t position;
+        size_t frame_size;
+    public:
+        memory_object_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos);
+        virtual ~memory_object_descriptor_response_imp();
+        
+        uint8_t * STDCALL object_name();
+        uint16_t STDCALL localized_description();
+        uint16_t STDCALL memory_object_type();
+        uint16_t STDCALL target_descriptor_type();
+        uint16_t STDCALL target_descriptor_index();
+        uint64_t STDCALL start_address();
+        uint64_t STDCALL maximum_length();
+        uint64_t STDCALL length();
+        const char * STDCALL memory_object_type_to_str();
+    };
+}

--- a/controller/lib/src/osx/net_interface_imp.cpp
+++ b/controller/lib/src/osx/net_interface_imp.cpp
@@ -259,6 +259,10 @@ namespace avdecc_lib
         for(uint32_t index_j = 0; index_j < 1; index_j++)
         {
             ether_packet = pcap_next(pcap_interface, &pcap_header);
+            if(!ether_packet)
+            {
+                break;
+            }
         }
 
         return 0;

--- a/controller/lib/src/osx/notification_imp.cpp
+++ b/controller/lib/src/osx/notification_imp.cpp
@@ -89,6 +89,11 @@ namespace avdecc_lib
         while (true)
         {
             status = sem_wait(notify_waiting);
+            
+            if(status == -1)
+            {
+                perror("sem error");
+            }
 
             if((write_index - read_index) > 0)
             {

--- a/controller/lib/src/osx/system_layer2_multithreaded_callback.cpp
+++ b/controller/lib/src/osx/system_layer2_multithreaded_callback.cpp
@@ -357,6 +357,10 @@ namespace avdecc_lib
         int rc;
 
         rc = ((system_layer2_multithreaded_callback *)param)->proc_poll_loop();
+        if(rc == -1)
+        {
+            perror("Process Poll Loop error");
+        }
 
         return 0;
     }

--- a/controller/lib/src/response_frame.cpp
+++ b/controller/lib/src/response_frame.cpp
@@ -36,7 +36,7 @@
 
 namespace avdecc_lib {
     
-    response_frame::response_frame(const uint8_t *frame, size_t size, ssize_t pos)
+    response_frame::response_frame(const uint8_t *frame, size_t size, size_t pos)
     {
         position = pos;
         frame_size = size;
@@ -55,7 +55,7 @@ namespace avdecc_lib {
         free(desc_buffer);
     }
     
-    int response_frame::replace_frame(const uint8_t *frame, ssize_t pos, size_t size)
+    int response_frame::replace_frame(const uint8_t *frame, size_t pos, size_t size)
     {
         uint8_t * replaced_buffer = NULL;
 
@@ -85,7 +85,7 @@ namespace avdecc_lib {
         return 0;
     }
     
-    int response_frame::replace_desc_frame(const uint8_t *frame, ssize_t pos, size_t size)
+    int response_frame::replace_desc_frame(const uint8_t *frame, size_t pos, size_t size)
     {
         uint8_t * replaced_buffer = NULL;
 
@@ -126,12 +126,12 @@ namespace avdecc_lib {
         return desc_buffer;
     }
 
-    ssize_t response_frame::get_pos()
+    size_t response_frame::get_pos()
     {
         return position;
     }
     
-    ssize_t response_frame::get_desc_pos()
+    size_t response_frame::get_desc_pos()
     {
         return desc_position;
     }

--- a/controller/lib/src/response_frame.cpp
+++ b/controller/lib/src/response_frame.cpp
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * response_frame.cpp
+ *
+ * Response Frame class stores the current frame whenever the replace_frame() method is called
+ */
+
+#include "response_frame.h"
+#include "build.h"
+#include <stdlib.h>
+#include <iostream>
+
+namespace avdecc_lib {
+    
+    response_frame::response_frame(const uint8_t *frame, size_t size, ssize_t pos)
+    {
+        buffer = (uint8_t *)malloc(size * sizeof(uint8_t)); //allocate space for the frame
+        replace_frame(frame, pos, size);
+    }
+    
+    response_frame::~response_frame()
+    {
+        free(buffer);
+    }
+    
+    void response_frame::replace_frame(const uint8_t *frame, ssize_t pos, size_t size)
+    {
+        if(size > frame_size)
+        {
+            buffer = (uint8_t *)malloc(size * sizeof(uint8_t)); //allocate space for the new frame
+            memcpy(buffer, frame, size);
+
+        }
+        else
+        {
+            assert(size <= frame_size);
+            memcpy(buffer, frame, size); //copy the new frame
+        }
+        
+        position = pos;
+        frame_size = size;
+    }
+
+    uint8_t * response_frame::get_buffer()
+    {
+        return buffer;
+    }
+    
+    ssize_t response_frame::get_pos()
+    {
+        return position;
+    }
+    
+    size_t response_frame::get_size()
+    {
+        return frame_size;
+    }
+}

--- a/controller/lib/src/response_frame.cpp
+++ b/controller/lib/src/response_frame.cpp
@@ -42,11 +42,17 @@ namespace avdecc_lib {
         frame_size = size;
         buffer = (uint8_t *)malloc(frame_size * sizeof(uint8_t)); //allocate space for the new frame
         memcpy(buffer, frame, frame_size);
+        
+        desc_frame_size = size;
+        desc_position = pos;
+        desc_buffer = (uint8_t *)malloc(desc_frame_size * sizeof(uint8_t));
+        memcpy(desc_buffer, frame, desc_frame_size);
     }
 
     response_frame::~response_frame()
     {
         free(buffer);
+        free(desc_buffer);
     }
     
     int response_frame::replace_frame(const uint8_t *frame, ssize_t pos, size_t size)
@@ -78,19 +84,66 @@ namespace avdecc_lib {
         
         return 0;
     }
+    
+    int response_frame::replace_desc_frame(const uint8_t *frame, ssize_t pos, size_t size)
+    {
+        uint8_t * replaced_buffer = NULL;
+
+        if(size <= desc_frame_size)
+        {
+            assert(size <= desc_frame_size);
+            memcpy(desc_buffer, frame, size);
+        }
+        else
+        {
+            replaced_buffer = (uint8_t *) realloc (desc_buffer, size * sizeof(uint8_t));
+            if(replaced_buffer != NULL)
+            {
+                desc_buffer = replaced_buffer;
+                memcpy(desc_buffer, frame, size);
+            }
+            else
+            {
+                log_imp_ref->post_log_msg(LOGGING_LEVEL_ERROR, "Error reallocating memory");
+                free(desc_buffer);
+                return -1;
+            }
+        }
+        desc_position = pos;
+        desc_frame_size = size;
+        
+        return 0;
+    }
+
 
     uint8_t * response_frame::get_buffer()
     {
         return buffer;
     }
     
+    uint8_t * response_frame::get_desc_buffer()
+    {
+        return desc_buffer;
+    }
+
     ssize_t response_frame::get_pos()
     {
         return position;
     }
     
+    ssize_t response_frame::get_desc_pos()
+    {
+        return desc_position;
+    }
+
     size_t response_frame::get_size()
     {
         return frame_size;
     }
+    
+    size_t response_frame::get_desc_size()
+    {
+        return desc_frame_size;
+    }
+
 }

--- a/controller/lib/src/stream_input_counters_response_imp.cpp
+++ b/controller/lib/src/stream_input_counters_response_imp.cpp
@@ -52,7 +52,10 @@ namespace avdecc_lib
         }
     }
     
-    stream_input_counters_response_imp::~stream_input_counters_response_imp(){}
+    stream_input_counters_response_imp::~stream_input_counters_response_imp()
+    {
+        free(m_frame);
+    }
     
     uint32_t STDCALL stream_input_counters_response_imp::get_counter_valid(int name)
     {

--- a/controller/lib/src/stream_input_counters_response_imp.cpp
+++ b/controller/lib/src/stream_input_counters_response_imp.cpp
@@ -1,0 +1,128 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * stream_input_counters_response_imp.cpp
+ *
+ * STREAM INPUT counters response implementation
+ */
+
+#include "enumeration.h"
+#include "log_imp.h"
+#include "stream_input_counters_response_imp.h"
+
+namespace avdecc_lib
+{
+    stream_input_counters_response_imp::stream_input_counters_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos)
+    {
+        m_position = pos;
+        m_size = frame_len;
+        m_frame = (uint8_t *)malloc(m_size * sizeof(uint8_t));
+        memcpy(m_frame, frame, m_size);
+
+        m_counters_valid = jdksavdecc_uint32_get(m_frame, ETHER_HDR_SIZE
+                                                 + JDKSAVDECC_AEM_COMMAND_GET_COUNTERS_RESPONSE_OFFSET_COUNTERS_VALID);
+        
+        for(int i = 0; i<31; i++){
+            int r = jdksavdecc_uint32_read(&m_counters_block[i], frame, ETHER_HDR_SIZE
+                                       + JDKSAVDECC_AEM_COMMAND_GET_COUNTERS_RESPONSE_OFFSET_COUNTERS_BLOCK + 4 * i,
+                                       frame_len);
+            if (r < 0)
+                break;
+        }
+    }
+    
+    stream_input_counters_response_imp::~stream_input_counters_response_imp(){}
+    
+    uint32_t STDCALL stream_input_counters_response_imp::get_counter_valid(int name)
+    {
+        switch(name)
+        {
+            case STREAM_INPUT_MEDIA_LOCKED:
+                return m_counters_valid & 0x01;
+            case STREAM_INPUT_MEDIA_UNLOCKED:
+                return m_counters_valid >> 1 & 0x01;
+            case STREAM_INPUT_STREAM_RESET:
+                return m_counters_valid >> 2 & 0x01;
+            case STREAM_INPUT_SEQ_NUM_MISMATCH:
+                return m_counters_valid >> 3 & 0x01;
+            case STREAM_INPUT_MEDIA_RESET:
+                return m_counters_valid >> 4 & 0x01;
+            case STREAM_INPUT_TIMESTAMP_UNCERTAIN:
+                return m_counters_valid >> 5 & 0x01;
+            case STREAM_INPUT_TIMESTAMP_VALID:
+                return m_counters_valid >> 6 & 0x01;
+            case STREAM_INPUT_TIMESTAMP_NOT_VALID:
+                return m_counters_valid >> 7 & 0x01;
+            case STREAM_INPUT_UNSUPPORTED_FORMAT:
+                return m_counters_valid >> 8 & 0x01;
+            case STREAM_INPUT_LATE_TIMESTAMP:
+                return m_counters_valid >> 9 & 0x01;
+            case STREAM_INPUT_EARLY_TIMESTAMP:
+                return m_counters_valid >> 10 & 0x01;
+            case STREAM_INPUT_FRAMES_RX:
+                return m_counters_valid >> 11 & 0x01;
+            case STREAM_INPUT_FRAMES_TX:
+                return m_counters_valid >> 12 & 0x01;
+            default:
+                log_imp_ref->post_log_msg(LOGGING_LEVEL_ERROR, "counter name not found");
+        }
+        return 0;
+    }
+
+    uint32_t STDCALL stream_input_counters_response_imp::get_counter_by_name(int name)
+    {
+        switch(name)
+        {
+            case STREAM_INPUT_MEDIA_LOCKED:
+                return m_counters_block[0];
+            case STREAM_INPUT_MEDIA_UNLOCKED:
+                return m_counters_block[1];
+            case STREAM_INPUT_STREAM_RESET:
+                return m_counters_block[2];
+            case STREAM_INPUT_SEQ_NUM_MISMATCH:
+                return m_counters_block[3];
+            case STREAM_INPUT_MEDIA_RESET:
+                return m_counters_block[4];
+            case STREAM_INPUT_TIMESTAMP_UNCERTAIN:
+                return m_counters_block[5];
+            case STREAM_INPUT_TIMESTAMP_VALID:
+                return m_counters_block[6];
+            case STREAM_INPUT_TIMESTAMP_NOT_VALID:
+                return m_counters_block[7];
+            case STREAM_INPUT_UNSUPPORTED_FORMAT:
+                return m_counters_block[8];
+            case STREAM_INPUT_LATE_TIMESTAMP:
+                return m_counters_block[9];
+            case STREAM_INPUT_EARLY_TIMESTAMP:
+                return m_counters_block[10];
+            case STREAM_INPUT_FRAMES_RX:
+                return m_counters_block[11];
+            case STREAM_INPUT_FRAMES_TX:
+                return m_counters_block[12];
+            default:
+                log_imp_ref->post_log_msg(LOGGING_LEVEL_ERROR, "counter name not found");
+        }
+        return 0;
+    }
+}

--- a/controller/lib/src/stream_input_counters_response_imp.h
+++ b/controller/lib/src/stream_input_counters_response_imp.h
@@ -47,7 +47,7 @@ namespace avdecc_lib
         stream_input_counters_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos);
         virtual ~stream_input_counters_response_imp();
         
-        uint32_t get_counter_valid(int name);
-        uint32_t get_counter_by_name(int name);
+        uint32_t STDCALL get_counter_valid(int name);
+        uint32_t STDCALL get_counter_by_name(int name);
     };
 }

--- a/controller/lib/src/stream_input_counters_response_imp.h
+++ b/controller/lib/src/stream_input_counters_response_imp.h
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * stream_input_counters_response_imp.h
+ *
+ * STREAM INPUT counters response implementation class
+ */
+
+#pragma once
+
+#include "stream_input_counters_response.h"
+#include "descriptor_base_imp.h"
+
+namespace avdecc_lib
+{
+    class stream_input_counters_response_imp : public stream_input_counters_response
+    {
+    private:
+        uint32_t m_counters_valid;
+        uint32_t m_counters_block [31];
+        uint8_t * m_frame;
+        size_t m_size;
+        ssize_t m_position;
+        
+    public:
+        stream_input_counters_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos);
+        virtual ~stream_input_counters_response_imp();
+        
+        uint32_t get_counter_valid(int name);
+        uint32_t get_counter_by_name(int name);
+    };
+}

--- a/controller/lib/src/stream_input_descriptor_imp.cpp
+++ b/controller/lib/src/stream_input_descriptor_imp.cpp
@@ -41,286 +41,63 @@
 
 namespace avdecc_lib
 {
-    stream_input_descriptor_imp::stream_input_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj)
+    stream_input_descriptor_imp::stream_input_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos)
     {
-        ssize_t ret = jdksavdecc_descriptor_stream_read(&stream_input_desc, frame, pos, frame_len);
-
-        if (ret < 0)
-        {
-            throw avdecc_read_descriptor_error("stream_input_desc_read error");
-        }
-
-        memset(&stream_input_flags, 0, sizeof(struct stream_input_desc_stream_flags));
-        memset(&aem_cmd_set_stream_format_resp, 0, sizeof(struct jdksavdecc_aem_command_set_stream_format_response));
-        memset(&aem_cmd_get_stream_format_resp, 0, sizeof(struct jdksavdecc_aem_command_get_stream_format_response));
-        memset(&aem_cmd_set_stream_info_resp, 0, sizeof(struct jdksavdecc_aem_command_set_stream_info_response));
-        memset(&aem_cmd_get_stream_info_resp, 0, sizeof(struct jdksavdecc_aem_command_get_stream_info_response));
-        memset(&aem_cmd_get_counters_resp, 0, sizeof(struct jdksavdecc_aem_command_get_counters_response));
-        
-        memset(&acmp_cmd_get_rx_state_resp, 0, sizeof(struct jdksavdecc_acmpdu));
-
-        stream_flags_init();
+        m_type = jdksavdecc_descriptor_stream_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
+        m_index = jdksavdecc_descriptor_stream_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 
     stream_input_descriptor_imp::~stream_input_descriptor_imp() {}
-
-    void stream_input_descriptor_imp::stream_flags_init()
+    
+    stream_input_descriptor_response * STDCALL stream_input_descriptor_imp::get_stream_input_response()
     {
-        stream_input_flags.clock_sync_source = stream_input_desc.stream_flags & 0x01;
-        stream_input_flags.class_a = stream_input_desc.stream_flags >> 1 & 0x01;
-        stream_input_flags.class_b = stream_input_desc.stream_flags >> 2 & 0x01;
-        stream_input_flags.supports_encrypted = stream_input_desc.stream_flags >> 3 & 0x01;
-        stream_input_flags.primary_backup_supported = stream_input_desc.stream_flags >> 4 & 0x01;
-        stream_input_flags.primary_backup_valid = stream_input_desc.stream_flags >> 5 & 0x01;
-        stream_input_flags.secondary_backup_supported = stream_input_desc.stream_flags >> 6 & 0x01;
-        stream_input_flags.secondary_backup_valid = stream_input_desc.stream_flags >> 7 & 0x01;
-        stream_input_flags.tertiary_backup_supported = stream_input_desc.stream_flags >> 8 & 0x01;
-        stream_input_flags.tertiary_backup_valid = stream_input_desc.stream_flags >> 9 & 0x01;
+        std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
+        return resp = new stream_input_descriptor_response_imp(resp_ref->get_buffer(),
+                                                               resp_ref->get_size(), resp_ref->get_pos());
+    }
+    
+    stream_input_counters_response * STDCALL stream_input_descriptor_imp::get_stream_input_counters_response()
+    {
+        std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
+        return counters_resp = new stream_input_counters_response_imp(resp_ref->get_buffer(),
+                                                                      resp_ref->get_size(), resp_ref->get_pos());
+    }
+    
+    stream_input_get_stream_format_response * STDCALL stream_input_descriptor_imp::get_stream_input_get_stream_format_response()
+    {
+        std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
+        return get_format_resp  = new stream_input_get_stream_format_response_imp(resp_ref->get_buffer(),
+                                                                                  resp_ref->get_size(), resp_ref->get_pos());
+    }
+    
+    stream_input_get_stream_info_response * STDCALL stream_input_descriptor_imp::get_stream_input_get_stream_info_response()
+    {
+        std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
+        return get_info_resp  = new stream_input_get_stream_info_response_imp(resp_ref->get_buffer(),
+                                                                                  resp_ref->get_size(), resp_ref->get_pos());
+    }
+    
+    stream_input_get_rx_state_response * STDCALL stream_input_descriptor_imp::get_stream_input_get_rx_state_response()
+    {
+        std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
+        return get_rx_state_resp  = new stream_input_get_rx_state_response_imp(resp_ref->get_buffer(),
+                                                                              resp_ref->get_size(), resp_ref->get_pos());
     }
 
     uint16_t STDCALL stream_input_descriptor_imp::descriptor_type() const
     {
-        assert(stream_input_desc.descriptor_type == JDKSAVDECC_DESCRIPTOR_STREAM_INPUT);
-        return stream_input_desc.descriptor_type;
+        assert(m_type == JDKSAVDECC_DESCRIPTOR_STREAM_INPUT);
+        return m_type;
     }
 
     uint16_t STDCALL stream_input_descriptor_imp::descriptor_index() const
     {
-        return stream_input_desc.descriptor_index;
+        return m_index;
     }
-
-    uint8_t * STDCALL stream_input_descriptor_imp::object_name()
-    {
-        return stream_input_desc.object_name.value;
-    }
-
-    uint16_t STDCALL stream_input_descriptor_imp::localized_description()
-    {
-        return stream_input_desc.localized_description;
-    }
-
-    uint16_t STDCALL stream_input_descriptor_imp::clock_domain_index()
-    {
-        return stream_input_desc.clock_domain_index;
-    }
-
-    uint16_t stream_input_descriptor_imp::stream_flags()
-    {
-        return stream_input_desc.stream_flags;
-    }
-
-    bool STDCALL stream_input_descriptor_imp::stream_flags_clock_sync_source()
-    {
-        return stream_input_flags.clock_sync_source;
-    }
-
-    bool STDCALL stream_input_descriptor_imp::stream_flags_class_a()
-    {
-        return stream_input_flags.class_a;
-    }
-
-    bool STDCALL stream_input_descriptor_imp::stream_flags_class_b()
-    {
-        return stream_input_flags.class_b;
-    }
-
-    bool STDCALL stream_input_descriptor_imp::stream_flags_supports_encrypted()
-    {
-        return stream_input_flags.supports_encrypted;
-    }
-
-    bool STDCALL stream_input_descriptor_imp::stream_flags_primary_backup_supported()
-    {
-        return stream_input_flags.primary_backup_supported;
-    }
-
-    bool STDCALL stream_input_descriptor_imp::stream_flags_primary_backup_valid()
-    {
-        return stream_input_flags.primary_backup_valid;
-    }
-
-    bool STDCALL stream_input_descriptor_imp::stream_flags_secondary_backup_supported()
-    {
-        return stream_input_flags.secondary_backup_supported;
-    }
-
-    bool STDCALL stream_input_descriptor_imp::stream_flags_secondary_backup_valid()
-    {
-        return stream_input_flags.secondary_backup_valid;
-    }
-
-    bool STDCALL stream_input_descriptor_imp::stream_flags_tertiary_backup_supported()
-    {
-        return stream_input_flags.tertiary_backup_supported;
-    }
-
-    bool STDCALL stream_input_descriptor_imp::stream_flags_tertiary_backup_valid()
-    {
-        return stream_input_flags.tertiary_backup_valid;
-    }
-
-    const char * STDCALL stream_input_descriptor_imp::current_format()
-    {
-        uint64_t current_format = jdksavdecc_uint64_get(&stream_input_desc.current_format, 0);
-        return utility::ieee1722_format_value_to_name(current_format);
-    }
-
-    uint16_t stream_input_descriptor_imp::formats_offset()
-    {
-        assert(stream_input_desc.formats_offset == 132);
-        return stream_input_desc.formats_offset;
-    }
-
-    uint16_t STDCALL stream_input_descriptor_imp::number_of_formats()
-    {
-        assert(stream_input_desc.number_of_formats <= 47);
-        return stream_input_desc.number_of_formats;
-    }
-
-    uint64_t STDCALL stream_input_descriptor_imp::backup_talker_entity_id_0()
-    {
-        return jdksavdecc_uint64_get(&stream_input_desc.backup_talker_entity_id_0, 0);
-    }
-
-    uint16_t STDCALL stream_input_descriptor_imp::backup_talker_unique_0()
-    {
-        return stream_input_desc.backup_talker_unique_0;
-    }
-
-    uint64_t STDCALL stream_input_descriptor_imp::backup_talker_entity_id_1()
-    {
-        return jdksavdecc_uint64_get(&stream_input_desc.backup_talker_entity_id_1, 0);
-    }
-
-    uint16_t STDCALL stream_input_descriptor_imp::backup_talker_unique_1()
-    {
-        return stream_input_desc.backup_talker_unique_1;
-    }
-
-    uint64_t STDCALL stream_input_descriptor_imp::backup_talker_entity_id_2()
-    {
-        return jdksavdecc_uint64_get(&stream_input_desc.backup_talker_entity_id_2, 0);
-    }
-
-    uint16_t STDCALL stream_input_descriptor_imp::backup_talker_unique_2()
-    {
-        return stream_input_desc.backup_talker_unique_2;
-    }
-
-    uint64_t STDCALL stream_input_descriptor_imp::backedup_talker_entity_id()
-    {
-        return jdksavdecc_uint64_get(&stream_input_desc.backedup_talker_entity_id, 0);
-    }
-
-    uint16_t STDCALL stream_input_descriptor_imp::backedup_talker_unique()
-    {
-        return stream_input_desc.backedup_talker_unique;
-    }
-
-    uint16_t STDCALL stream_input_descriptor_imp::avb_interface_index()
-    {
-        return stream_input_desc.avb_interface_index;
-    }
-
-    uint32_t STDCALL stream_input_descriptor_imp::buffer_length()
-    {
-        return stream_input_desc.buffer_length;
-    }
-
+    
     uint64_t STDCALL stream_input_descriptor_imp::set_stream_format_stream_format()
     {
         return jdksavdecc_uint64_get(&aem_cmd_set_stream_format_resp.stream_format, 0);
-    }
-
-    void stream_input_descriptor_imp::update_stream_format(struct jdksavdecc_eui64 stream_format)
-    {
-        stream_input_desc.current_format = stream_format;
-    }
-
-    uint64_t STDCALL stream_input_descriptor_imp::get_stream_format_stream_format()
-    {
-        return jdksavdecc_uint64_get(&aem_cmd_get_stream_format_resp.stream_format, 0);
-    }
-
-    uint32_t STDCALL stream_input_descriptor_imp::get_stream_info_flags()
-    {
-        return aem_cmd_get_stream_info_resp.aem_stream_info_flags;
-    }
-
-    uint64_t STDCALL stream_input_descriptor_imp::get_stream_info_stream_format()
-    {
-        return jdksavdecc_uint64_get(&aem_cmd_get_stream_info_resp.stream_format, 0);
-    }
-
-    uint64_t STDCALL stream_input_descriptor_imp::get_stream_info_stream_id()
-    {
-        return jdksavdecc_uint64_get(&aem_cmd_get_stream_info_resp.stream_id, 0);
-    }
-
-    uint32_t STDCALL stream_input_descriptor_imp::get_stream_info_msrp_accumulated_latency()
-    {
-        return aem_cmd_get_stream_info_resp.msrp_accumulated_latency;
-    }
-
-    uint64_t STDCALL stream_input_descriptor_imp::get_stream_info_stream_dest_mac()
-    {
-        uint64_t stream_dest_mac;
-        utility::convert_eui48_to_uint64(aem_cmd_get_stream_info_resp.stream_dest_mac.value, stream_dest_mac);
-
-        return stream_dest_mac;
-    }
-
-    uint8_t STDCALL stream_input_descriptor_imp::get_stream_info_msrp_failure_code()
-    {
-        return aem_cmd_get_stream_info_resp.msrp_failure_code;
-    }
-
-    uint64_t STDCALL stream_input_descriptor_imp::get_stream_info_msrp_failure_bridge_id()
-    {
-        return jdksavdecc_uint64_get(&aem_cmd_get_stream_info_resp.msrp_failure_bridge_id, 0);
-    }
-
-    bool stream_input_descriptor_imp::is_clock_sync_source_set()
-    {
-        return stream_input_flags.clock_sync_source;
-    }
-
-    uint64_t STDCALL stream_input_descriptor_imp::get_rx_state_stream_id()
-    {
-        return jdksavdecc_uint64_get(&acmp_cmd_get_rx_state_resp.header.stream_id.value, 0);
-    }
-
-    uint16_t STDCALL stream_input_descriptor_imp::get_rx_state_talker_unique_id()
-    {
-        return acmp_cmd_get_rx_state_resp.talker_unique_id;
-    }
-
-    uint16_t STDCALL stream_input_descriptor_imp::get_rx_state_listener_unique_id()
-    {
-        return acmp_cmd_get_rx_state_resp.listener_unique_id;
-    }
-
-    uint64_t STDCALL stream_input_descriptor_imp::get_rx_state_stream_dest_mac()
-    {
-        uint64_t stream_dest_mac;
-        utility::convert_eui48_to_uint64(acmp_cmd_get_rx_state_resp.stream_dest_mac.value, stream_dest_mac); 
-
-        return stream_dest_mac;
-    }
-
-    uint16_t STDCALL stream_input_descriptor_imp::get_rx_state_connection_count()
-    {
-        return acmp_cmd_get_rx_state_resp.connection_count;
-    }
-
-    uint16_t STDCALL stream_input_descriptor_imp::get_rx_state_flags()
-    {
-        return acmp_cmd_get_rx_state_resp.flags;
-    }
-
-    uint16_t STDCALL stream_input_descriptor_imp::get_rx_state_stream_vlan_id()
-    {
-        return acmp_cmd_get_rx_state_resp.stream_vlan_id;
     }
 
     int STDCALL stream_input_descriptor_imp::send_set_stream_format_cmd(void *notification_id, uint64_t new_stream_format)
@@ -392,11 +169,6 @@ namespace avdecc_lib
 
         aecp_controller_state_machine_ref->update_inflight_for_rcvd_resp(notification_id, msg_type, u_field, &cmd_frame);
 
-        if(status == AEM_STATUS_SUCCESS)
-        {
-            update_stream_format(aem_cmd_set_stream_format_resp.stream_format);
-        }
-
         return 0;
     }
 
@@ -444,27 +216,29 @@ namespace avdecc_lib
     int stream_input_descriptor_imp::proc_get_stream_format_resp(void *&notification_id, const uint8_t *frame, size_t frame_len, int &status)
     {
         struct jdksavdecc_frame cmd_frame;
+        struct jdksavdecc_aem_command_get_stream_format_response m_stream_format_response;
         ssize_t aem_cmd_get_stream_format_resp_returned;
         uint32_t msg_type;
         bool u_field;
 
         memcpy(cmd_frame.payload, frame, frame_len);
 
-        aem_cmd_get_stream_format_resp_returned = jdksavdecc_aem_command_get_stream_format_response_read(&aem_cmd_get_stream_format_resp,
+        aem_cmd_get_stream_format_resp_returned = jdksavdecc_aem_command_get_stream_format_response_read(&m_stream_format_response,
                                                                                                          frame,
                                                                                                          ETHER_HDR_SIZE,
                                                                                                          frame_len);
-
         if(aem_cmd_get_stream_format_resp_returned < 0)
         {
             log_imp_ref->post_log_msg(LOGGING_LEVEL_ERROR, "aem_cmd_get_stream_format_resp_read error\n");
             assert(aem_cmd_get_stream_format_resp_returned >= 0);
             return -1;
         }
+        
+        replace_frame(frame, ETHER_HDR_SIZE, frame_len);
 
-        msg_type = aem_cmd_get_stream_format_resp.aem_header.aecpdu_header.header.message_type;
-        status = aem_cmd_get_stream_format_resp.aem_header.aecpdu_header.header.status;
-        u_field = aem_cmd_get_stream_format_resp.aem_header.command_type >> 15 & 0x01; // u_field = the msb of the uint16_t command_type
+        msg_type = m_stream_format_response.aem_header.aecpdu_header.header.message_type;
+        status = m_stream_format_response.aem_header.aecpdu_header.header.status;
+        u_field = m_stream_format_response.aem_header.command_type >> 15 & 0x01; // u_field = the msb of the uint16_t command_type
 
         aecp_controller_state_machine_ref->update_inflight_for_rcvd_resp(notification_id, msg_type, u_field, &cmd_frame);
 
@@ -529,12 +303,13 @@ namespace avdecc_lib
     int stream_input_descriptor_imp::proc_get_stream_info_resp(void *&notification_id, const uint8_t *frame, size_t frame_len, int &status)
     {
         struct jdksavdecc_frame cmd_frame;
+        struct jdksavdecc_aem_command_get_stream_info_response m_stream_info_resp;
         ssize_t aem_cmd_get_stream_info_resp_returned;
         uint32_t msg_type;
         bool u_field;
 
         memcpy(cmd_frame.payload, frame, frame_len);
-        aem_cmd_get_stream_info_resp_returned = jdksavdecc_aem_command_get_stream_info_response_read(&aem_cmd_get_stream_info_resp,
+        aem_cmd_get_stream_info_resp_returned = jdksavdecc_aem_command_get_stream_info_response_read(&m_stream_info_resp,
                                                                                                      frame,
                                                                                                      ETHER_HDR_SIZE,
                                                                                                      frame_len);
@@ -545,10 +320,12 @@ namespace avdecc_lib
             assert(aem_cmd_get_stream_info_resp_returned >= 0);
             return -1;
         }
+        
+        replace_frame(frame, ETHER_HDR_SIZE, frame_len);
 
-        msg_type = aem_cmd_get_stream_info_resp.aem_header.aecpdu_header.header.message_type;
-        status = aem_cmd_get_stream_info_resp.aem_header.aecpdu_header.header.status;
-        u_field = aem_cmd_get_stream_info_resp.aem_header.command_type >> 15 & 0x01; // u_field = the msb of the uint16_t command_type
+        msg_type = m_stream_info_resp.aem_header.aecpdu_header.header.message_type;
+        status = m_stream_info_resp.aem_header.aecpdu_header.header.status;
+        u_field = m_stream_info_resp.aem_header.command_type >> 15 & 0x01; // u_field = the msb of the uint16_t command_type
 
         aecp_controller_state_machine_ref->update_inflight_for_rcvd_resp(notification_id, msg_type, u_field, &cmd_frame);
 
@@ -699,10 +476,11 @@ namespace avdecc_lib
 
     int STDCALL stream_input_descriptor_imp::send_connect_rx_cmd(void *notification_id, uint64_t talker_entity_id, uint16_t talker_unique_id, uint16_t flags)
     {
+        entity_descriptor_response *entity_resp_ref = base_end_station_imp_ref->get_entity_desc_by_index(0)->get_entity_response();
         struct jdksavdecc_frame cmd_frame;
         struct jdksavdecc_acmpdu acmp_cmd_connect_rx;
         ssize_t acmp_cmd_connect_rx_returned;
-        uint64_t listener_entity_id = base_end_station_imp_ref->get_entity_desc_by_index(0)->entity_id();
+        uint64_t listener_entity_id = entity_resp_ref->entity_id();
 
         /****************************************** ACMP Common Data *****************************************/
         acmp_cmd_connect_rx.controller_entity_id = base_end_station_imp_ref->get_adp()->get_controller_entity_id();
@@ -732,7 +510,8 @@ namespace avdecc_lib
 
         acmp_controller_state_machine_ref->common_hdr_init(JDKSAVDECC_ACMP_MESSAGE_TYPE_CONNECT_RX_COMMAND, &cmd_frame);
         system_queue_tx(notification_id, CMD_WITH_NOTIFICATION, cmd_frame.payload, cmd_frame.length);
-
+        
+        free(entity_resp_ref);
         return 0;
     }
 
@@ -763,10 +542,11 @@ namespace avdecc_lib
 
     int STDCALL stream_input_descriptor_imp::send_disconnect_rx_cmd(void *notification_id, uint64_t talker_entity_id, uint16_t talker_unique_id)
     {
+        entity_descriptor_response *entity_resp_ref = base_end_station_imp_ref->get_entity_desc_by_index(0)->get_entity_response();
         struct jdksavdecc_frame cmd_frame;
         struct jdksavdecc_acmpdu acmp_cmd_disconnect_rx;
         ssize_t acmp_cmd_disconnect_rx_returned;
-        uint64_t listener_entity_id = base_end_station_imp_ref->get_entity_desc_by_index(0)->entity_id();
+        uint64_t listener_entity_id = entity_resp_ref->entity_id();
 
         /******************************************* ACMP Common Data *******************************************/
         acmp_cmd_disconnect_rx.controller_entity_id = base_end_station_imp_ref->get_adp()->get_controller_entity_id();
@@ -797,6 +577,7 @@ namespace avdecc_lib
         acmp_controller_state_machine_ref->common_hdr_init(JDKSAVDECC_ACMP_MESSAGE_TYPE_DISCONNECT_RX_COMMAND, &cmd_frame);
         system_queue_tx(notification_id, CMD_WITH_NOTIFICATION, cmd_frame.payload, cmd_frame.length);
 
+        free(entity_resp_ref);
         return 0;
     }
 
@@ -827,10 +608,11 @@ namespace avdecc_lib
 
     int STDCALL stream_input_descriptor_imp::send_get_rx_state_cmd(void *notification_id)
     {
+        entity_descriptor_response *entity_resp_ref = base_end_station_imp_ref->get_entity_desc_by_index(0)->get_entity_response();
         struct jdksavdecc_frame cmd_frame;
         struct jdksavdecc_acmpdu acmp_cmd_get_rx_state;
         ssize_t acmp_cmd_get_rx_state_returned;
-        uint64_t listener_entity_id = base_end_station_imp_ref->get_entity_desc_by_index(0)->entity_id();
+        uint64_t listener_entity_id = entity_resp_ref->entity_id();
 
         /******************************************* ACMP Common Data ******************************************/
         acmp_cmd_get_rx_state.controller_entity_id = base_end_station_imp_ref->get_adp()->get_controller_entity_id();
@@ -861,12 +643,14 @@ namespace avdecc_lib
         acmp_controller_state_machine_ref->common_hdr_init(JDKSAVDECC_ACMP_MESSAGE_TYPE_GET_RX_STATE_COMMAND, &cmd_frame);
         system_queue_tx(notification_id, CMD_WITH_NOTIFICATION, cmd_frame.payload, cmd_frame.length);
 
+        free(entity_resp_ref);
         return 0;
     }
 
     int stream_input_descriptor_imp::proc_get_rx_state_resp(void *&notification_id, const uint8_t *frame, size_t frame_len, int &status)
     {
         struct jdksavdecc_frame cmd_frame;
+        struct jdksavdecc_acmpdu acmp_cmd_get_rx_state_resp; // Store the response received after sending a GET_RX_STATE command.
         ssize_t acmp_cmd_get_rx_state_resp_returned;
 
         memcpy(cmd_frame.payload, frame, frame_len);
@@ -881,6 +665,8 @@ namespace avdecc_lib
             assert(acmp_cmd_get_rx_state_resp_returned >= 0);
             return -1;
         }
+        
+        replace_frame(frame, ETHER_HDR_SIZE, frame_len);
 
         status = acmp_cmd_get_rx_state_resp.header.status;
 
@@ -933,28 +719,20 @@ namespace avdecc_lib
     int stream_input_descriptor_imp::proc_get_counters_resp(void *&notification_id, const uint8_t *frame, size_t frame_len, int &status)
     {
         struct jdksavdecc_frame cmd_frame;
+        struct jdksavdecc_aem_command_get_counters_response stream_input_counters_resp;
         ssize_t aem_cmd_get_stream_input_counters_resp_returned;
         uint32_t msg_type;
         bool u_field;
-        int i = 0;
-        int r = 0;
         
         memcpy(cmd_frame.payload, frame, frame_len);
         
-        aem_cmd_get_stream_input_counters_resp_returned = jdksavdecc_aem_command_get_counters_response_read(&aem_cmd_get_counters_resp,
-                                                                                                      frame,
-                                                                                                      ETHER_HDR_SIZE,
-                                                                                                      frame_len);
+        aem_cmd_get_stream_input_counters_resp_returned = jdksavdecc_aem_command_get_counters_response_read(&stream_input_counters_resp,
+                                                                                                            frame,
+                                                                                                            ETHER_HDR_SIZE,
+                                                                                                            frame_len);
         
-        for(i = 0; i<31; i++){
-            r = jdksavdecc_uint32_read(&counters_response.counters_block[i], frame, ETHER_HDR_SIZE + JDKSAVDECC_AEM_COMMAND_GET_COUNTERS_RESPONSE_OFFSET_COUNTERS_BLOCK + 4 * i,
-                                       frame_len);
-            
-            if (r < 0)
-                break;
-        }
+        replace_frame(frame, ETHER_HDR_SIZE, frame_len);
 
-        
         if(aem_cmd_get_stream_input_counters_resp_returned < 0)
         {
             log_imp_ref->post_log_msg(LOGGING_LEVEL_ERROR, "aem_cmd_get_stream_input_counters_resp_read error\n");
@@ -962,84 +740,12 @@ namespace avdecc_lib
             return -1;
         }
         
-        msg_type = aem_cmd_get_counters_resp.aem_header.aecpdu_header.header.message_type;
-        status = aem_cmd_get_counters_resp.aem_header.aecpdu_header.header.status;
-        u_field = aem_cmd_get_counters_resp.aem_header.command_type >> 15 & 0x01; // u_field = the msb of the uint16_t command_type
+        msg_type =stream_input_counters_resp.aem_header.aecpdu_header.header.message_type;
+        status = stream_input_counters_resp.aem_header.aecpdu_header.header.status;
+        u_field = stream_input_counters_resp.aem_header.command_type >> 15 & 0x01; // u_field = the msb of the uint16_t command_type
         
         aecp_controller_state_machine_ref->update_inflight_for_rcvd_resp(notification_id, msg_type, u_field, &cmd_frame);
         
-        return 0;
-    }
-    
-    uint32_t STDCALL stream_input_descriptor_imp::get_counter_by_name(int name)
-    {
-        switch(name)
-        {
-            case STREAM_INPUT_MEDIA_LOCKED:
-                return counters_response.counters_block[0];
-            case STREAM_INPUT_MEDIA_UNLOCKED:
-                return counters_response.counters_block[1];
-            case STREAM_INPUT_STREAM_RESET:
-                return counters_response.counters_block[2];
-            case STREAM_INPUT_SEQ_NUM_MISMATCH:
-                return counters_response.counters_block[3];
-            case STREAM_INPUT_MEDIA_RESET:
-                return counters_response.counters_block[4];
-            case STREAM_INPUT_TIMESTAMP_UNCERTAIN:
-                return counters_response.counters_block[5];
-            case STREAM_INPUT_TIMESTAMP_VALID:
-                return counters_response.counters_block[6];
-            case STREAM_INPUT_TIMESTAMP_NOT_VALID:
-                return counters_response.counters_block[7];
-            case STREAM_INPUT_UNSUPPORTED_FORMAT:
-                return counters_response.counters_block[8];
-            case STREAM_INPUT_LATE_TIMESTAMP:
-                return counters_response.counters_block[9];
-            case STREAM_INPUT_EARLY_TIMESTAMP:
-                return counters_response.counters_block[10];
-            case STREAM_INPUT_FRAMES_RX:
-                return counters_response.counters_block[11];
-            case STREAM_INPUT_FRAMES_TX:
-                return counters_response.counters_block[12];
-            default:
-                log_imp_ref->post_log_msg(LOGGING_LEVEL_ERROR, "counter name not found");
-        }
-        return 0;
-    }
-    
-    uint32_t STDCALL stream_input_descriptor_imp::get_counter_valid(int name)
-    {
-        switch(name)
-        {
-            case STREAM_INPUT_MEDIA_LOCKED:
-                return aem_cmd_get_counters_resp.counters_valid & 0x01;
-            case STREAM_INPUT_MEDIA_UNLOCKED:
-                return aem_cmd_get_counters_resp.counters_valid >> 1 & 0x01;
-            case STREAM_INPUT_STREAM_RESET:
-                return aem_cmd_get_counters_resp.counters_valid >> 2 & 0x01;
-            case STREAM_INPUT_SEQ_NUM_MISMATCH:
-                return aem_cmd_get_counters_resp.counters_valid >> 3 & 0x01;
-            case STREAM_INPUT_MEDIA_RESET:
-                return aem_cmd_get_counters_resp.counters_valid >> 4 & 0x01;
-            case STREAM_INPUT_TIMESTAMP_UNCERTAIN:
-                return aem_cmd_get_counters_resp.counters_valid >> 5 & 0x01;
-            case STREAM_INPUT_TIMESTAMP_VALID:
-                return aem_cmd_get_counters_resp.counters_valid >> 6 & 0x01;
-            case STREAM_INPUT_TIMESTAMP_NOT_VALID:
-                return aem_cmd_get_counters_resp.counters_valid >> 7 & 0x01;
-            case STREAM_INPUT_UNSUPPORTED_FORMAT:
-                return aem_cmd_get_counters_resp.counters_valid >> 8 & 0x01;
-            case STREAM_INPUT_LATE_TIMESTAMP:
-                return aem_cmd_get_counters_resp.counters_valid >> 9 & 0x01;
-            case STREAM_INPUT_EARLY_TIMESTAMP:
-                return aem_cmd_get_counters_resp.counters_valid >> 10 & 0x01;
-            case STREAM_INPUT_FRAMES_RX:
-                return aem_cmd_get_counters_resp.counters_valid >> 11 & 0x01;
-            case STREAM_INPUT_FRAMES_TX:
-                return aem_cmd_get_counters_resp.counters_valid >> 12 & 0x01;
-            default:
-                log_imp_ref->post_log_msg(LOGGING_LEVEL_ERROR, "counter name not found");
-        }
         return 0;
     }
 }

--- a/controller/lib/src/stream_input_descriptor_imp.cpp
+++ b/controller/lib/src/stream_input_descriptor_imp.cpp
@@ -48,8 +48,8 @@ namespace avdecc_lib
     stream_input_descriptor_response * STDCALL stream_input_descriptor_imp::get_stream_input_response()
     {
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
-        return resp = new stream_input_descriptor_response_imp(resp_ref->get_buffer(),
-                                                               resp_ref->get_size(), resp_ref->get_pos());
+        return resp = new stream_input_descriptor_response_imp(resp_ref->get_desc_buffer(),
+                                                               resp_ref->get_desc_size(), resp_ref->get_desc_pos());
     }
 
     stream_input_counters_response * STDCALL stream_input_descriptor_imp::get_stream_input_counters_response()
@@ -78,17 +78,6 @@ namespace avdecc_lib
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
         return get_rx_state_resp  = new stream_input_get_rx_state_response_imp(resp_ref->get_buffer(),
                                                                               resp_ref->get_size(), resp_ref->get_pos());
-    }
-
-    uint16_t STDCALL stream_input_descriptor_imp::descriptor_type() const
-    {
-        assert(jdksavdecc_descriptor_stream_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos()) == JDKSAVDECC_DESCRIPTOR_STREAM_INPUT);
-        return jdksavdecc_descriptor_stream_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
-    }
-
-    uint16_t STDCALL stream_input_descriptor_imp::descriptor_index() const
-    {
-        return jdksavdecc_descriptor_stream_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 
     uint64_t STDCALL stream_input_descriptor_imp::set_stream_format_stream_format()
@@ -218,6 +207,7 @@ namespace avdecc_lib
         bool u_field;
 
         memcpy(cmd_frame.payload, frame, frame_len);
+        memset(&m_stream_format_response, 0, sizeof(jdksavdecc_aem_command_get_stream_format_response));
 
         aem_cmd_get_stream_format_resp_returned = jdksavdecc_aem_command_get_stream_format_response_read(&m_stream_format_response,
                                                                                                          frame,
@@ -260,7 +250,7 @@ namespace avdecc_lib
         struct jdksavdecc_frame cmd_frame;
         struct jdksavdecc_aem_command_get_stream_info aem_cmd_get_stream_info;
         ssize_t aem_cmd_get_stream_info_returned;
-        memset(&aem_cmd_get_stream_info,0,sizeof(aem_cmd_get_stream_info));
+        memset(&aem_cmd_get_stream_info, 0, sizeof(aem_cmd_get_stream_info));
 
         /******************************************** AECP Common Data *******************************************/
         aem_cmd_get_stream_info.aem_header.aecpdu_header.controller_entity_id = base_end_station_imp_ref->get_adp()->get_controller_entity_id();
@@ -305,6 +295,8 @@ namespace avdecc_lib
         bool u_field;
 
         memcpy(cmd_frame.payload, frame, frame_len);
+        memset(&m_stream_info_resp, 0, sizeof(jdksavdecc_aem_command_get_stream_info_response));
+
         aem_cmd_get_stream_info_resp_returned = jdksavdecc_aem_command_get_stream_info_response_read(&m_stream_info_resp,
                                                                                                      frame,
                                                                                                      ETHER_HDR_SIZE,
@@ -376,8 +368,9 @@ namespace avdecc_lib
         uint32_t msg_type;
         bool u_field;
 
-        memset(&aem_cmd_start_streaming_resp,0,sizeof(aem_cmd_start_streaming_resp));
         memcpy(cmd_frame.payload, frame, frame_len);
+        memset(&aem_cmd_start_streaming_resp,0,sizeof(aem_cmd_start_streaming_resp));
+
         aem_cmd_start_streaming_resp_returned = jdksavdecc_aem_command_start_streaming_response_read(&aem_cmd_start_streaming_resp,
                                                                                                      frame,
                                                                                                      ETHER_HDR_SIZE,
@@ -447,8 +440,9 @@ namespace avdecc_lib
         uint32_t msg_type;
         bool u_field;
 
-        memset(&aem_cmd_stop_streaming_resp,0,sizeof(aem_cmd_stop_streaming_resp));
         memcpy(cmd_frame.payload, frame, frame_len);
+        memset(&aem_cmd_stop_streaming_resp,0,sizeof(aem_cmd_stop_streaming_resp));
+
         aem_cmd_stop_streaming_resp_returned = jdksavdecc_aem_command_stop_streaming_response_read(&aem_cmd_stop_streaming_resp,
                                                                                                    frame,
                                                                                                    ETHER_HDR_SIZE,
@@ -721,6 +715,7 @@ namespace avdecc_lib
         bool u_field;
         
         memcpy(cmd_frame.payload, frame, frame_len);
+        memset(&stream_input_counters_resp, 0, sizeof(jdksavdecc_aem_command_get_counters_response));
         
         aem_cmd_get_stream_input_counters_resp_returned = jdksavdecc_aem_command_get_counters_response_read(&stream_input_counters_resp,
                                                                                                             frame,

--- a/controller/lib/src/stream_input_descriptor_imp.cpp
+++ b/controller/lib/src/stream_input_descriptor_imp.cpp
@@ -27,7 +27,9 @@
  * STREAM INPUT descriptor implementation
  */
 
+#include <mutex>
 #include <vector>
+
 #include "util.h"
 #include "avdecc_error.h"
 #include "enumeration.h"

--- a/controller/lib/src/stream_input_descriptor_imp.cpp
+++ b/controller/lib/src/stream_input_descriptor_imp.cpp
@@ -41,11 +41,7 @@
 
 namespace avdecc_lib
 {
-    stream_input_descriptor_imp::stream_input_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos)
-    {
-        m_type = jdksavdecc_descriptor_stream_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
-        m_index = jdksavdecc_descriptor_stream_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
-    }
+    stream_input_descriptor_imp::stream_input_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos) {}
 
     stream_input_descriptor_imp::~stream_input_descriptor_imp() {}
     
@@ -55,28 +51,28 @@ namespace avdecc_lib
         return resp = new stream_input_descriptor_response_imp(resp_ref->get_buffer(),
                                                                resp_ref->get_size(), resp_ref->get_pos());
     }
-    
+
     stream_input_counters_response * STDCALL stream_input_descriptor_imp::get_stream_input_counters_response()
     {
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
         return counters_resp = new stream_input_counters_response_imp(resp_ref->get_buffer(),
                                                                       resp_ref->get_size(), resp_ref->get_pos());
     }
-    
+
     stream_input_get_stream_format_response * STDCALL stream_input_descriptor_imp::get_stream_input_get_stream_format_response()
     {
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
         return get_format_resp  = new stream_input_get_stream_format_response_imp(resp_ref->get_buffer(),
                                                                                   resp_ref->get_size(), resp_ref->get_pos());
     }
-    
+
     stream_input_get_stream_info_response * STDCALL stream_input_descriptor_imp::get_stream_input_get_stream_info_response()
     {
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
         return get_info_resp  = new stream_input_get_stream_info_response_imp(resp_ref->get_buffer(),
                                                                                   resp_ref->get_size(), resp_ref->get_pos());
     }
-    
+
     stream_input_get_rx_state_response * STDCALL stream_input_descriptor_imp::get_stream_input_get_rx_state_response()
     {
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
@@ -86,15 +82,15 @@ namespace avdecc_lib
 
     uint16_t STDCALL stream_input_descriptor_imp::descriptor_type() const
     {
-        assert(m_type == JDKSAVDECC_DESCRIPTOR_STREAM_INPUT);
-        return m_type;
+        assert(jdksavdecc_descriptor_stream_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos()) == JDKSAVDECC_DESCRIPTOR_STREAM_INPUT);
+        return jdksavdecc_descriptor_stream_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 
     uint16_t STDCALL stream_input_descriptor_imp::descriptor_index() const
     {
-        return m_index;
+        return jdksavdecc_descriptor_stream_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
     }
-    
+
     uint64_t STDCALL stream_input_descriptor_imp::set_stream_format_stream_format()
     {
         return jdksavdecc_uint64_get(&aem_cmd_set_stream_format_resp.stream_format, 0);
@@ -510,8 +506,8 @@ namespace avdecc_lib
 
         acmp_controller_state_machine_ref->common_hdr_init(JDKSAVDECC_ACMP_MESSAGE_TYPE_CONNECT_RX_COMMAND, &cmd_frame);
         system_queue_tx(notification_id, CMD_WITH_NOTIFICATION, cmd_frame.payload, cmd_frame.length);
-        
-        free(entity_resp_ref);
+
+        delete entity_resp_ref;
         return 0;
     }
 
@@ -577,7 +573,7 @@ namespace avdecc_lib
         acmp_controller_state_machine_ref->common_hdr_init(JDKSAVDECC_ACMP_MESSAGE_TYPE_DISCONNECT_RX_COMMAND, &cmd_frame);
         system_queue_tx(notification_id, CMD_WITH_NOTIFICATION, cmd_frame.payload, cmd_frame.length);
 
-        free(entity_resp_ref);
+        delete entity_resp_ref;
         return 0;
     }
 
@@ -643,7 +639,7 @@ namespace avdecc_lib
         acmp_controller_state_machine_ref->common_hdr_init(JDKSAVDECC_ACMP_MESSAGE_TYPE_GET_RX_STATE_COMMAND, &cmd_frame);
         system_queue_tx(notification_id, CMD_WITH_NOTIFICATION, cmd_frame.payload, cmd_frame.length);
 
-        free(entity_resp_ref);
+        delete entity_resp_ref;
         return 0;
     }
 

--- a/controller/lib/src/stream_input_descriptor_imp.h
+++ b/controller/lib/src/stream_input_descriptor_imp.h
@@ -43,9 +43,6 @@ namespace avdecc_lib
     class stream_input_descriptor_imp : public stream_input_descriptor, public virtual descriptor_base_imp
     {
     private:
-        uint16_t m_type;
-        uint16_t m_index;
-
         struct jdksavdecc_aem_command_set_stream_format_response aem_cmd_set_stream_format_resp; // Store the response received after sending a SET_STREAM_FORMAT command.
         struct jdksavdecc_acmpdu acmp_cmd_connect_rx_resp; // Store the response received after sending a CONNECT_RX command.
         struct jdksavdecc_acmpdu acmp_cmd_disconnect_rx_resp; // Store the response received after sending a DISCONNECT_RX command.

--- a/controller/lib/src/stream_input_descriptor_imp.h
+++ b/controller/lib/src/stream_input_descriptor_imp.h
@@ -32,101 +32,42 @@
 #include "jdksavdecc_acmp.h"
 #include "descriptor_base_imp.h"
 #include "stream_input_descriptor.h"
+#include "stream_input_descriptor_response_imp.h"
+#include "stream_input_counters_response_imp.h"
+#include "stream_input_get_stream_format_response_imp.h"
+#include "stream_input_get_stream_info_response_imp.h"
+#include "stream_input_get_rx_state_response_imp.h"
 
 namespace avdecc_lib
 {
     class stream_input_descriptor_imp : public stream_input_descriptor, public virtual descriptor_base_imp
     {
     private:
-        struct jdksavdecc_descriptor_stream stream_input_desc; // Structure containing the stream_input_desc fields
+        uint16_t m_type;
+        uint16_t m_index;
 
-        struct stream_input_desc_stream_flags
-        {
-            bool clock_sync_source;
-            bool class_a;
-            bool class_b;
-            bool supports_encrypted;
-            bool primary_backup_supported;
-            bool primary_backup_valid;
-            bool secondary_backup_supported;
-            bool secondary_backup_valid;
-            bool tertiary_backup_supported;
-            bool tertiary_backup_valid;
-        };
-
-        struct stream_input_desc_stream_flags stream_input_flags;
         struct jdksavdecc_aem_command_set_stream_format_response aem_cmd_set_stream_format_resp; // Store the response received after sending a SET_STREAM_FORMAT command.
-        struct jdksavdecc_aem_command_get_stream_format_response aem_cmd_get_stream_format_resp; // Store the response received after sending a GET_STREAM_FORMAT command.
-        struct jdksavdecc_aem_command_set_stream_info_response aem_cmd_set_stream_info_resp; // Store the response received after sending a SET_STREAM_INFO command.
-        struct jdksavdecc_aem_command_get_stream_info_response aem_cmd_get_stream_info_resp; // Store the response received after sending a GET_STREAM_INFO command.
-        struct jdksavdecc_aem_command_get_counters_response aem_cmd_get_counters_resp;
-        struct get_counters_response_with_block
-        {
-            jdksavdecc_aem_command_get_counters_response aem_cmd_get_counters_response;
-            uint32_t counters_block [31];
-        };
-        
-        struct get_counters_response_with_block counters_response;
-
         struct jdksavdecc_acmpdu acmp_cmd_connect_rx_resp; // Store the response received after sending a CONNECT_RX command.
         struct jdksavdecc_acmpdu acmp_cmd_disconnect_rx_resp; // Store the response received after sending a DISCONNECT_RX command.
-        struct jdksavdecc_acmpdu acmp_cmd_get_rx_state_resp; // Store the response received after sending a GET_RX_STATE command.
-
     public:
         stream_input_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
         virtual ~stream_input_descriptor_imp();
+        
+        stream_input_descriptor_response_imp *resp;
+        stream_input_counters_response_imp *counters_resp;
+        stream_input_get_stream_format_response_imp *get_format_resp;
+        stream_input_get_stream_info_response_imp *get_info_resp;
+        stream_input_get_rx_state_response_imp *get_rx_state_resp;
 
         uint16_t STDCALL descriptor_type() const;
         uint16_t STDCALL descriptor_index() const;
-        uint8_t * STDCALL object_name();
-        uint16_t STDCALL localized_description();
-
-        uint16_t STDCALL clock_domain_index();
-        uint16_t STDCALL stream_flags();
-        bool STDCALL stream_flags_clock_sync_source();
-        bool STDCALL stream_flags_class_a();
-        bool STDCALL stream_flags_class_b();
-        bool STDCALL stream_flags_supports_encrypted();
-        bool STDCALL stream_flags_primary_backup_supported();
-        bool STDCALL stream_flags_primary_backup_valid();
-        bool STDCALL stream_flags_secondary_backup_supported();
-        bool STDCALL stream_flags_secondary_backup_valid();
-        bool STDCALL stream_flags_tertiary_backup_supported();
-        bool STDCALL stream_flags_tertiary_backup_valid();
-        const char * STDCALL current_format();
-        uint16_t formats_offset();
-        uint16_t STDCALL number_of_formats();
-        uint64_t STDCALL backup_talker_entity_id_0();
-        uint16_t STDCALL backup_talker_unique_0();
-        uint64_t STDCALL backup_talker_entity_id_1();
-        uint16_t STDCALL backup_talker_unique_1();
-        uint64_t STDCALL backup_talker_entity_id_2();
-        uint16_t STDCALL backup_talker_unique_2();
-        uint64_t STDCALL backedup_talker_entity_id();
-        uint16_t STDCALL backedup_talker_unique();
-        uint16_t STDCALL avb_interface_index();
-        uint32_t STDCALL buffer_length();
+        stream_input_descriptor_response * STDCALL get_stream_input_response();
+        stream_input_counters_response * STDCALL get_stream_input_counters_response();
+        stream_input_get_stream_format_response * STDCALL get_stream_input_get_stream_format_response();
+        stream_input_get_stream_info_response * STDCALL get_stream_input_get_stream_info_response();
+        stream_input_get_rx_state_response * STDCALL get_stream_input_get_rx_state_response();
+        
         uint64_t STDCALL set_stream_format_stream_format();
-        uint64_t STDCALL get_stream_format_stream_format();
-        uint32_t STDCALL get_stream_info_flags();
-        uint64_t STDCALL get_stream_info_stream_format();
-        uint64_t STDCALL get_stream_info_stream_id();
-        uint32_t STDCALL get_stream_info_msrp_accumulated_latency();
-        uint64_t STDCALL get_stream_info_stream_dest_mac();
-        uint8_t STDCALL get_stream_info_msrp_failure_code();
-        uint64_t STDCALL get_stream_info_msrp_failure_bridge_id();
-        bool is_clock_sync_source_set();
-        uint64_t STDCALL get_rx_state_stream_id();
-        uint16_t STDCALL get_rx_state_talker_unique_id();
-        uint16_t STDCALL get_rx_state_listener_unique_id();
-        uint64_t STDCALL get_rx_state_stream_dest_mac();
-        uint16_t STDCALL get_rx_state_connection_count();
-        uint16_t STDCALL get_rx_state_flags();
-        uint16_t STDCALL get_rx_state_stream_vlan_id();
-        uint32_t STDCALL get_counter_valid(int name);
-        uint32_t STDCALL get_counter_by_name(int name);
-        int STDCALL send_get_counters_cmd(void *notification_id);
-        int proc_get_counters_resp(void *&notification_id, const uint8_t *fram, size_t frame_len, int &status);
         
 		int STDCALL send_set_stream_format_cmd(void *notification_id, uint64_t new_stream_format);
         int proc_set_stream_format_resp(void *&notification_id, const uint8_t *frame, size_t frame_len, int &status);
@@ -154,16 +95,9 @@ namespace avdecc_lib
 
         int STDCALL send_get_rx_state_cmd(void *notification_id);
         int proc_get_rx_state_resp(void *&notification_id, const uint8_t *frame, size_t frame_len, int &status);
+        
+        int STDCALL send_get_counters_cmd(void *notification_id);
+        int proc_get_counters_resp(void *&notification_id, const uint8_t *fram, size_t frame_len, int &status);
 
-    private:
-        /**
-         * Store the stream flags componenets of the STREAM INPUT descriptor object in a vector.
-         */
-        void stream_flags_init();
-
-        /**
-         * Update the internal STREAM INPUT descriptor's stream format field.
-         */
-        void update_stream_format(struct jdksavdecc_eui64 stream_format);
     };
 }

--- a/controller/lib/src/stream_input_descriptor_imp.h
+++ b/controller/lib/src/stream_input_descriptor_imp.h
@@ -56,8 +56,6 @@ namespace avdecc_lib
         stream_input_get_stream_info_response_imp *get_info_resp;
         stream_input_get_rx_state_response_imp *get_rx_state_resp;
 
-        uint16_t STDCALL descriptor_type() const;
-        uint16_t STDCALL descriptor_index() const;
         stream_input_descriptor_response * STDCALL get_stream_input_response();
         stream_input_counters_response * STDCALL get_stream_input_counters_response();
         stream_input_get_stream_format_response * STDCALL get_stream_input_get_stream_format_response();

--- a/controller/lib/src/stream_input_descriptor_response_imp.cpp
+++ b/controller/lib/src/stream_input_descriptor_response_imp.cpp
@@ -22,9 +22,9 @@
  */
 
 /**
- * stream_input_descriptor_imp.cpp
+ * stream_input_descriptor_response_imp.cpp
  *
- * STREAM INPUT descriptor implementation
+ * STREAM INPUT descriptor response implementation
  */
 
 #include <vector>
@@ -41,18 +41,20 @@
 
 namespace avdecc_lib
 {
-    stream_input_descriptor_response_imp::stream_input_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos) : descriptor_base_imp(nullptr, frame, frame_len, pos)
+    stream_input_descriptor_response_imp::stream_input_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos)
     {
         memset(&stream_input_flags, 0, sizeof(struct stream_input_desc_stream_flags));
         frame_size = frame_len;
         buffer = (uint8_t *)malloc(frame_size * sizeof(uint8_t));
         memcpy(buffer, frame, frame_size);
         position = pos;
-
         stream_flags_init();
     }
     
-    stream_input_descriptor_response_imp::~stream_input_descriptor_response_imp() {}
+    stream_input_descriptor_response_imp::~stream_input_descriptor_response_imp()
+    {
+        free(buffer);
+    }
     
     void stream_input_descriptor_response_imp::stream_flags_init()
     {
@@ -143,7 +145,6 @@ namespace avdecc_lib
         uint64_t current_format;
         current_format = jdksavdecc_uint64_get(&buffer[position +
                                             JDKSAVDECC_DESCRIPTOR_STREAM_OFFSET_CURRENT_FORMAT], 0);
-
         return utility::ieee1722_format_value_to_name(current_format);
     }
     

--- a/controller/lib/src/stream_input_descriptor_response_imp.cpp
+++ b/controller/lib/src/stream_input_descriptor_response_imp.cpp
@@ -1,0 +1,219 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2013 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * stream_input_descriptor_imp.cpp
+ *
+ * STREAM INPUT descriptor implementation
+ */
+
+#include <vector>
+#include "util.h"
+#include "avdecc_error.h"
+#include "enumeration.h"
+#include "log_imp.h"
+#include "adp.h"
+#include "end_station_imp.h"
+#include "system_tx_queue.h"
+#include "acmp_controller_state_machine.h"
+#include "aecp_controller_state_machine.h"
+#include "stream_input_descriptor_response_imp.h"
+
+namespace avdecc_lib
+{
+    stream_input_descriptor_response_imp::stream_input_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos) : descriptor_base_imp(nullptr, frame, frame_len, pos)
+    {
+        memset(&stream_input_flags, 0, sizeof(struct stream_input_desc_stream_flags));
+        frame_size = frame_len;
+        buffer = (uint8_t *)malloc(frame_size * sizeof(uint8_t));
+        memcpy(buffer, frame, frame_size);
+        position = pos;
+
+        stream_flags_init();
+    }
+    
+    stream_input_descriptor_response_imp::~stream_input_descriptor_response_imp() {}
+    
+    void stream_input_descriptor_response_imp::stream_flags_init()
+    {
+        stream_input_flags.clock_sync_source = stream_flags() & 0x01;
+        stream_input_flags.class_a = stream_flags() >> 1 & 0x01;
+        stream_input_flags.class_b = stream_flags() >> 2 & 0x01;
+        stream_input_flags.supports_encrypted = stream_flags() >> 3 & 0x01;
+        stream_input_flags.primary_backup_supported = stream_flags() >> 4 & 0x01;
+        stream_input_flags.primary_backup_valid = stream_flags() >> 5 & 0x01;
+        stream_input_flags.secondary_backup_supported = stream_flags() >> 6 & 0x01;
+        stream_input_flags.secondary_backup_valid = stream_flags() >> 7 & 0x01;
+        stream_input_flags.tertiary_backup_supported = stream_flags() >> 8 & 0x01;
+        stream_input_flags.tertiary_backup_valid = stream_flags() >> 9 & 0x01;
+    }
+
+    uint8_t * STDCALL stream_input_descriptor_response_imp::object_name()
+    {
+        return (uint8_t *)&buffer[position + JDKSAVDECC_DESCRIPTOR_STREAM_OFFSET_OBJECT_NAME];
+    }
+    
+    uint16_t STDCALL stream_input_descriptor_response_imp::localized_description()
+    {
+        return jdksavdecc_descriptor_stream_get_localized_description(buffer, position);
+    }
+    
+    uint16_t STDCALL stream_input_descriptor_response_imp::clock_domain_index()
+    {
+        return jdksavdecc_descriptor_stream_get_clock_domain_index(buffer, position);
+    }
+    
+    uint16_t stream_input_descriptor_response_imp::stream_flags()
+    {
+        return jdksavdecc_descriptor_stream_get_stream_flags(buffer, position);
+    }
+    
+    bool STDCALL stream_input_descriptor_response_imp::stream_flags_clock_sync_source()
+    {
+        return stream_input_flags.clock_sync_source;
+    }
+    
+    bool STDCALL stream_input_descriptor_response_imp::stream_flags_class_a()
+    {
+        return stream_input_flags.class_a;
+    }
+    
+    bool STDCALL stream_input_descriptor_response_imp::stream_flags_class_b()
+    {
+        return stream_input_flags.class_b;
+    }
+    
+    bool STDCALL stream_input_descriptor_response_imp::stream_flags_supports_encrypted()
+    {
+        return stream_input_flags.supports_encrypted;
+    }
+    
+    bool STDCALL stream_input_descriptor_response_imp::stream_flags_primary_backup_supported()
+    {
+        return stream_input_flags.primary_backup_supported;
+    }
+    
+    bool STDCALL stream_input_descriptor_response_imp::stream_flags_primary_backup_valid()
+    {
+        return stream_input_flags.primary_backup_valid;
+    }
+    
+    bool STDCALL stream_input_descriptor_response_imp::stream_flags_secondary_backup_supported()
+    {
+        return stream_input_flags.secondary_backup_supported;
+    }
+    
+    bool STDCALL stream_input_descriptor_response_imp::stream_flags_secondary_backup_valid()
+    {
+        return stream_input_flags.secondary_backup_valid;
+    }
+    
+    bool STDCALL stream_input_descriptor_response_imp::stream_flags_tertiary_backup_supported()
+    {
+        return stream_input_flags.tertiary_backup_supported;
+    }
+    
+    bool STDCALL stream_input_descriptor_response_imp::stream_flags_tertiary_backup_valid()
+    {
+        return stream_input_flags.tertiary_backup_valid;
+    }
+    
+    const char * STDCALL stream_input_descriptor_response_imp::current_format()
+    {
+        uint64_t current_format;
+        current_format = jdksavdecc_uint64_get(&buffer[position +
+                                            JDKSAVDECC_DESCRIPTOR_STREAM_OFFSET_CURRENT_FORMAT], 0);
+
+        return utility::ieee1722_format_value_to_name(current_format);
+    }
+    
+    uint16_t stream_input_descriptor_response_imp::formats_offset()
+    {
+        assert(jdksavdecc_descriptor_stream_get_formats_offset(buffer, position) == 132);
+        return jdksavdecc_descriptor_stream_get_formats_offset(buffer, position);
+    }
+    
+    uint16_t STDCALL stream_input_descriptor_response_imp::number_of_formats()
+    {
+        assert(jdksavdecc_descriptor_stream_get_number_of_formats(buffer, position));
+        return jdksavdecc_descriptor_stream_get_number_of_formats(buffer, position);
+    }
+    
+    uint64_t STDCALL stream_input_descriptor_response_imp::backup_talker_entity_id_0()
+    {
+        uint64_t backup_talker_entity_id_0;
+        return backup_talker_entity_id_0 = jdksavdecc_uint64_get(&buffer[position +
+                                                 JDKSAVDECC_DESCRIPTOR_STREAM_OFFSET_BACKUP_TALKER_ENTITY_ID_0], 0);
+    }
+    
+    uint16_t STDCALL stream_input_descriptor_response_imp::backup_talker_unique_0()
+    {
+        return jdksavdecc_descriptor_stream_get_backup_talker_unique_0(buffer, position);
+    }
+    
+    uint64_t STDCALL stream_input_descriptor_response_imp::backup_talker_entity_id_1()
+    {
+        uint64_t backup_talker_entity_id_1;
+        return backup_talker_entity_id_1 = jdksavdecc_uint64_get(&buffer[position +
+                                                                         JDKSAVDECC_DESCRIPTOR_STREAM_OFFSET_BACKUP_TALKER_ENTITY_ID_1], 0);
+    }
+    
+    uint16_t STDCALL stream_input_descriptor_response_imp::backup_talker_unique_1()
+    {
+        return jdksavdecc_descriptor_stream_get_backup_talker_unique_1(buffer, position);
+    }
+    
+    uint64_t STDCALL stream_input_descriptor_response_imp::backup_talker_entity_id_2()
+    {
+        uint64_t backup_talker_entity_id_2;
+        return backup_talker_entity_id_2 = jdksavdecc_uint64_get(&buffer[position +
+                                                                         JDKSAVDECC_DESCRIPTOR_STREAM_OFFSET_BACKUP_TALKER_ENTITY_ID_2], 0);
+    }
+    
+    uint16_t STDCALL stream_input_descriptor_response_imp::backup_talker_unique_2()
+    {
+        return jdksavdecc_descriptor_stream_get_backup_talker_unique_2(buffer, position);
+    }
+    
+    uint64_t STDCALL stream_input_descriptor_response_imp::backedup_talker_entity_id()
+    {
+        uint64_t backedup_talker_entity_id;
+        return backedup_talker_entity_id = jdksavdecc_uint64_get(&buffer[position +
+                                                                         JDKSAVDECC_DESCRIPTOR_STREAM_OFFSET_BACKEDUP_TALKER_ENTITY_ID], 0);
+    }
+    
+    uint16_t STDCALL stream_input_descriptor_response_imp::backedup_talker_unique()
+    {
+        return jdksavdecc_descriptor_stream_get_backedup_talker_unique(buffer, position);
+    }
+    
+    uint16_t STDCALL stream_input_descriptor_response_imp::avb_interface_index()
+    {
+        return jdksavdecc_descriptor_stream_get_avb_interface_index(buffer, position);
+    }
+    
+    uint32_t STDCALL stream_input_descriptor_response_imp::buffer_length()
+    {
+        return jdksavdecc_descriptor_stream_get_buffer_length(buffer, position);
+    }
+}

--- a/controller/lib/src/stream_input_descriptor_response_imp.h
+++ b/controller/lib/src/stream_input_descriptor_response_imp.h
@@ -30,12 +30,12 @@
 #pragma once
 
 #include "jdksavdecc_acmp.h"
-#include "descriptor_base_imp.h"
 #include "stream_input_descriptor_response.h"
+#include "jdksavdecc_aem_descriptor.h"
 
 namespace avdecc_lib
 {
-    class stream_input_descriptor_response_imp : public stream_input_descriptor_response, public virtual descriptor_base_imp
+    class stream_input_descriptor_response_imp : public stream_input_descriptor_response
     {
     private:
         struct stream_input_desc_stream_flags

--- a/controller/lib/src/stream_input_descriptor_response_imp.h
+++ b/controller/lib/src/stream_input_descriptor_response_imp.h
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * stream_input_descriptor_response_imp.h
+ *
+ * STREAM INPUT descriptor response implementation class
+ */
+
+#pragma once
+
+#include "jdksavdecc_acmp.h"
+#include "descriptor_base_imp.h"
+#include "stream_input_descriptor_response.h"
+
+namespace avdecc_lib
+{
+    class stream_input_descriptor_response_imp : public stream_input_descriptor_response, public virtual descriptor_base_imp
+    {
+    private:
+        struct stream_input_desc_stream_flags
+        {
+            bool clock_sync_source;
+            bool class_a;
+            bool class_b;
+            bool supports_encrypted;
+            bool primary_backup_supported;
+            bool primary_backup_valid;
+            bool secondary_backup_supported;
+            bool secondary_backup_valid;
+            bool tertiary_backup_supported;
+            bool tertiary_backup_valid;
+        };
+        
+        uint8_t * buffer;
+        ssize_t position;
+        size_t frame_size;
+        struct stream_input_desc_stream_flags stream_input_flags;
+    public:
+        stream_input_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos);
+        virtual ~stream_input_descriptor_response_imp();
+
+        uint8_t * STDCALL object_name();
+        uint16_t STDCALL localized_description();
+        uint16_t STDCALL clock_domain_index();
+        uint16_t STDCALL stream_flags();
+        bool STDCALL stream_flags_clock_sync_source();
+        bool STDCALL stream_flags_class_a();
+        bool STDCALL stream_flags_class_b();
+        bool STDCALL stream_flags_supports_encrypted();
+        bool STDCALL stream_flags_primary_backup_supported();
+        bool STDCALL stream_flags_primary_backup_valid();
+        bool STDCALL stream_flags_secondary_backup_supported();
+        bool STDCALL stream_flags_secondary_backup_valid();
+        bool STDCALL stream_flags_tertiary_backup_supported();
+        bool STDCALL stream_flags_tertiary_backup_valid();
+        const char * STDCALL current_format();
+        uint16_t formats_offset();
+        uint16_t STDCALL number_of_formats();
+        uint64_t STDCALL backup_talker_entity_id_0();
+        uint16_t STDCALL backup_talker_unique_0();
+        uint64_t STDCALL backup_talker_entity_id_1();
+        uint16_t STDCALL backup_talker_unique_1();
+        uint64_t STDCALL backup_talker_entity_id_2();
+        uint16_t STDCALL backup_talker_unique_2();
+        uint64_t STDCALL backedup_talker_entity_id();
+        uint16_t STDCALL backedup_talker_unique();
+        uint16_t STDCALL avb_interface_index();
+        uint32_t STDCALL buffer_length();
+    private:
+        /**
+         * Store the stream flags componenets of the STREAM INPUT descriptor object in a vector.
+         */
+        void stream_flags_init();
+        
+        /**
+         * Update the internal STREAM INPUT descriptor's stream format field.
+         */
+        void update_stream_format(struct jdksavdecc_eui64 stream_format);
+    };
+}

--- a/controller/lib/src/stream_input_get_rx_state_response_imp.cpp
+++ b/controller/lib/src/stream_input_get_rx_state_response_imp.cpp
@@ -24,7 +24,7 @@
 /**
  * stream_input_get_rx_state_response_imp.cpp
  *
- * STREAM INPUT get stream format response implementation
+ * STREAM INPUT get rx state response implementation
  */
 
 #include "enumeration.h"
@@ -42,9 +42,11 @@ namespace avdecc_lib
         memcpy(m_frame, frame, m_size);
     }
     
-    stream_input_get_rx_state_response_imp::~stream_input_get_rx_state_response_imp(){}
-    
-    
+    stream_input_get_rx_state_response_imp::~stream_input_get_rx_state_response_imp()
+    {
+        free(m_frame);
+    }
+
     uint64_t STDCALL stream_input_get_rx_state_response_imp::get_rx_state_stream_id()
     {
         jdksavdecc_eui64 stream_id;

--- a/controller/lib/src/stream_input_get_rx_state_response_imp.cpp
+++ b/controller/lib/src/stream_input_get_rx_state_response_imp.cpp
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * stream_input_get_rx_state_response_imp.cpp
+ *
+ * STREAM INPUT get stream format response implementation
+ */
+
+#include "enumeration.h"
+#include "log_imp.h"
+#include "stream_input_get_rx_state_response_imp.h"
+#include "util.h"
+
+namespace avdecc_lib
+{
+    stream_input_get_rx_state_response_imp::stream_input_get_rx_state_response_imp(uint8_t *frame, size_t frame_len, ssize_t pos)
+    {
+        m_position = pos;
+        m_size = frame_len;
+        m_frame = (uint8_t *)malloc(m_size * sizeof(uint8_t));
+        memcpy(m_frame, frame, m_size);
+    }
+    
+    stream_input_get_rx_state_response_imp::~stream_input_get_rx_state_response_imp(){}
+    
+    
+    uint64_t STDCALL stream_input_get_rx_state_response_imp::get_rx_state_stream_id()
+    {
+        jdksavdecc_eui64 stream_id;
+        stream_id = jdksavdecc_common_control_header_get_stream_id(m_frame, m_position);
+        return jdksavdecc_eui64_convert_to_uint64(&stream_id);
+    }
+    
+    uint16_t STDCALL stream_input_get_rx_state_response_imp::get_rx_state_talker_unique_id()
+    {
+        return jdksavdecc_acmpdu_get_talker_unique_id(m_frame, m_position);
+    }
+    
+    uint16_t STDCALL stream_input_get_rx_state_response_imp::get_rx_state_listener_unique_id()
+    {
+        return jdksavdecc_acmpdu_get_listener_unique_id(m_frame, m_position);
+    }
+    
+    uint64_t STDCALL stream_input_get_rx_state_response_imp::get_rx_state_stream_dest_mac()
+    {
+        jdksavdecc_eui48 stream_dest_mac;
+        stream_dest_mac = jdksavdecc_acmpdu_get_stream_dest_mac(m_frame, m_position);
+        
+        return jdksavdecc_eui48_convert_to_uint64(&stream_dest_mac);
+    }
+    
+    uint16_t STDCALL stream_input_get_rx_state_response_imp::get_rx_state_connection_count()
+    {
+        return jdksavdecc_acmpdu_get_connection_count(m_frame, m_position);
+    }
+    
+    uint16_t STDCALL stream_input_get_rx_state_response_imp::get_rx_state_flags()
+    {
+        return jdksavdecc_acmpdu_get_flags(m_frame, m_position);
+    }
+    
+    uint16_t STDCALL stream_input_get_rx_state_response_imp::get_rx_state_stream_vlan_id()
+    {
+        return jdksavdecc_acmpdu_get_stream_vlan_id(m_frame, m_position);
+    }
+}

--- a/controller/lib/src/stream_input_get_rx_state_response_imp.h
+++ b/controller/lib/src/stream_input_get_rx_state_response_imp.h
@@ -24,7 +24,7 @@
 /**
  * stream_input_get_rx_state_response_imp.h
  *
- * STREAM INPUT stream format response implementation class
+ * STREAM INPUT rx state response implementation class
  */
 
 #pragma once

--- a/controller/lib/src/stream_input_get_rx_state_response_imp.h
+++ b/controller/lib/src/stream_input_get_rx_state_response_imp.h
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * stream_input_get_rx_state_response_imp.h
+ *
+ * STREAM INPUT stream format response implementation class
+ */
+
+#pragma once
+
+#include "stream_input_get_rx_state_response.h"
+#include "jdksavdecc_acmp.h"
+
+namespace avdecc_lib
+{
+    class stream_input_get_rx_state_response_imp : public stream_input_get_rx_state_response
+    {
+    private:
+        uint8_t * m_frame;
+        size_t m_size;
+        ssize_t m_position;
+    public:
+        stream_input_get_rx_state_response_imp(uint8_t *frame, size_t frame_len, ssize_t pos);
+        virtual ~stream_input_get_rx_state_response_imp();
+        
+        uint64_t STDCALL get_rx_state_stream_id();
+        uint16_t STDCALL get_rx_state_talker_unique_id();
+        uint16_t STDCALL get_rx_state_listener_unique_id();
+        uint64_t STDCALL get_rx_state_stream_dest_mac();
+        uint16_t STDCALL get_rx_state_connection_count();
+        uint16_t STDCALL get_rx_state_flags();
+        uint16_t STDCALL get_rx_state_stream_vlan_id();
+    };
+}

--- a/controller/lib/src/stream_input_get_stream_format_response_imp.cpp
+++ b/controller/lib/src/stream_input_get_stream_format_response_imp.cpp
@@ -42,7 +42,10 @@ namespace avdecc_lib
         memcpy(m_frame, frame, m_size);
     }
     
-    stream_input_get_stream_format_response_imp::~stream_input_get_stream_format_response_imp(){}
+    stream_input_get_stream_format_response_imp::~stream_input_get_stream_format_response_imp()
+    {
+        free(m_frame);
+    }
 
     uint64_t STDCALL stream_input_get_stream_format_response_imp::get_stream_format()
     {

--- a/controller/lib/src/stream_input_get_stream_format_response_imp.cpp
+++ b/controller/lib/src/stream_input_get_stream_format_response_imp.cpp
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * stream_input_get_stream_format_response_imp.cpp
+ *
+ * STREAM INPUT get stream format response implementation
+ */
+
+#include "enumeration.h"
+#include "log_imp.h"
+#include "stream_input_get_stream_format_response_imp.h"
+#include "util.h"
+
+namespace avdecc_lib
+{
+    stream_input_get_stream_format_response_imp::stream_input_get_stream_format_response_imp(uint8_t *frame, size_t frame_len, ssize_t pos)
+    {
+        m_position = pos;
+        m_size = frame_len;
+        m_frame = (uint8_t *)malloc(m_size * sizeof(uint8_t));
+        memcpy(m_frame, frame, m_size);
+    }
+    
+    stream_input_get_stream_format_response_imp::~stream_input_get_stream_format_response_imp(){}
+
+    uint64_t STDCALL stream_input_get_stream_format_response_imp::get_stream_format()
+    {
+        jdksavdecc_eui64 format_eui64;
+        format_eui64 = jdksavdecc_eui64_get(m_frame, m_position + JDKSAVDECC_AEM_COMMAND_GET_STREAM_FORMAT_RESPONSE_OFFSET_STREAM_FORMAT);
+        return jdksavdecc_eui64_convert_to_uint64(&format_eui64);
+    }
+}

--- a/controller/lib/src/stream_input_get_stream_format_response_imp.h
+++ b/controller/lib/src/stream_input_get_stream_format_response_imp.h
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * stream_input_get_stream_format_response_imp.h
+ *
+ * STREAM INPUT stream format response implementation class
+ */
+
+#pragma once
+
+#include "stream_input_get_stream_format_response.h"
+#include "jdksavdecc_aem_command.h"
+
+namespace avdecc_lib
+{
+    class stream_input_get_stream_format_response_imp : public stream_input_get_stream_format_response
+    {
+    private:
+        uint8_t * m_frame;
+        size_t m_size;
+        ssize_t m_position;
+    public:
+        stream_input_get_stream_format_response_imp(uint8_t *frame, size_t frame_len, ssize_t pos);
+        virtual ~stream_input_get_stream_format_response_imp();
+        
+        uint64_t STDCALL get_stream_format();
+    };
+}

--- a/controller/lib/src/stream_input_get_stream_format_response_imp.h
+++ b/controller/lib/src/stream_input_get_stream_format_response_imp.h
@@ -24,7 +24,7 @@
 /**
  * stream_input_get_stream_format_response_imp.h
  *
- * STREAM INPUT stream format response implementation class
+ * STREAM INPUT get stream format response implementation class
  */
 
 #pragma once

--- a/controller/lib/src/stream_input_get_stream_info_response_imp.cpp
+++ b/controller/lib/src/stream_input_get_stream_info_response_imp.cpp
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * stream_input_get_stream_info_response_imp.cpp
+ *
+ * STREAM INPUT get stream info response implementation
+ */
+
+#include "enumeration.h"
+#include "log_imp.h"
+#include "stream_input_get_stream_info_response_imp.h"
+#include "util.h"
+
+namespace avdecc_lib
+{
+    stream_input_get_stream_info_response_imp::stream_input_get_stream_info_response_imp(uint8_t *frame, size_t frame_len, ssize_t pos)
+    {
+        m_position = pos;
+        m_size = frame_len;
+        m_frame = (uint8_t *)malloc(m_size * sizeof(uint8_t));
+        memcpy(m_frame, frame, m_size);
+    }
+    
+    stream_input_get_stream_info_response_imp::~stream_input_get_stream_info_response_imp(){}
+    
+    uint32_t STDCALL stream_input_get_stream_info_response_imp::get_stream_info_flags()
+    {
+        return jdksavdecc_aem_command_get_stream_info_response_get_aem_stream_info_flags(m_frame, m_position);
+    }
+    
+    uint64_t STDCALL stream_input_get_stream_info_response_imp::get_stream_info_stream_format()
+    {
+        jdksavdecc_eui64 stream_format;
+        stream_format = jdksavdecc_aem_command_get_stream_info_response_get_stream_format(m_frame, m_position);
+        return jdksavdecc_eui64_convert_to_uint64(&stream_format);
+    }
+    
+    uint64_t STDCALL stream_input_get_stream_info_response_imp::get_stream_info_stream_id()
+    {
+        jdksavdecc_eui64 stream_id;
+        stream_id = jdksavdecc_aem_command_get_stream_info_response_get_stream_id(m_frame, m_position);
+        return jdksavdecc_eui64_convert_to_uint64(&stream_id);
+    }
+    
+    uint32_t STDCALL stream_input_get_stream_info_response_imp::get_stream_info_msrp_accumulated_latency()
+    {
+        return jdksavdecc_aem_command_get_stream_info_response_get_msrp_accumulated_latency(m_frame, m_position);
+    }
+    
+    uint64_t STDCALL stream_input_get_stream_info_response_imp::get_stream_info_stream_dest_mac()
+    {
+        jdksavdecc_eui48 dest_mac;
+        dest_mac = jdksavdecc_aem_command_get_stream_info_response_get_stream_dest_mac(m_frame, m_position);
+        return jdksavdecc_eui48_convert_to_uint64(&dest_mac);
+    }
+    
+    uint8_t STDCALL stream_input_get_stream_info_response_imp::get_stream_info_msrp_failure_code()
+    {
+        return jdksavdecc_aem_command_get_stream_info_response_get_msrp_failure_code(m_frame, m_position);
+    }
+    
+    uint64_t STDCALL stream_input_get_stream_info_response_imp::get_stream_info_msrp_failure_bridge_id()
+    {
+        jdksavdecc_eui64 msrp_failure_bridge_id;
+        msrp_failure_bridge_id = jdksavdecc_aem_command_get_stream_info_response_get_msrp_failure_bridge_id(m_frame, m_position);
+        return jdksavdecc_eui64_convert_to_uint64(&msrp_failure_bridge_id);
+    }
+}

--- a/controller/lib/src/stream_input_get_stream_info_response_imp.cpp
+++ b/controller/lib/src/stream_input_get_stream_info_response_imp.cpp
@@ -42,7 +42,10 @@ namespace avdecc_lib
         memcpy(m_frame, frame, m_size);
     }
     
-    stream_input_get_stream_info_response_imp::~stream_input_get_stream_info_response_imp(){}
+    stream_input_get_stream_info_response_imp::~stream_input_get_stream_info_response_imp()
+    {
+        free(m_frame);
+    }
     
     uint32_t STDCALL stream_input_get_stream_info_response_imp::get_stream_info_flags()
     {

--- a/controller/lib/src/stream_input_get_stream_info_response_imp.h
+++ b/controller/lib/src/stream_input_get_stream_info_response_imp.h
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * stream_input_get_stream_info_response_imp.h
+ *
+ * STREAM INPUT stream info response implementation class
+ */
+
+#pragma once
+
+#include "stream_input_get_stream_info_response.h"
+#include "jdksavdecc_aem_command.h"
+
+namespace avdecc_lib
+{
+    class stream_input_get_stream_info_response_imp : public stream_input_get_stream_info_response
+    {
+    private:
+        uint8_t * m_frame;
+        size_t m_size;
+        ssize_t m_position;
+    public:
+        stream_input_get_stream_info_response_imp(uint8_t *frame, size_t frame_len, ssize_t pos);
+        virtual ~stream_input_get_stream_info_response_imp();
+        
+        uint64_t STDCALL get_stream_format_stream_format();
+        uint32_t STDCALL get_stream_info_flags();
+        uint64_t STDCALL get_stream_info_stream_format();
+        uint64_t STDCALL get_stream_info_stream_id();
+        uint32_t STDCALL get_stream_info_msrp_accumulated_latency();
+        uint64_t STDCALL get_stream_info_stream_dest_mac();
+        uint8_t STDCALL get_stream_info_msrp_failure_code();
+        uint64_t STDCALL get_stream_info_msrp_failure_bridge_id();
+    };
+}

--- a/controller/lib/src/stream_input_get_stream_info_response_imp.h
+++ b/controller/lib/src/stream_input_get_stream_info_response_imp.h
@@ -24,7 +24,7 @@
 /**
  * stream_input_get_stream_info_response_imp.h
  *
- * STREAM INPUT stream info response implementation class
+ * STREAM INPUT get stream info response implementation class
  */
 
 #pragma once

--- a/controller/lib/src/stream_output_descriptor_imp.cpp
+++ b/controller/lib/src/stream_output_descriptor_imp.cpp
@@ -41,331 +41,67 @@
 
 namespace avdecc_lib
 {
-    stream_output_descriptor_imp::stream_output_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj)
+    stream_output_descriptor_imp::stream_output_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos)
     {
-        ssize_t ret = jdksavdecc_descriptor_stream_read(&stream_output_desc, frame, pos, frame_len);
-
-        if (ret < 0)
-        {
-            throw avdecc_read_descriptor_error("stream_output_desc_read error");
-        }
-
-        memset(&stream_output_flags, 0, sizeof(struct stream_output_desc_stream_flags));
+        m_type = jdksavdecc_descriptor_stream_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
+        m_index = jdksavdecc_descriptor_stream_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
+        
         memset(&aem_cmd_set_stream_format_resp, 0, sizeof(struct jdksavdecc_aem_command_set_stream_format_response));
-        memset(&aem_cmd_get_stream_format_resp, 0, sizeof(struct jdksavdecc_aem_command_get_stream_format_response));
         memset(&aem_cmd_set_stream_info_resp, 0, sizeof(struct jdksavdecc_aem_command_set_stream_info_response));
-        memset(&aem_cmd_get_stream_info_resp, 0, sizeof(struct jdksavdecc_aem_command_get_stream_info_response));
-
-        memset(&acmp_cmd_get_tx_state_resp, 0, sizeof(struct jdksavdecc_acmpdu));
-        memset(&acmp_cmd_get_tx_connection_resp, 0, sizeof(struct jdksavdecc_acmpdu));
-
-        stream_flags_init();
-
-		stream_info_flags["CLASS_B"]                  = JDKSAVDECC_AEM_COMMAND_SET_STREAM_INFO_FLAG_CLASS_B;
-		stream_info_flags["FAST_CONNECT"]             = JDKSAVDECC_AEM_COMMAND_SET_STREAM_INFO_FLAG_FAST_CONNECT;
-		stream_info_flags["SAVED_STATE"]              = JDKSAVDECC_AEM_COMMAND_SET_STREAM_INFO_FLAG_SAVED_STATE;
-		stream_info_flags["STREAMING_WAIT"]           = JDKSAVDECC_AEM_COMMAND_SET_STREAM_INFO_FLAG_STREAMING_WAIT;
-		stream_info_flags["ENCRYPTED_PDU"]            = JDKSAVDECC_AEM_COMMAND_SET_STREAM_INFO_FLAG_ENCRYPTED_PDU;
-		stream_info_flags["STREAM_VLAN_ID_VALID"]     = JDKSAVDECC_AEM_COMMAND_SET_STREAM_INFO_FLAG_STREAM_VLAN_ID_VALID;
-		stream_info_flags["CONNECTED"]                = JDKSAVDECC_AEM_COMMAND_SET_STREAM_INFO_FLAG_CONNECTED;
-		stream_info_flags["MSRP_FAILURE_VALID"]       = JDKSAVDECC_AEM_COMMAND_SET_STREAM_INFO_FLAG_MSRP_FAILURE_VALID;
-		stream_info_flags["STREAM_DEST_MAC_VALID"]    = JDKSAVDECC_AEM_COMMAND_SET_STREAM_INFO_FLAG_STREAM_DEST_MAC_VALID;
-		stream_info_flags["MSRP_ACC_LAT_VALID"]       = JDKSAVDECC_AEM_COMMAND_SET_STREAM_INFO_FLAG_MSRP_ACC_LAT_VALID;
-		stream_info_flags["STREAM_ID_VALID"]          = JDKSAVDECC_AEM_COMMAND_SET_STREAM_INFO_FLAG_STREAM_ID_VALID;
-		stream_info_flags["STREAM_FORMAT_VALID"]      = JDKSAVDECC_AEM_COMMAND_SET_STREAM_INFO_FLAG_STREAM_FORMAT_VALID;
-
     }
 
     stream_output_descriptor_imp::~stream_output_descriptor_imp() {}
-
-    void stream_output_descriptor_imp::stream_flags_init()
+    
+    stream_output_descriptor_response * STDCALL stream_output_descriptor_imp::get_stream_output_response()
     {
-        stream_output_flags.clock_sync_source = stream_output_desc.stream_flags >> 0 & 0x01;;
-        stream_output_flags.class_a = stream_output_desc.stream_flags >> 1 & 0x01;
-        stream_output_flags.class_b = stream_output_desc.stream_flags >> 2 & 0x01;
-        stream_output_flags.supports_encrypted = stream_output_desc.stream_flags >> 3 & 0x01;
-        stream_output_flags.primary_backup_supported = stream_output_desc.stream_flags >> 4 & 0x01;
-        stream_output_flags.primary_backup_valid = stream_output_desc.stream_flags >> 5 & 0x01;
-        stream_output_flags.secondary_backup_supported = stream_output_desc.stream_flags >> 6 & 0x01;
-        stream_output_flags.secondary_backup_valid = stream_output_desc.stream_flags >> 7 & 0x01;
-        stream_output_flags.tertiary_backup_supported = stream_output_desc.stream_flags >> 8 & 0x01;
-        stream_output_flags.tertiary_backup_valid = stream_output_desc.stream_flags >> 9 & 0x01;
+        std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
+        return resp = new stream_output_descriptor_response_imp(resp_ref->get_buffer(),
+                                                               resp_ref->get_size(), resp_ref->get_pos());
+    }
+    
+    stream_output_get_stream_format_response * STDCALL stream_output_descriptor_imp::get_stream_output_get_stream_format_response()
+    {
+        std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
+        return get_format_resp  = new stream_output_get_stream_format_response_imp(resp_ref->get_buffer(),
+                                                                                  resp_ref->get_size(), resp_ref->get_pos());
+    }
+    
+    stream_output_get_stream_info_response * STDCALL stream_output_descriptor_imp::get_stream_output_get_stream_info_response()
+    {
+        std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
+        return get_info_resp  = new stream_output_get_stream_info_response_imp(resp_ref->get_buffer(),
+                                                                                   resp_ref->get_size(), resp_ref->get_pos());
+    }
+    
+    stream_output_get_tx_state_response * STDCALL stream_output_descriptor_imp::get_stream_output_get_tx_state_response()
+    {
+        std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
+        return get_tx_state_resp  = new stream_output_get_tx_state_response_imp(resp_ref->get_buffer(),
+                                                                               resp_ref->get_size(), resp_ref->get_pos());
+    }
+    
+    stream_output_get_tx_connection_response * STDCALL stream_output_descriptor_imp::get_stream_output_get_tx_connection_response()
+    {
+        std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
+        return get_tx_connection_resp  = new stream_output_get_tx_connection_response_imp(resp_ref->get_buffer(),
+                                                                                resp_ref->get_size(), resp_ref->get_pos());
     }
 
     uint16_t STDCALL stream_output_descriptor_imp::descriptor_type() const
     {
-        assert(stream_output_desc.descriptor_type == JDKSAVDECC_DESCRIPTOR_STREAM_OUTPUT);
-        return stream_output_desc.descriptor_type;
+        assert(m_type == JDKSAVDECC_DESCRIPTOR_STREAM_OUTPUT);
+        return m_type;
     }
 
     uint16_t STDCALL stream_output_descriptor_imp::descriptor_index() const
     {
-        return stream_output_desc.descriptor_index;
-    }
-
-    uint8_t * STDCALL stream_output_descriptor_imp::object_name()
-    {
-        return stream_output_desc.object_name.value;
-    }
-
-    uint16_t STDCALL stream_output_descriptor_imp::localized_description()
-    {
-        return stream_output_desc.localized_description;
-    }
-
-    uint16_t STDCALL stream_output_descriptor_imp::clock_domain_index()
-    {
-        return stream_output_desc.clock_domain_index;
-    }
-
-    uint16_t stream_output_descriptor_imp::stream_flags()
-    {
-        return stream_output_desc.stream_flags;
-    }
-
-    bool STDCALL stream_output_descriptor_imp::stream_flags_clock_sync_source()
-    {
-        return stream_output_flags.clock_sync_source;
-    }
-
-    bool STDCALL stream_output_descriptor_imp::stream_flags_class_a()
-    {
-        return stream_output_flags.class_a;
-    }
-
-    bool STDCALL stream_output_descriptor_imp::stream_flags_class_b()
-    {
-        return stream_output_flags.class_b;
-    }
-
-    bool STDCALL stream_output_descriptor_imp::stream_flags_supports_encrypted()
-    {
-        return stream_output_flags.supports_encrypted;
-    }
-
-    bool STDCALL stream_output_descriptor_imp::stream_flags_primary_backup_supported()
-    {
-        return stream_output_flags.primary_backup_supported;
-    }
-
-    bool STDCALL stream_output_descriptor_imp::stream_flags_primary_backup_valid()
-    {
-        return stream_output_flags.primary_backup_valid;
-    }
-
-    bool STDCALL stream_output_descriptor_imp::stream_flags_secondary_backup_supported()
-    {
-        return stream_output_flags.secondary_backup_supported;
-    }
-
-    bool STDCALL stream_output_descriptor_imp::stream_flags_secondary_backup_valid()
-    {
-        return stream_output_flags.secondary_backup_valid;
-    }
-
-    bool STDCALL stream_output_descriptor_imp::stream_flags_tertiary_backup_supported()
-    {
-        return stream_output_flags.tertiary_backup_supported;
-    }
-
-    bool STDCALL stream_output_descriptor_imp::stream_flags_tertiary_backup_valid()
-    {
-        return stream_output_flags.tertiary_backup_valid;
-    }
-
-    const char * stream_output_descriptor_imp::current_format()
-    {
-        uint64_t current_format = jdksavdecc_uint64_get(&stream_output_desc.current_format, 0);
-
-        return utility::ieee1722_format_value_to_name(current_format);
-    }
-
-    uint16_t stream_output_descriptor_imp::formats_offset()
-    {
-        assert(stream_output_desc.formats_offset == 132);
-        return stream_output_desc.formats_offset;
-    }
-
-    uint16_t STDCALL stream_output_descriptor_imp::number_of_formats()
-    {
-        assert(stream_output_desc.number_of_formats <= 47);
-        return stream_output_desc.number_of_formats;
-    }
-
-    uint64_t STDCALL stream_output_descriptor_imp::backup_talker_entity_id_0()
-    {
-        return jdksavdecc_uint64_get(&stream_output_desc.backup_talker_entity_id_0, 0);
-    }
-
-    uint16_t STDCALL stream_output_descriptor_imp::backup_talker_unique_0()
-    {
-        return stream_output_desc.backup_talker_unique_0;
-    }
-
-    uint64_t STDCALL stream_output_descriptor_imp::backup_talker_entity_id_1()
-    {
-        return jdksavdecc_uint64_get(&stream_output_desc.backup_talker_entity_id_1, 0);
-    }
-
-    uint16_t STDCALL stream_output_descriptor_imp::backup_talker_unique_1()
-    {
-        return stream_output_desc.backup_talker_unique_1;
-    }
-
-    uint64_t STDCALL stream_output_descriptor_imp::backup_talker_entity_id_2()
-    {
-        return jdksavdecc_uint64_get(&stream_output_desc.backup_talker_entity_id_2, 0);
-    }
-
-    uint16_t STDCALL stream_output_descriptor_imp::backup_talker_unique_2()
-    {
-        return stream_output_desc.backup_talker_unique_2;
-    }
-
-    uint64_t STDCALL stream_output_descriptor_imp::backedup_talker_entity_id()
-    {
-        return jdksavdecc_uint64_get(&stream_output_desc.backedup_talker_entity_id, 0);
-    }
-
-    uint16_t STDCALL stream_output_descriptor_imp::backedup_talker_unique()
-    {
-        return stream_output_desc.backedup_talker_unique;
-    }
-
-    uint16_t STDCALL stream_output_descriptor_imp::avb_interface_index()
-    {
-        return stream_output_desc.avb_interface_index;
-    }
-
-    uint32_t STDCALL stream_output_descriptor_imp::buffer_length()
-    {
-        return stream_output_desc.buffer_length;
+        return m_index;
     }
 
     uint64_t STDCALL stream_output_descriptor_imp::set_stream_format_stream_format()
     {
         return jdksavdecc_uint64_get(&aem_cmd_set_stream_format_resp.stream_format, 0);
     }
-
-    void stream_output_descriptor_imp::update_stream_format(struct jdksavdecc_eui64 stream_format)
-    {
-        stream_output_desc.current_format = stream_format;
-    }
-
-    uint64_t STDCALL stream_output_descriptor_imp::get_stream_format_stream_format()
-    {
-        return jdksavdecc_uint64_get(&aem_cmd_get_stream_format_resp.stream_format, 0);
-    }
-
-    uint32_t STDCALL stream_output_descriptor_imp::get_stream_info_flags()
-    {
-        return aem_cmd_get_stream_info_resp.aem_stream_info_flags;
-    }
-
-    uint64_t STDCALL stream_output_descriptor_imp::get_stream_info_stream_format()
-    {
-        return jdksavdecc_uint64_get(&aem_cmd_get_stream_info_resp.stream_format, 0);
-    }
-
-    uint64_t STDCALL stream_output_descriptor_imp::get_stream_info_stream_id()
-    {
-        return jdksavdecc_uint64_get(&aem_cmd_get_stream_info_resp.stream_id, 0);
-    }
-
-    uint32_t STDCALL stream_output_descriptor_imp::get_stream_info_msrp_accumulated_latency()
-    {
-        return aem_cmd_get_stream_info_resp.msrp_accumulated_latency;
-    }
-
-    uint64_t STDCALL stream_output_descriptor_imp::get_stream_info_stream_dest_mac()
-    {
-        uint64_t stream_dest_mac;
-        utility::convert_eui48_to_uint64(aem_cmd_get_stream_info_resp.stream_dest_mac.value, stream_dest_mac);
-
-        return stream_dest_mac;
-    }
-
-    uint8_t STDCALL stream_output_descriptor_imp::get_stream_info_msrp_failure_code()
-    {
-        return aem_cmd_get_stream_info_resp.msrp_failure_code;
-    }
-
-    uint16_t STDCALL stream_output_descriptor_imp::get_stream_info_stream_vlan_id()
-	{
-		return aem_cmd_get_stream_info_resp.stream_vlan_id;
- 	}
-
-    uint64_t STDCALL stream_output_descriptor_imp::get_stream_info_msrp_failure_bridge_id()
-    {
-        return jdksavdecc_uint64_get(&aem_cmd_get_stream_info_resp.msrp_failure_bridge_id, 0);
-    }
-
-    bool stream_output_descriptor_imp::is_clock_sync_source_set()
-    {
-        return stream_output_flags.clock_sync_source;
-    }
-
-    uint64_t STDCALL stream_output_descriptor_imp::get_tx_state_stream_id()
-    {
-        return jdksavdecc_uint64_get(&acmp_cmd_get_tx_state_resp.header.stream_id, 0);
-    }
-
-    uint64_t STDCALL stream_output_descriptor_imp::get_tx_state_stream_dest_mac()
-    {
-        uint64_t stream_dest_mac;
-        utility::convert_eui48_to_uint64(acmp_cmd_get_tx_state_resp.stream_dest_mac.value, stream_dest_mac);
-
-        return stream_dest_mac;
-    }
-
-    uint16_t STDCALL stream_output_descriptor_imp::get_tx_state_connection_count()
-    {
-        return acmp_cmd_get_tx_state_resp.connection_count;
-    }
-
-    uint16_t STDCALL stream_output_descriptor_imp::get_tx_state_stream_vlan_id()
-    {
-        return acmp_cmd_get_tx_state_resp.stream_vlan_id;
-    }
-    
-    uint64_t STDCALL stream_output_descriptor_imp::get_tx_connection_stream_id()
-    {
-        return jdksavdecc_uint64_get(&acmp_cmd_get_tx_connection_resp.header.stream_id, 0);
-    }
-
-    uint16_t STDCALL stream_output_descriptor_imp::get_tx_connection_talker_unique_id()
-    {
-        return acmp_cmd_get_tx_connection_resp.talker_unique_id;
-    }
-
-    uint16_t STDCALL stream_output_descriptor_imp::get_tx_connection_listener_unique_id()
-    {
-        return acmp_cmd_get_tx_connection_resp.listener_unique_id;
-    }
-
-    uint64_t STDCALL stream_output_descriptor_imp::get_tx_connection_stream_dest_mac()
-    {
-        uint64_t stream_dest_mac;
-        utility::convert_eui48_to_uint64(acmp_cmd_get_tx_connection_resp.stream_dest_mac.value, stream_dest_mac);
-
-        return stream_dest_mac;
-    }
-
-    uint16_t STDCALL stream_output_descriptor_imp::get_tx_connection_connection_count()
-    {
-        return acmp_cmd_get_tx_connection_resp.connection_count;
-    }
-
-    uint16_t STDCALL stream_output_descriptor_imp::get_tx_connection_stream_vlan_id()
-    {
-        return acmp_cmd_get_tx_connection_resp.stream_vlan_id;
-    }
-
-    uint64_t STDCALL stream_output_descriptor_imp::get_tx_connection_listener_entity_id()
-    {
-        return jdksavdecc_uint64_get(&acmp_cmd_get_tx_connection_resp.listener_entity_id, 0);
-    }
-
 
     int STDCALL stream_output_descriptor_imp::send_set_stream_format_cmd(void *notification_id, uint64_t new_stream_format)
     {
@@ -430,16 +166,13 @@ namespace avdecc_lib
             return -1;
         }
 
+        replace_frame(frame, ETHER_HDR_SIZE, frame_len);
+        
         msg_type = aem_cmd_set_stream_format_resp.aem_header.aecpdu_header.header.message_type;
         status = aem_cmd_set_stream_format_resp.aem_header.aecpdu_header.header.status;
         u_field = aem_cmd_set_stream_format_resp.aem_header.command_type >> 15 & 0x01; // u_field = the msb of the uint16_t command_type
 
         aecp_controller_state_machine_ref->update_inflight_for_rcvd_resp(notification_id, msg_type, u_field, &cmd_frame);
-
-        if(status == AEM_STATUS_SUCCESS)
-        {
-            update_stream_format(aem_cmd_set_stream_format_resp.stream_format);
-        }
 
         return 0;
     }
@@ -489,6 +222,7 @@ namespace avdecc_lib
     int stream_output_descriptor_imp::proc_get_stream_format_resp(void *&notification_id, const uint8_t *frame, size_t frame_len, int &status)
     {
         struct jdksavdecc_frame cmd_frame;
+        struct jdksavdecc_aem_command_get_stream_format_response aem_cmd_get_stream_format_resp;
         ssize_t aem_cmd_get_stream_format_resp_returned;
         uint32_t msg_type;
         bool u_field;
@@ -506,6 +240,8 @@ namespace avdecc_lib
             assert(aem_cmd_get_stream_format_resp_returned >= 0);
             return -1;
         }
+        
+        replace_frame(frame, ETHER_HDR_SIZE, frame_len);
 
         msg_type = aem_cmd_get_stream_format_resp.aem_header.aecpdu_header.header.message_type;
         status = aem_cmd_get_stream_format_resp.aem_header.aecpdu_header.header.status;
@@ -580,6 +316,8 @@ namespace avdecc_lib
             assert(read_status >= 0);
             return -1;
         }
+        
+        replace_frame(frame, ETHER_HDR_SIZE, frame_len);
 
         msg_type = aem_cmd_set_stream_info_resp.aem_header.aecpdu_header.header.message_type;
         status = aem_cmd_set_stream_info_resp.aem_header.aecpdu_header.header.status;
@@ -632,18 +370,10 @@ namespace avdecc_lib
         return 0;
     }
 
-	bool stream_output_descriptor_imp::get_stream_info_flag(const char *flag)
-	{
-		std::map<string, int>::iterator it;
-
-		it = stream_info_flags.find(flag);
-		assert(it != stream_info_flags.end());
-		return ((aem_cmd_get_stream_info_resp.aem_stream_info_flags & it->second) != 0);
-	}
-
     int stream_output_descriptor_imp::proc_get_stream_info_resp(void *&notification_id, const uint8_t *frame, size_t frame_len, int &status)
     {
         struct jdksavdecc_frame cmd_frame;
+        struct jdksavdecc_aem_command_get_stream_info_response aem_cmd_get_stream_info_resp;
         ssize_t aem_cmd_get_stream_info_resp_returned;
         uint32_t msg_type;
         bool u_field;
@@ -660,6 +390,8 @@ namespace avdecc_lib
             assert(aem_cmd_get_stream_info_resp_returned >= 0);
             return -1;
         }
+        
+        replace_frame(frame, ETHER_HDR_SIZE, frame_len);
 
         msg_type = aem_cmd_get_stream_info_resp.aem_header.aecpdu_header.header.message_type;
         status = aem_cmd_get_stream_info_resp.aem_header.aecpdu_header.header.status;
@@ -816,10 +548,11 @@ namespace avdecc_lib
 
     int STDCALL stream_output_descriptor_imp::send_get_tx_state_cmd(void *notification_id)
     {
+        entity_descriptor_response *entity_resp_ref = base_end_station_imp_ref->get_entity_desc_by_index(0)->get_entity_response();
         struct jdksavdecc_frame cmd_frame;
         struct jdksavdecc_acmpdu acmp_cmd_get_tx_state;
         ssize_t acmp_cmd_get_tx_state_returned;
-        uint64_t talker_entity_id = base_end_station_imp_ref->get_entity_desc_by_index(0)->entity_id();
+        uint64_t talker_entity_id = entity_resp_ref->entity_id();
 
         /******************************************* ACMP Common Data ******************************************/
         acmp_cmd_get_tx_state.controller_entity_id = base_end_station_imp_ref->get_adp()->get_controller_entity_id();
@@ -849,13 +582,15 @@ namespace avdecc_lib
 
         acmp_controller_state_machine_ref->common_hdr_init(JDKSAVDECC_ACMP_MESSAGE_TYPE_GET_TX_STATE_COMMAND, &cmd_frame);
         system_queue_tx(notification_id, CMD_WITH_NOTIFICATION, cmd_frame.payload, cmd_frame.length);
-
+        
+        free(entity_resp_ref);
         return 0;
     }
 
     int stream_output_descriptor_imp::proc_get_tx_state_resp(void *&notification_id, const uint8_t *frame, size_t frame_len, int &status)
     {
         struct jdksavdecc_frame cmd_frame;
+        struct jdksavdecc_acmpdu acmp_cmd_get_tx_state_resp;
         ssize_t acmp_cmd_get_tx_state_resp_returned;
 
         memcpy(cmd_frame.payload, frame, frame_len);
@@ -870,6 +605,8 @@ namespace avdecc_lib
             assert(acmp_cmd_get_tx_state_resp_returned >= 0);
             return -1;
         }
+        
+        replace_frame(frame, ETHER_HDR_SIZE, frame_len);
 
         status = acmp_cmd_get_tx_state_resp.header.status;
 
@@ -880,10 +617,11 @@ namespace avdecc_lib
 
     int STDCALL stream_output_descriptor_imp::send_get_tx_connection_cmd(void *notification_id, uint64_t listener_entity_id, uint16_t listener_unique_id)
     {
+        entity_descriptor_response *entity_resp_ref = base_end_station_imp_ref->get_entity_desc_by_index(0)->get_entity_response();
         struct jdksavdecc_frame cmd_frame;
         struct jdksavdecc_acmpdu acmp_cmd_get_tx_connection;
         ssize_t acmp_cmd_get_tx_connection_returned;
-        uint64_t talker_entity_id = base_end_station_imp_ref->get_entity_desc_by_index(0)->entity_id();
+        uint64_t talker_entity_id = entity_resp_ref->entity_id();
 
         /********************************************* ACMP Common Data *********************************************/
         acmp_cmd_get_tx_connection.controller_entity_id = base_end_station_imp_ref->get_adp()->get_controller_entity_id();
@@ -913,13 +651,15 @@ namespace avdecc_lib
 
         acmp_controller_state_machine_ref->common_hdr_init(JDKSAVDECC_ACMP_MESSAGE_TYPE_GET_TX_CONNECTION_COMMAND, &cmd_frame);
         system_queue_tx(notification_id, CMD_WITH_NOTIFICATION, cmd_frame.payload, cmd_frame.length);
-
+        
+        free(entity_resp_ref);
         return 0;
     }
 
     int stream_output_descriptor_imp::proc_get_tx_connection_resp(void *&notification_id, const uint8_t *frame, size_t frame_len, int &status)
     {
         struct jdksavdecc_frame cmd_frame;
+        struct jdksavdecc_acmpdu acmp_cmd_get_tx_connection_resp;
         ssize_t acmp_cmd_get_tx_connection_resp_returned;
 
         memcpy(cmd_frame.payload, frame, frame_len);
@@ -934,6 +674,8 @@ namespace avdecc_lib
             assert(acmp_cmd_get_tx_connection_resp_returned >= 0);
             return -1;
         }
+        
+        replace_frame(frame, ETHER_HDR_SIZE, frame_len);
 
         status = acmp_cmd_get_tx_connection_resp.header.status;
 

--- a/controller/lib/src/stream_output_descriptor_imp.cpp
+++ b/controller/lib/src/stream_output_descriptor_imp.cpp
@@ -27,7 +27,9 @@
  * STREAM OUTPUT descriptor implementation
  */
 
+#include <mutex>
 #include <vector>
+
 #include "util.h"
 #include "avdecc_error.h"
 #include "enumeration.h"

--- a/controller/lib/src/stream_output_descriptor_imp.cpp
+++ b/controller/lib/src/stream_output_descriptor_imp.cpp
@@ -43,9 +43,6 @@ namespace avdecc_lib
 {
     stream_output_descriptor_imp::stream_output_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos)
     {
-        m_type = jdksavdecc_descriptor_stream_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
-        m_index = jdksavdecc_descriptor_stream_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
-        
         memset(&aem_cmd_set_stream_format_resp, 0, sizeof(struct jdksavdecc_aem_command_set_stream_format_response));
         memset(&aem_cmd_set_stream_info_resp, 0, sizeof(struct jdksavdecc_aem_command_set_stream_info_response));
     }
@@ -58,28 +55,28 @@ namespace avdecc_lib
         return resp = new stream_output_descriptor_response_imp(resp_ref->get_buffer(),
                                                                resp_ref->get_size(), resp_ref->get_pos());
     }
-    
+
     stream_output_get_stream_format_response * STDCALL stream_output_descriptor_imp::get_stream_output_get_stream_format_response()
     {
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
         return get_format_resp  = new stream_output_get_stream_format_response_imp(resp_ref->get_buffer(),
                                                                                   resp_ref->get_size(), resp_ref->get_pos());
     }
-    
+
     stream_output_get_stream_info_response * STDCALL stream_output_descriptor_imp::get_stream_output_get_stream_info_response()
     {
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
         return get_info_resp  = new stream_output_get_stream_info_response_imp(resp_ref->get_buffer(),
                                                                                    resp_ref->get_size(), resp_ref->get_pos());
     }
-    
+
     stream_output_get_tx_state_response * STDCALL stream_output_descriptor_imp::get_stream_output_get_tx_state_response()
     {
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
         return get_tx_state_resp  = new stream_output_get_tx_state_response_imp(resp_ref->get_buffer(),
                                                                                resp_ref->get_size(), resp_ref->get_pos());
     }
-    
+
     stream_output_get_tx_connection_response * STDCALL stream_output_descriptor_imp::get_stream_output_get_tx_connection_response()
     {
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
@@ -89,13 +86,13 @@ namespace avdecc_lib
 
     uint16_t STDCALL stream_output_descriptor_imp::descriptor_type() const
     {
-        assert(m_type == JDKSAVDECC_DESCRIPTOR_STREAM_OUTPUT);
-        return m_type;
+        assert(jdksavdecc_descriptor_stream_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos()) == JDKSAVDECC_DESCRIPTOR_STREAM_OUTPUT);
+        return jdksavdecc_descriptor_stream_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 
     uint16_t STDCALL stream_output_descriptor_imp::descriptor_index() const
     {
-        return m_index;
+        return jdksavdecc_descriptor_stream_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 
     uint64_t STDCALL stream_output_descriptor_imp::set_stream_format_stream_format()
@@ -582,8 +579,8 @@ namespace avdecc_lib
 
         acmp_controller_state_machine_ref->common_hdr_init(JDKSAVDECC_ACMP_MESSAGE_TYPE_GET_TX_STATE_COMMAND, &cmd_frame);
         system_queue_tx(notification_id, CMD_WITH_NOTIFICATION, cmd_frame.payload, cmd_frame.length);
-        
-        free(entity_resp_ref);
+
+        delete entity_resp_ref;
         return 0;
     }
 
@@ -651,8 +648,8 @@ namespace avdecc_lib
 
         acmp_controller_state_machine_ref->common_hdr_init(JDKSAVDECC_ACMP_MESSAGE_TYPE_GET_TX_CONNECTION_COMMAND, &cmd_frame);
         system_queue_tx(notification_id, CMD_WITH_NOTIFICATION, cmd_frame.payload, cmd_frame.length);
-        
-        free(entity_resp_ref);
+
+        delete entity_resp_ref;
         return 0;
     }
 

--- a/controller/lib/src/stream_output_descriptor_imp.cpp
+++ b/controller/lib/src/stream_output_descriptor_imp.cpp
@@ -52,15 +52,15 @@ namespace avdecc_lib
     stream_output_descriptor_response * STDCALL stream_output_descriptor_imp::get_stream_output_response()
     {
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
-        return resp = new stream_output_descriptor_response_imp(resp_ref->get_buffer(),
-                                                               resp_ref->get_size(), resp_ref->get_pos());
+        return resp = new stream_output_descriptor_response_imp(resp_ref->get_desc_buffer(),
+                                                                resp_ref->get_desc_size(), resp_ref->get_desc_pos());
     }
 
     stream_output_get_stream_format_response * STDCALL stream_output_descriptor_imp::get_stream_output_get_stream_format_response()
     {
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
         return get_format_resp  = new stream_output_get_stream_format_response_imp(resp_ref->get_buffer(),
-                                                                                  resp_ref->get_size(), resp_ref->get_pos());
+                                                                                   resp_ref->get_size(), resp_ref->get_pos());
     }
 
     stream_output_get_stream_info_response * STDCALL stream_output_descriptor_imp::get_stream_output_get_stream_info_response()
@@ -82,17 +82,6 @@ namespace avdecc_lib
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
         return get_tx_connection_resp  = new stream_output_get_tx_connection_response_imp(resp_ref->get_buffer(),
                                                                                 resp_ref->get_size(), resp_ref->get_pos());
-    }
-
-    uint16_t STDCALL stream_output_descriptor_imp::descriptor_type() const
-    {
-        assert(jdksavdecc_descriptor_stream_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos()) == JDKSAVDECC_DESCRIPTOR_STREAM_OUTPUT);
-        return jdksavdecc_descriptor_stream_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
-    }
-
-    uint16_t STDCALL stream_output_descriptor_imp::descriptor_index() const
-    {
-        return jdksavdecc_descriptor_stream_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 
     uint64_t STDCALL stream_output_descriptor_imp::set_stream_format_stream_format()
@@ -225,6 +214,7 @@ namespace avdecc_lib
         bool u_field;
 
         memcpy(cmd_frame.payload, frame, frame_len);
+        memset(&aem_cmd_get_stream_format_resp, 0, sizeof(jdksavdecc_aem_command_get_stream_format_response));
 
         aem_cmd_get_stream_format_resp_returned = jdksavdecc_aem_command_get_stream_format_response_read(&aem_cmd_get_stream_format_resp,
                                                                                                          frame,
@@ -376,6 +366,8 @@ namespace avdecc_lib
         bool u_field;
 
         memcpy(cmd_frame.payload, frame, frame_len);
+        memset(&aem_cmd_get_stream_info_resp, 0, sizeof(jdksavdecc_aem_command_get_stream_info_response));
+        
         aem_cmd_get_stream_info_resp_returned = jdksavdecc_aem_command_get_stream_info_response_read(&aem_cmd_get_stream_info_resp,
                                                                                                      frame,
                                                                                                      ETHER_HDR_SIZE,
@@ -405,7 +397,7 @@ namespace avdecc_lib
         struct jdksavdecc_aem_command_start_streaming aem_cmd_start_streaming;
         ssize_t aem_cmd_start_streaming_returned;
 
-        memset(&aem_cmd_start_streaming,0,sizeof(aem_cmd_start_streaming));
+        memset(&aem_cmd_start_streaming, 0, sizeof(aem_cmd_start_streaming));
         /******************************************** AECP Common Data *******************************************/
         aem_cmd_start_streaming.aem_header.aecpdu_header.controller_entity_id = base_end_station_imp_ref->get_adp()->get_controller_entity_id();
         // Fill aem_cmd_start_streaming.sequence_id in AEM Controller State Machine
@@ -448,8 +440,9 @@ namespace avdecc_lib
         uint32_t msg_type;
         bool u_field;
 
-        memset(&aem_cmd_start_streaming_resp,0,sizeof(aem_cmd_start_streaming_resp));
         memcpy(cmd_frame.payload, frame, frame_len);
+        memset(&aem_cmd_start_streaming_resp,0,sizeof(aem_cmd_start_streaming_resp));
+
         aem_cmd_start_streaming_resp_returned = jdksavdecc_aem_command_start_streaming_response_read(&aem_cmd_start_streaming_resp,
                                                                                                      frame,
                                                                                                      ETHER_HDR_SIZE,
@@ -520,8 +513,9 @@ namespace avdecc_lib
         uint32_t msg_type;
         bool u_field;
 
-        memset(&aem_cmd_stop_streaming_resp,0,sizeof(aem_cmd_stop_streaming_resp));
         memcpy(cmd_frame.payload, frame, frame_len);
+        memset(&aem_cmd_stop_streaming_resp,0,sizeof(aem_cmd_stop_streaming_resp));
+
         aem_cmd_stop_streaming_resp_returned = jdksavdecc_aem_command_stop_streaming_response_read(&aem_cmd_stop_streaming_resp,
                                                                                                    frame,
                                                                                                    ETHER_HDR_SIZE,

--- a/controller/lib/src/stream_output_descriptor_imp.h
+++ b/controller/lib/src/stream_output_descriptor_imp.h
@@ -60,8 +60,6 @@ namespace avdecc_lib
         stream_output_get_tx_state_response_imp *get_tx_state_resp;
         stream_output_get_tx_connection_response_imp *get_tx_connection_resp;
 
-        uint16_t STDCALL descriptor_type() const;
-        uint16_t STDCALL descriptor_index() const;
         stream_output_descriptor_response * STDCALL get_stream_output_response();
         stream_output_get_stream_format_response * STDCALL get_stream_output_get_stream_format_response();
         stream_output_get_stream_info_response * STDCALL get_stream_output_get_stream_info_response();

--- a/controller/lib/src/stream_output_descriptor_imp.h
+++ b/controller/lib/src/stream_output_descriptor_imp.h
@@ -37,95 +37,40 @@ using namespace std;
 #include "jdksavdecc_acmp.h"
 #include "descriptor_base_imp.h"
 #include "stream_output_descriptor.h"
+#include "stream_output_descriptor_response_imp.h"
+#include "stream_output_get_stream_format_response_imp.h"
+#include "stream_output_get_stream_info_response_imp.h"
+#include "stream_output_get_tx_state_response_imp.h"
+#include "stream_output_get_tx_connection_response_imp.h"
 
 namespace avdecc_lib
 {
     class stream_output_descriptor_imp : public stream_output_descriptor, public virtual descriptor_base_imp
     {
     private:
-        struct jdksavdecc_descriptor_stream stream_output_desc; // Structure containing the stream_output_desc fields
-
-		std::map <string, int> stream_info_flags;
-
-        struct stream_output_desc_stream_flags
-        {
-            bool clock_sync_source;
-            bool class_a;
-            bool class_b;
-            bool supports_encrypted;
-            bool primary_backup_supported;
-            bool primary_backup_valid;
-            bool secondary_backup_supported;
-            bool secondary_backup_valid;
-            bool tertiary_backup_supported;
-            bool tertiary_backup_valid;
-        };
-
-        struct stream_output_desc_stream_flags stream_output_flags;
+        uint16_t m_type;
+        uint16_t m_index;
         struct jdksavdecc_aem_command_set_stream_format_response aem_cmd_set_stream_format_resp; // Store the response received after sending a SET_STREAM_FORMAT command.
-        struct jdksavdecc_aem_command_get_stream_format_response aem_cmd_get_stream_format_resp; // Store the response received after sending a GET_STREAM_FORMAT command.
         struct jdksavdecc_aem_command_set_stream_info_response aem_cmd_set_stream_info_resp; // Store the response received after sending a SET_STREAM_INFO command.
-        struct jdksavdecc_aem_command_get_stream_info_response aem_cmd_get_stream_info_resp; // Store the response received after sending a GET_STREAM_INFO command.
-
-        struct jdksavdecc_acmpdu acmp_cmd_get_tx_state_resp; // Store the response received after sending a GET_TX_STATE command.
-        struct jdksavdecc_acmpdu acmp_cmd_get_tx_connection_resp; // Store the response received after sending a GET_TX_CONNECTION command.
-
     public:
         stream_output_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
         virtual ~stream_output_descriptor_imp();
+        
+        stream_output_descriptor_response_imp *resp;
+        stream_output_get_stream_format_response_imp *get_format_resp;
+        stream_output_get_stream_info_response_imp *get_info_resp;
+        stream_output_get_tx_state_response_imp *get_tx_state_resp;
+        stream_output_get_tx_connection_response_imp *get_tx_connection_resp;
 
         uint16_t STDCALL descriptor_type() const;
         uint16_t STDCALL descriptor_index() const;
-        uint8_t * STDCALL object_name();
-        uint16_t STDCALL localized_description();
-
-        uint16_t STDCALL clock_domain_index();
-        uint16_t STDCALL stream_flags();
-        bool STDCALL stream_flags_clock_sync_source();
-        bool STDCALL stream_flags_class_a();
-        bool STDCALL stream_flags_class_b();
-        bool STDCALL stream_flags_supports_encrypted();
-        bool STDCALL stream_flags_primary_backup_supported();
-        bool STDCALL stream_flags_primary_backup_valid();
-        bool STDCALL stream_flags_secondary_backup_supported();
-        bool STDCALL stream_flags_secondary_backup_valid();
-        bool STDCALL stream_flags_tertiary_backup_supported();
-        bool STDCALL stream_flags_tertiary_backup_valid();
-        const char * STDCALL current_format();
-        uint16_t formats_offset();
-        uint16_t STDCALL number_of_formats();
-        uint64_t STDCALL backup_talker_entity_id_0();
-        uint16_t STDCALL backup_talker_unique_0();
-        uint64_t STDCALL backup_talker_entity_id_1();
-        uint16_t STDCALL backup_talker_unique_1();
-        uint64_t STDCALL backup_talker_entity_id_2();
-        uint16_t STDCALL backup_talker_unique_2();
-        uint64_t STDCALL backedup_talker_entity_id();
-        uint16_t STDCALL backedup_talker_unique();
-        uint16_t STDCALL avb_interface_index();
-        uint32_t STDCALL buffer_length();
+        stream_output_descriptor_response * STDCALL get_stream_output_response();
+        stream_output_get_stream_format_response * STDCALL get_stream_output_get_stream_format_response();
+        stream_output_get_stream_info_response * STDCALL get_stream_output_get_stream_info_response();
+        stream_output_get_tx_state_response * STDCALL get_stream_output_get_tx_state_response();
+        stream_output_get_tx_connection_response * STDCALL get_stream_output_get_tx_connection_response();
+        
         uint64_t STDCALL set_stream_format_stream_format();
-        uint64_t STDCALL get_stream_format_stream_format();
-        uint32_t STDCALL get_stream_info_flags();
-        uint64_t STDCALL get_stream_info_stream_format();
-        uint64_t STDCALL get_stream_info_stream_id();
-        uint32_t STDCALL get_stream_info_msrp_accumulated_latency();
-        uint64_t STDCALL get_stream_info_stream_dest_mac();
-        uint8_t STDCALL get_stream_info_msrp_failure_code();
-        uint64_t STDCALL get_stream_info_msrp_failure_bridge_id();
-        uint16_t STDCALL get_stream_info_stream_vlan_id() ;
-        bool is_clock_sync_source_set();
-        uint64_t STDCALL get_tx_state_stream_id();
-        uint64_t STDCALL get_tx_state_stream_dest_mac();
-        uint16_t STDCALL get_tx_state_connection_count();
-        uint16_t STDCALL get_tx_state_stream_vlan_id();
-        uint64_t STDCALL get_tx_connection_stream_id();
-        uint16_t STDCALL get_tx_connection_talker_unique_id();
-        uint16_t STDCALL get_tx_connection_listener_unique_id();
-        uint64_t STDCALL get_tx_connection_stream_dest_mac();
-        uint16_t STDCALL get_tx_connection_connection_count();
-        uint16_t STDCALL get_tx_connection_stream_vlan_id();
-        uint64_t STDCALL get_tx_connection_listener_entity_id();
 
 		int STDCALL send_set_stream_format_cmd(void *notification_id, uint64_t new_stream_format);
         int proc_set_stream_format_resp(void *&notification_id, const uint8_t *frame, size_t frame_len, int &status);
@@ -139,8 +84,6 @@ namespace avdecc_lib
         int STDCALL send_get_stream_info_cmd(void *notification_id);
         int proc_get_stream_info_resp(void *&notification_id, const uint8_t *frame, size_t frame_len, int &status);
 
-		bool STDCALL get_stream_info_flag(const char *flag);
-
         int STDCALL send_start_streaming_cmd(void *notification_id);
         int proc_start_streaming_resp(void *&notification_id, const uint8_t *frame, size_t frame_len, int &status);
 
@@ -152,16 +95,5 @@ namespace avdecc_lib
 
         int STDCALL send_get_tx_connection_cmd(void *notification_id, uint64_t listener_entity_id, uint16_t listener_unique_id);
         int proc_get_tx_connection_resp(void *&notification_id, const uint8_t *frame, size_t frame_len, int &status);
-
-    private:
-        /**
-         * Store the stream flags components of the STREAM OUTPUT descriptor object in a vector.
-         */
-        void stream_flags_init();
-
-        /**
-         * Update the internal STREAM OUTPUT descriptor's stream format field.
-         */
-        void update_stream_format(struct jdksavdecc_eui64 stream_format);
     };
 }

--- a/controller/lib/src/stream_output_descriptor_imp.h
+++ b/controller/lib/src/stream_output_descriptor_imp.h
@@ -48,8 +48,6 @@ namespace avdecc_lib
     class stream_output_descriptor_imp : public stream_output_descriptor, public virtual descriptor_base_imp
     {
     private:
-        uint16_t m_type;
-        uint16_t m_index;
         struct jdksavdecc_aem_command_set_stream_format_response aem_cmd_set_stream_format_resp; // Store the response received after sending a SET_STREAM_FORMAT command.
         struct jdksavdecc_aem_command_set_stream_info_response aem_cmd_set_stream_info_resp; // Store the response received after sending a SET_STREAM_INFO command.
     public:

--- a/controller/lib/src/stream_output_descriptor_response_imp.cpp
+++ b/controller/lib/src/stream_output_descriptor_response_imp.cpp
@@ -1,0 +1,239 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2013 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * stream_output_descriptor_imp.cpp
+ *
+ * STREAM OUTPUT descriptor implementation
+ */
+
+#include <vector>
+#include "util.h"
+#include "avdecc_error.h"
+#include "enumeration.h"
+#include "log_imp.h"
+#include "adp.h"
+#include "end_station_imp.h"
+#include "system_tx_queue.h"
+#include "acmp_controller_state_machine.h"
+#include "aecp_controller_state_machine.h"
+#include "stream_output_descriptor_response_imp.h"
+
+namespace avdecc_lib
+{
+    stream_output_descriptor_response_imp::stream_output_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos) : descriptor_base_imp(nullptr, frame, frame_len, pos)
+    {
+        memset(&stream_output_flags, 0, sizeof(struct stream_output_desc_stream_flags));
+        frame_size = frame_len;
+        buffer = (uint8_t *)malloc(frame_size * sizeof(uint8_t));
+        memcpy(buffer, frame, frame_size);
+        position = pos;
+
+        stream_flags_init();
+        
+        stream_info_flags["CLASS_B"]                  = JDKSAVDECC_AEM_COMMAND_SET_STREAM_INFO_FLAG_CLASS_B;
+        stream_info_flags["FAST_CONNECT"]             = JDKSAVDECC_AEM_COMMAND_SET_STREAM_INFO_FLAG_FAST_CONNECT;
+        stream_info_flags["SAVED_STATE"]              = JDKSAVDECC_AEM_COMMAND_SET_STREAM_INFO_FLAG_SAVED_STATE;
+        stream_info_flags["STREAMING_WAIT"]           = JDKSAVDECC_AEM_COMMAND_SET_STREAM_INFO_FLAG_STREAMING_WAIT;
+        stream_info_flags["ENCRYPTED_PDU"]            = JDKSAVDECC_AEM_COMMAND_SET_STREAM_INFO_FLAG_ENCRYPTED_PDU;
+        stream_info_flags["STREAM_VLAN_ID_VALID"]     = JDKSAVDECC_AEM_COMMAND_SET_STREAM_INFO_FLAG_STREAM_VLAN_ID_VALID;
+        stream_info_flags["CONNECTED"]                = JDKSAVDECC_AEM_COMMAND_SET_STREAM_INFO_FLAG_CONNECTED;
+        stream_info_flags["MSRP_FAILURE_VALID"]       = JDKSAVDECC_AEM_COMMAND_SET_STREAM_INFO_FLAG_MSRP_FAILURE_VALID;
+        stream_info_flags["STREAM_DEST_MAC_VALID"]    = JDKSAVDECC_AEM_COMMAND_SET_STREAM_INFO_FLAG_STREAM_DEST_MAC_VALID;
+        stream_info_flags["MSRP_ACC_LAT_VALID"]       = JDKSAVDECC_AEM_COMMAND_SET_STREAM_INFO_FLAG_MSRP_ACC_LAT_VALID;
+        stream_info_flags["STREAM_ID_VALID"]          = JDKSAVDECC_AEM_COMMAND_SET_STREAM_INFO_FLAG_STREAM_ID_VALID;
+        stream_info_flags["STREAM_FORMAT_VALID"]      = JDKSAVDECC_AEM_COMMAND_SET_STREAM_INFO_FLAG_STREAM_FORMAT_VALID;
+        
+    }
+    
+    stream_output_descriptor_response_imp::~stream_output_descriptor_response_imp() {}
+    
+    void stream_output_descriptor_response_imp::stream_flags_init()
+    {
+        stream_output_flags.clock_sync_source = stream_flags() >> 0 & 0x01;;
+        stream_output_flags.class_a = stream_flags() >> 1 & 0x01;
+        stream_output_flags.class_b = stream_flags() >> 2 & 0x01;
+        stream_output_flags.supports_encrypted = stream_flags() >> 3 & 0x01;
+        stream_output_flags.primary_backup_supported = stream_flags() >> 4 & 0x01;
+        stream_output_flags.primary_backup_valid = stream_flags() >> 5 & 0x01;
+        stream_output_flags.secondary_backup_supported = stream_flags() >> 6 & 0x01;
+        stream_output_flags.secondary_backup_valid = stream_flags() >> 7 & 0x01;
+        stream_output_flags.tertiary_backup_supported = stream_flags() >> 8 & 0x01;
+        stream_output_flags.tertiary_backup_valid = stream_flags() >> 9 & 0x01;
+    }
+    uint8_t * STDCALL stream_output_descriptor_response_imp::object_name()
+    {
+        return (uint8_t *)&buffer[position + JDKSAVDECC_DESCRIPTOR_STREAM_OFFSET_OBJECT_NAME];
+    }
+    
+    uint16_t STDCALL stream_output_descriptor_response_imp::localized_description()
+    {
+        return jdksavdecc_descriptor_stream_get_localized_description(buffer, position);
+    }
+    
+    uint16_t STDCALL stream_output_descriptor_response_imp::clock_domain_index()
+    {
+        return jdksavdecc_descriptor_stream_get_clock_domain_index(buffer, position);
+    }
+    
+    uint16_t stream_output_descriptor_response_imp::stream_flags()
+    {
+        return jdksavdecc_descriptor_stream_get_stream_flags(buffer, position);
+    }
+    
+    bool STDCALL stream_output_descriptor_response_imp::stream_flags_clock_sync_source()
+    {
+        return stream_output_flags.clock_sync_source;
+    }
+    
+    bool STDCALL stream_output_descriptor_response_imp::stream_flags_class_a()
+    {
+        return stream_output_flags.class_a;
+    }
+    
+    bool STDCALL stream_output_descriptor_response_imp::stream_flags_class_b()
+    {
+        return stream_output_flags.class_b;
+    }
+    
+    bool STDCALL stream_output_descriptor_response_imp::stream_flags_supports_encrypted()
+    {
+        return stream_output_flags.supports_encrypted;
+    }
+    
+    bool STDCALL stream_output_descriptor_response_imp::stream_flags_primary_backup_supported()
+    {
+        return stream_output_flags.primary_backup_supported;
+    }
+    
+    bool STDCALL stream_output_descriptor_response_imp::stream_flags_primary_backup_valid()
+    {
+        return stream_output_flags.primary_backup_valid;
+    }
+    
+    bool STDCALL stream_output_descriptor_response_imp::stream_flags_secondary_backup_supported()
+    {
+        return stream_output_flags.secondary_backup_supported;
+    }
+    
+    bool STDCALL stream_output_descriptor_response_imp::stream_flags_secondary_backup_valid()
+    {
+        return stream_output_flags.secondary_backup_valid;
+    }
+    
+    bool STDCALL stream_output_descriptor_response_imp::stream_flags_tertiary_backup_supported()
+    {
+        return stream_output_flags.tertiary_backup_supported;
+    }
+    
+    bool STDCALL stream_output_descriptor_response_imp::stream_flags_tertiary_backup_valid()
+    {
+        return stream_output_flags.tertiary_backup_valid;
+    }
+    
+    const char * STDCALL stream_output_descriptor_response_imp::current_format()
+    {
+        uint64_t current_format;
+        current_format = jdksavdecc_uint64_get(&buffer[position +
+                                                       JDKSAVDECC_DESCRIPTOR_STREAM_OFFSET_CURRENT_FORMAT], 0);
+        
+        return utility::ieee1722_format_value_to_name(current_format);
+    }
+    
+    uint16_t stream_output_descriptor_response_imp::formats_offset()
+    {
+        assert(jdksavdecc_descriptor_stream_get_formats_offset(buffer, position) == 132);
+        return jdksavdecc_descriptor_stream_get_formats_offset(buffer, position);
+    }
+    
+    uint16_t STDCALL stream_output_descriptor_response_imp::number_of_formats()
+    {
+        assert(jdksavdecc_descriptor_stream_get_number_of_formats(buffer, position));
+        return jdksavdecc_descriptor_stream_get_number_of_formats(buffer, position);
+    }
+    
+    uint64_t STDCALL stream_output_descriptor_response_imp::backup_talker_entity_id_0()
+    {
+        uint64_t backup_talker_entity_id_0;
+        return backup_talker_entity_id_0 = jdksavdecc_uint64_get(&buffer[position +
+                                                            JDKSAVDECC_DESCRIPTOR_STREAM_OFFSET_BACKUP_TALKER_ENTITY_ID_0], 0);
+    }
+    
+    uint16_t STDCALL stream_output_descriptor_response_imp::backup_talker_unique_0()
+    {
+        return jdksavdecc_descriptor_stream_get_backup_talker_unique_0(buffer, position);
+    }
+    
+    uint64_t STDCALL stream_output_descriptor_response_imp::backup_talker_entity_id_1()
+    {
+        uint64_t backup_talker_entity_id_1;
+        return backup_talker_entity_id_1 = jdksavdecc_uint64_get(&buffer[position +
+                                                                         JDKSAVDECC_DESCRIPTOR_STREAM_OFFSET_BACKUP_TALKER_ENTITY_ID_1], 0);    }
+    
+    uint16_t STDCALL stream_output_descriptor_response_imp::backup_talker_unique_1()
+    {
+        return jdksavdecc_descriptor_stream_get_backup_talker_unique_1(buffer, position);
+    }
+    
+    uint64_t STDCALL stream_output_descriptor_response_imp::backup_talker_entity_id_2()
+    {
+        uint64_t backup_talker_entity_id_2;
+        return backup_talker_entity_id_2 = jdksavdecc_uint64_get(&buffer[position +
+                                                                         JDKSAVDECC_DESCRIPTOR_STREAM_OFFSET_BACKUP_TALKER_ENTITY_ID_2], 0);    }
+    
+    uint16_t STDCALL stream_output_descriptor_response_imp::backup_talker_unique_2()
+    {
+        return jdksavdecc_descriptor_stream_get_backup_talker_unique_2(buffer, position);
+    }
+    
+    uint64_t STDCALL stream_output_descriptor_response_imp::backedup_talker_entity_id()
+    {
+        uint64_t backedup_talker_entity_id;
+        return backedup_talker_entity_id = jdksavdecc_uint64_get(&buffer[position +
+                                                                         JDKSAVDECC_DESCRIPTOR_STREAM_OFFSET_BACKEDUP_TALKER_ENTITY_ID], 0);
+    }
+    
+    uint16_t STDCALL stream_output_descriptor_response_imp::backedup_talker_unique()
+    {
+        return jdksavdecc_descriptor_stream_get_backedup_talker_unique(buffer, position);
+    }
+    
+    uint16_t STDCALL stream_output_descriptor_response_imp::avb_interface_index()
+    {
+        return jdksavdecc_descriptor_stream_get_avb_interface_index(buffer, position);
+    }
+    
+    uint32_t STDCALL stream_output_descriptor_response_imp::buffer_length()
+    {
+        return jdksavdecc_descriptor_stream_get_buffer_length(buffer, position);
+    }
+    
+    bool stream_output_descriptor_response_imp::get_stream_info_flag(const char *flag)
+    {
+        std::map<string, int>::iterator it;
+        
+        it = stream_info_flags.find(flag);
+        assert(it != stream_info_flags.end());
+        return it->second;
+    }
+}

--- a/controller/lib/src/stream_output_descriptor_response_imp.cpp
+++ b/controller/lib/src/stream_output_descriptor_response_imp.cpp
@@ -22,9 +22,9 @@
  */
 
 /**
- * stream_output_descriptor_imp.cpp
+ * stream_output_descriptor_response_imp.cpp
  *
- * STREAM OUTPUT descriptor implementation
+ * STREAM OUTPUT descriptor response implementation
  */
 
 #include <vector>
@@ -41,14 +41,13 @@
 
 namespace avdecc_lib
 {
-    stream_output_descriptor_response_imp::stream_output_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos) : descriptor_base_imp(nullptr, frame, frame_len, pos)
+    stream_output_descriptor_response_imp::stream_output_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos)
     {
         memset(&stream_output_flags, 0, sizeof(struct stream_output_desc_stream_flags));
         frame_size = frame_len;
         buffer = (uint8_t *)malloc(frame_size * sizeof(uint8_t));
         memcpy(buffer, frame, frame_size);
         position = pos;
-
         stream_flags_init();
         
         stream_info_flags["CLASS_B"]                  = JDKSAVDECC_AEM_COMMAND_SET_STREAM_INFO_FLAG_CLASS_B;
@@ -63,10 +62,12 @@ namespace avdecc_lib
         stream_info_flags["MSRP_ACC_LAT_VALID"]       = JDKSAVDECC_AEM_COMMAND_SET_STREAM_INFO_FLAG_MSRP_ACC_LAT_VALID;
         stream_info_flags["STREAM_ID_VALID"]          = JDKSAVDECC_AEM_COMMAND_SET_STREAM_INFO_FLAG_STREAM_ID_VALID;
         stream_info_flags["STREAM_FORMAT_VALID"]      = JDKSAVDECC_AEM_COMMAND_SET_STREAM_INFO_FLAG_STREAM_FORMAT_VALID;
-        
     }
     
-    stream_output_descriptor_response_imp::~stream_output_descriptor_response_imp() {}
+    stream_output_descriptor_response_imp::~stream_output_descriptor_response_imp()
+    {
+        free(buffer);
+    }
     
     void stream_output_descriptor_response_imp::stream_flags_init()
     {
@@ -81,6 +82,7 @@ namespace avdecc_lib
         stream_output_flags.tertiary_backup_supported = stream_flags() >> 8 & 0x01;
         stream_output_flags.tertiary_backup_valid = stream_flags() >> 9 & 0x01;
     }
+
     uint8_t * STDCALL stream_output_descriptor_response_imp::object_name()
     {
         return (uint8_t *)&buffer[position + JDKSAVDECC_DESCRIPTOR_STREAM_OFFSET_OBJECT_NAME];
@@ -188,7 +190,8 @@ namespace avdecc_lib
     {
         uint64_t backup_talker_entity_id_1;
         return backup_talker_entity_id_1 = jdksavdecc_uint64_get(&buffer[position +
-                                                                         JDKSAVDECC_DESCRIPTOR_STREAM_OFFSET_BACKUP_TALKER_ENTITY_ID_1], 0);    }
+                                                                         JDKSAVDECC_DESCRIPTOR_STREAM_OFFSET_BACKUP_TALKER_ENTITY_ID_1], 0);
+    }
     
     uint16_t STDCALL stream_output_descriptor_response_imp::backup_talker_unique_1()
     {
@@ -199,7 +202,8 @@ namespace avdecc_lib
     {
         uint64_t backup_talker_entity_id_2;
         return backup_talker_entity_id_2 = jdksavdecc_uint64_get(&buffer[position +
-                                                                         JDKSAVDECC_DESCRIPTOR_STREAM_OFFSET_BACKUP_TALKER_ENTITY_ID_2], 0);    }
+                                                                         JDKSAVDECC_DESCRIPTOR_STREAM_OFFSET_BACKUP_TALKER_ENTITY_ID_2], 0);
+    }
     
     uint16_t STDCALL stream_output_descriptor_response_imp::backup_talker_unique_2()
     {
@@ -231,7 +235,6 @@ namespace avdecc_lib
     bool stream_output_descriptor_response_imp::get_stream_info_flag(const char *flag)
     {
         std::map<string, int>::iterator it;
-        
         it = stream_info_flags.find(flag);
         assert(it != stream_info_flags.end());
         return it->second;

--- a/controller/lib/src/stream_output_descriptor_response_imp.h
+++ b/controller/lib/src/stream_output_descriptor_response_imp.h
@@ -34,16 +34,15 @@
 using namespace std;
 
 #include "jdksavdecc_acmp.h"
-#include "descriptor_base_imp.h"
 #include "stream_output_descriptor_response.h"
+#include "jdksavdecc_aem_descriptor.h"
 
 namespace avdecc_lib
 {
-    class stream_output_descriptor_response_imp : public stream_output_descriptor_response, public virtual descriptor_base_imp
+    class stream_output_descriptor_response_imp : public stream_output_descriptor_response
     {
     private:
         std::map <string, int> stream_info_flags;
-        
         struct stream_output_desc_stream_flags
         {
             bool clock_sync_source;

--- a/controller/lib/src/stream_output_descriptor_response_imp.h
+++ b/controller/lib/src/stream_output_descriptor_response_imp.h
@@ -1,0 +1,103 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * stream_output_descriptor_response_imp.h
+ *
+ * STREAM OUTPUT descriptor response implementation class
+ */
+
+#pragma once
+#include <iostream>
+#include <map>
+#include <string>
+using namespace std;
+
+#include "jdksavdecc_acmp.h"
+#include "descriptor_base_imp.h"
+#include "stream_output_descriptor_response.h"
+
+namespace avdecc_lib
+{
+    class stream_output_descriptor_response_imp : public stream_output_descriptor_response, public virtual descriptor_base_imp
+    {
+    private:
+        std::map <string, int> stream_info_flags;
+        
+        struct stream_output_desc_stream_flags
+        {
+            bool clock_sync_source;
+            bool class_a;
+            bool class_b;
+            bool supports_encrypted;
+            bool primary_backup_supported;
+            bool primary_backup_valid;
+            bool secondary_backup_supported;
+            bool secondary_backup_valid;
+            bool tertiary_backup_supported;
+            bool tertiary_backup_valid;
+        };
+        
+        uint8_t * buffer;
+        ssize_t position;
+        size_t frame_size;
+        struct stream_output_desc_stream_flags stream_output_flags;
+    public:
+        stream_output_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos);
+        virtual ~stream_output_descriptor_response_imp();
+        
+        uint8_t * STDCALL object_name();
+        uint16_t STDCALL localized_description();
+        uint16_t STDCALL clock_domain_index();
+        uint16_t STDCALL stream_flags();
+        bool STDCALL stream_flags_clock_sync_source();
+        bool STDCALL stream_flags_class_a();
+        bool STDCALL stream_flags_class_b();
+        bool STDCALL stream_flags_supports_encrypted();
+        bool STDCALL stream_flags_primary_backup_supported();
+        bool STDCALL stream_flags_primary_backup_valid();
+        bool STDCALL stream_flags_secondary_backup_supported();
+        bool STDCALL stream_flags_secondary_backup_valid();
+        bool STDCALL stream_flags_tertiary_backup_supported();
+        bool STDCALL stream_flags_tertiary_backup_valid();
+        const char * STDCALL current_format();
+        uint16_t formats_offset();
+        uint16_t STDCALL number_of_formats();
+        uint64_t STDCALL backup_talker_entity_id_0();
+        uint16_t STDCALL backup_talker_unique_0();
+        uint64_t STDCALL backup_talker_entity_id_1();
+        uint16_t STDCALL backup_talker_unique_1();
+        uint64_t STDCALL backup_talker_entity_id_2();
+        uint16_t STDCALL backup_talker_unique_2();
+        uint64_t STDCALL backedup_talker_entity_id();
+        uint16_t STDCALL backedup_talker_unique();
+        uint16_t STDCALL avb_interface_index();
+        uint32_t STDCALL buffer_length();
+        bool STDCALL get_stream_info_flag(const char *flag);
+    private:
+        /**
+         * Store the stream flags componenets of the STREAM INPUT descriptor object in a vector.
+         */
+        void stream_flags_init();
+    };
+}

--- a/controller/lib/src/stream_output_get_stream_format_response_imp.cpp
+++ b/controller/lib/src/stream_output_get_stream_format_response_imp.cpp
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * stream_output_get_stream_format_response_imp.cpp
+ *
+ * STREAM output counters response implementation
+ */
+
+#include "enumeration.h"
+#include "log_imp.h"
+#include "stream_output_get_stream_format_response_imp.h"
+#include "util.h"
+
+namespace avdecc_lib
+{
+    stream_output_get_stream_format_response_imp::stream_output_get_stream_format_response_imp(uint8_t *frame, size_t frame_len, ssize_t pos)
+    {
+        m_position = pos;
+        m_size = frame_len;
+        m_frame = (uint8_t *)malloc(m_size * sizeof(uint8_t));
+        memcpy(m_frame, frame, m_size);
+    }
+    
+    stream_output_get_stream_format_response_imp::~stream_output_get_stream_format_response_imp(){}
+    
+    uint64_t STDCALL stream_output_get_stream_format_response_imp::get_stream_format()
+    {
+        jdksavdecc_eui64 format_eui64;
+        format_eui64 = jdksavdecc_eui64_get(m_frame, m_position + JDKSAVDECC_AEM_COMMAND_GET_STREAM_FORMAT_RESPONSE_OFFSET_STREAM_FORMAT);
+        return jdksavdecc_eui64_convert_to_uint64(&format_eui64);
+    }
+}

--- a/controller/lib/src/stream_output_get_stream_format_response_imp.cpp
+++ b/controller/lib/src/stream_output_get_stream_format_response_imp.cpp
@@ -24,7 +24,7 @@
 /**
  * stream_output_get_stream_format_response_imp.cpp
  *
- * STREAM output counters response implementation
+ * STREAM OUTPUT get stream format response implementation
  */
 
 #include "enumeration.h"
@@ -42,7 +42,10 @@ namespace avdecc_lib
         memcpy(m_frame, frame, m_size);
     }
     
-    stream_output_get_stream_format_response_imp::~stream_output_get_stream_format_response_imp(){}
+    stream_output_get_stream_format_response_imp::~stream_output_get_stream_format_response_imp()
+    {
+        free(m_frame);
+    }
     
     uint64_t STDCALL stream_output_get_stream_format_response_imp::get_stream_format()
     {

--- a/controller/lib/src/stream_output_get_stream_format_response_imp.h
+++ b/controller/lib/src/stream_output_get_stream_format_response_imp.h
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * stream_output_get_stream_format_response_imp.h
+ *
+ * STREAM output stream format response implementation class
+ */
+
+#pragma once
+
+#include "stream_output_get_stream_format_response.h"
+#include "jdksavdecc_aem_command.h"
+
+namespace avdecc_lib
+{
+    class stream_output_get_stream_format_response_imp : public stream_output_get_stream_format_response
+    {
+    private:
+        uint8_t * m_frame;
+        size_t m_size;
+        ssize_t m_position;
+    public:
+        stream_output_get_stream_format_response_imp(uint8_t *frame, size_t frame_len, ssize_t pos);
+        virtual ~stream_output_get_stream_format_response_imp();
+        
+        uint64_t STDCALL get_stream_format();
+    };
+}

--- a/controller/lib/src/stream_output_get_stream_format_response_imp.h
+++ b/controller/lib/src/stream_output_get_stream_format_response_imp.h
@@ -24,7 +24,7 @@
 /**
  * stream_output_get_stream_format_response_imp.h
  *
- * STREAM output stream format response implementation class
+ * STREAM output get stream format response implementation class
  */
 
 #pragma once

--- a/controller/lib/src/stream_output_get_stream_info_response_imp.cpp
+++ b/controller/lib/src/stream_output_get_stream_info_response_imp.cpp
@@ -42,7 +42,10 @@ namespace avdecc_lib
         memcpy(m_frame, frame, m_size);
     }
     
-    stream_output_get_stream_info_response_imp::~stream_output_get_stream_info_response_imp(){}
+    stream_output_get_stream_info_response_imp::~stream_output_get_stream_info_response_imp()
+    {
+        free(m_frame);
+    }
     
     uint32_t STDCALL stream_output_get_stream_info_response_imp::get_stream_info_flags()
     {

--- a/controller/lib/src/stream_output_get_stream_info_response_imp.cpp
+++ b/controller/lib/src/stream_output_get_stream_info_response_imp.cpp
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * stream_output_get_stream_info_response_imp.cpp
+ *
+ * STREAM OUTPUT get stream info response implementation
+ */
+
+#include "enumeration.h"
+#include "log_imp.h"
+#include "stream_output_get_stream_info_response_imp.h"
+#include "util.h"
+
+namespace avdecc_lib
+{
+    stream_output_get_stream_info_response_imp::stream_output_get_stream_info_response_imp(uint8_t *frame, size_t frame_len, ssize_t pos)
+    {
+        m_position = pos;
+        m_size = frame_len;
+        m_frame = (uint8_t *)malloc(m_size * sizeof(uint8_t));
+        memcpy(m_frame, frame, m_size);
+    }
+    
+    stream_output_get_stream_info_response_imp::~stream_output_get_stream_info_response_imp(){}
+    
+    uint32_t STDCALL stream_output_get_stream_info_response_imp::get_stream_info_flags()
+    {
+        return jdksavdecc_aem_command_get_stream_info_response_get_aem_stream_info_flags(m_frame, m_position);
+    }
+    
+    uint64_t STDCALL stream_output_get_stream_info_response_imp::get_stream_info_stream_format()
+    {
+        jdksavdecc_eui64 stream_format;
+        stream_format = jdksavdecc_aem_command_get_stream_info_response_get_stream_format(m_frame, m_position);
+        return jdksavdecc_eui64_convert_to_uint64(&stream_format);
+    }
+    
+    uint64_t STDCALL stream_output_get_stream_info_response_imp::get_stream_info_stream_id()
+    {
+        jdksavdecc_eui64 stream_id;
+        stream_id = jdksavdecc_aem_command_get_stream_info_response_get_stream_id(m_frame, m_position);
+        return jdksavdecc_eui64_convert_to_uint64(&stream_id);
+    }
+    
+    uint32_t STDCALL stream_output_get_stream_info_response_imp::get_stream_info_msrp_accumulated_latency()
+    {
+        return jdksavdecc_aem_command_get_stream_info_response_get_msrp_accumulated_latency(m_frame, m_position);
+    }
+    
+    uint64_t STDCALL stream_output_get_stream_info_response_imp::get_stream_info_stream_dest_mac()
+    {
+        jdksavdecc_eui48 dest_mac;
+        dest_mac = jdksavdecc_aem_command_get_stream_info_response_get_stream_dest_mac(m_frame, m_position);
+        return jdksavdecc_eui48_convert_to_uint64(&dest_mac);
+    }
+    
+    uint8_t STDCALL stream_output_get_stream_info_response_imp::get_stream_info_msrp_failure_code()
+    {
+        return jdksavdecc_aem_command_get_stream_info_response_get_msrp_failure_code(m_frame, m_position);
+    }
+    
+    uint64_t STDCALL stream_output_get_stream_info_response_imp::get_stream_info_msrp_failure_bridge_id()
+    {
+        jdksavdecc_eui64 msrp_failure_bridge_id;
+        msrp_failure_bridge_id = jdksavdecc_aem_command_get_stream_info_response_get_msrp_failure_bridge_id(m_frame, m_position);
+        return jdksavdecc_eui64_convert_to_uint64(&msrp_failure_bridge_id);
+    }
+    
+    uint16_t STDCALL stream_output_get_stream_info_response_imp::get_stream_info_stream_vlan_id()
+    {
+        return jdksavdecc_aem_command_get_stream_info_response_get_stream_vlan_id(m_frame, m_position);
+    }
+}

--- a/controller/lib/src/stream_output_get_stream_info_response_imp.h
+++ b/controller/lib/src/stream_output_get_stream_info_response_imp.h
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * stream_output_get_stream_info_response_imp.h
+ *
+ * STREAM OUTPUT stream info response implementation class
+ */
+
+#pragma once
+
+#include "stream_output_get_stream_info_response.h"
+#include "jdksavdecc_aem_command.h"
+
+namespace avdecc_lib
+{
+    class stream_output_get_stream_info_response_imp : public stream_output_get_stream_info_response
+    {
+    private:
+        uint8_t * m_frame;
+        size_t m_size;
+        ssize_t m_position;
+    public:
+        stream_output_get_stream_info_response_imp(uint8_t *frame, size_t frame_len, ssize_t pos);
+        virtual ~stream_output_get_stream_info_response_imp();
+        
+        uint64_t STDCALL get_stream_format_stream_format();
+        uint32_t STDCALL get_stream_info_flags();
+        uint64_t STDCALL get_stream_info_stream_format();
+        uint64_t STDCALL get_stream_info_stream_id();
+        uint32_t STDCALL get_stream_info_msrp_accumulated_latency();
+        uint64_t STDCALL get_stream_info_stream_dest_mac();
+        uint8_t STDCALL get_stream_info_msrp_failure_code();
+        uint64_t STDCALL get_stream_info_msrp_failure_bridge_id();
+        uint16_t STDCALL get_stream_info_stream_vlan_id();
+    };
+}

--- a/controller/lib/src/stream_output_get_stream_info_response_imp.h
+++ b/controller/lib/src/stream_output_get_stream_info_response_imp.h
@@ -24,7 +24,7 @@
 /**
  * stream_output_get_stream_info_response_imp.h
  *
- * STREAM OUTPUT stream info response implementation class
+ * STREAM OUTPUT get stream info response implementation class
  */
 
 #pragma once

--- a/controller/lib/src/stream_output_get_tx_connection_response_imp.cpp
+++ b/controller/lib/src/stream_output_get_tx_connection_response_imp.cpp
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * stream_output_get_tx_connection_response_imp.cpp
+ *
+ * STREAM output get tx state response implementation
+ */
+
+#include "enumeration.h"
+#include "log_imp.h"
+#include "stream_output_get_tx_connection_response_imp.h"
+#include "util.h"
+
+namespace avdecc_lib
+{
+    stream_output_get_tx_connection_response_imp::stream_output_get_tx_connection_response_imp(uint8_t *frame, size_t frame_len, ssize_t pos)
+    {
+        m_position = pos;
+        m_size = frame_len;
+        m_frame = (uint8_t *)malloc(m_size * sizeof(uint8_t));
+        memcpy(m_frame, frame, m_size);
+    }
+    
+    stream_output_get_tx_connection_response_imp::~stream_output_get_tx_connection_response_imp(){}
+    
+    uint64_t STDCALL stream_output_get_tx_connection_response_imp::get_tx_connection_stream_id()
+    {
+        jdksavdecc_eui64 stream_id;
+        stream_id = jdksavdecc_common_control_header_get_stream_id(m_frame, m_position);
+        return jdksavdecc_eui64_convert_to_uint64(&stream_id);
+    }
+    
+    uint16_t STDCALL stream_output_get_tx_connection_response_imp::get_tx_connection_talker_unique_id()
+    {
+        return jdksavdecc_acmpdu_get_talker_unique_id(m_frame, m_position);
+    }
+    
+    uint16_t STDCALL stream_output_get_tx_connection_response_imp::get_tx_connection_listener_unique_id()
+    {
+        return jdksavdecc_acmpdu_get_listener_unique_id(m_frame, m_position);
+    }
+    
+    uint64_t STDCALL stream_output_get_tx_connection_response_imp::get_tx_connection_stream_dest_mac()
+    {
+        jdksavdecc_eui48 stream_dest_mac;
+        stream_dest_mac = jdksavdecc_acmpdu_get_stream_dest_mac(m_frame, m_position);
+        return jdksavdecc_eui48_convert_to_uint64(&stream_dest_mac);
+    }
+    
+    uint16_t STDCALL stream_output_get_tx_connection_response_imp::get_tx_connection_connection_count()
+    {
+        return jdksavdecc_acmpdu_get_connection_count(m_frame, m_position);
+    }
+    
+    uint16_t STDCALL stream_output_get_tx_connection_response_imp::get_tx_connection_stream_vlan_id()
+    {
+        return jdksavdecc_acmpdu_get_stream_vlan_id(m_frame, m_position);
+    }
+    
+    uint64_t STDCALL stream_output_get_tx_connection_response_imp::get_tx_connection_listener_entity_id()
+    {
+        jdksavdecc_eui64 listener_entity_id;
+        listener_entity_id = jdksavdecc_acmpdu_get_listener_entity_id(m_frame, m_position);
+        return jdksavdecc_eui64_convert_to_uint64(&listener_entity_id);
+    }
+}

--- a/controller/lib/src/stream_output_get_tx_connection_response_imp.cpp
+++ b/controller/lib/src/stream_output_get_tx_connection_response_imp.cpp
@@ -42,7 +42,10 @@ namespace avdecc_lib
         memcpy(m_frame, frame, m_size);
     }
     
-    stream_output_get_tx_connection_response_imp::~stream_output_get_tx_connection_response_imp(){}
+    stream_output_get_tx_connection_response_imp::~stream_output_get_tx_connection_response_imp()
+    {
+        free(m_frame);
+    }
     
     uint64_t STDCALL stream_output_get_tx_connection_response_imp::get_tx_connection_stream_id()
     {

--- a/controller/lib/src/stream_output_get_tx_connection_response_imp.h
+++ b/controller/lib/src/stream_output_get_tx_connection_response_imp.h
@@ -24,7 +24,7 @@
 /**
  * stream_output_get_tx_connection_response_imp.h
  *
- * STREAM OUTPUT tx connection response implementation class
+ * STREAM OUTPUT get tx connection response implementation class
  */
 
 #pragma once

--- a/controller/lib/src/stream_output_get_tx_connection_response_imp.h
+++ b/controller/lib/src/stream_output_get_tx_connection_response_imp.h
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * stream_output_get_tx_connection_response_imp.h
+ *
+ * STREAM OUTPUT tx connection response implementation class
+ */
+
+#pragma once
+
+#include "stream_output_get_tx_connection_response.h"
+#include "jdksavdecc_acmp.h"
+
+namespace avdecc_lib
+{
+    class stream_output_get_tx_connection_response_imp : public stream_output_get_tx_connection_response
+    {
+    private:
+        uint8_t * m_frame;
+        size_t m_size;
+        ssize_t m_position;
+    public:
+        stream_output_get_tx_connection_response_imp(uint8_t *frame, size_t frame_len, ssize_t pos);
+        virtual ~stream_output_get_tx_connection_response_imp();
+        
+        uint64_t STDCALL get_tx_connection_stream_id();
+        uint16_t STDCALL get_tx_connection_talker_unique_id();
+        uint16_t STDCALL get_tx_connection_listener_unique_id();
+        uint64_t STDCALL get_tx_connection_stream_dest_mac();
+        uint16_t STDCALL get_tx_connection_connection_count();
+        uint16_t STDCALL get_tx_connection_stream_vlan_id();
+        uint64_t STDCALL get_tx_connection_listener_entity_id();
+    };
+}

--- a/controller/lib/src/stream_output_get_tx_state_response_imp.cpp
+++ b/controller/lib/src/stream_output_get_tx_state_response_imp.cpp
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * stream_output_get_tx_state_response_imp.cpp
+ *
+ * STREAM output get tx state response implementation
+ */
+
+#include "enumeration.h"
+#include "log_imp.h"
+#include "stream_output_get_tx_state_response_imp.h"
+#include "util.h"
+
+namespace avdecc_lib
+{
+    stream_output_get_tx_state_response_imp::stream_output_get_tx_state_response_imp(uint8_t *frame, size_t frame_len, ssize_t pos)
+    {
+        m_position = pos;
+        m_size = frame_len;
+        m_frame = (uint8_t *)malloc(m_size * sizeof(uint8_t));
+        memcpy(m_frame, frame, m_size);
+    }
+    
+    stream_output_get_tx_state_response_imp::~stream_output_get_tx_state_response_imp(){}
+    
+    uint64_t STDCALL stream_output_get_tx_state_response_imp::get_tx_state_stream_id()
+    {
+        jdksavdecc_eui64 stream_id;
+        stream_id = jdksavdecc_common_control_header_get_stream_id(m_frame, m_position);
+        return jdksavdecc_eui64_convert_to_uint64(&stream_id);
+    }
+    
+    uint64_t STDCALL stream_output_get_tx_state_response_imp::get_tx_state_stream_dest_mac()
+    {
+        jdksavdecc_eui48 stream_dest_mac;
+        stream_dest_mac = jdksavdecc_acmpdu_get_stream_dest_mac(m_frame, m_position);
+        
+        return jdksavdecc_eui48_convert_to_uint64(&stream_dest_mac);
+    }
+    
+    uint16_t STDCALL stream_output_get_tx_state_response_imp::get_tx_state_connection_count()
+    {
+        return jdksavdecc_acmpdu_get_connection_count(m_frame, m_position);
+    }
+    
+    uint16_t STDCALL stream_output_get_tx_state_response_imp::get_tx_state_stream_vlan_id()
+    {
+        return jdksavdecc_acmpdu_get_stream_vlan_id(m_frame, m_position);
+    }
+}

--- a/controller/lib/src/stream_output_get_tx_state_response_imp.cpp
+++ b/controller/lib/src/stream_output_get_tx_state_response_imp.cpp
@@ -42,7 +42,10 @@ namespace avdecc_lib
         memcpy(m_frame, frame, m_size);
     }
     
-    stream_output_get_tx_state_response_imp::~stream_output_get_tx_state_response_imp(){}
+    stream_output_get_tx_state_response_imp::~stream_output_get_tx_state_response_imp()
+    {
+        free(m_frame);
+    }
     
     uint64_t STDCALL stream_output_get_tx_state_response_imp::get_tx_state_stream_id()
     {

--- a/controller/lib/src/stream_output_get_tx_state_response_imp.h
+++ b/controller/lib/src/stream_output_get_tx_state_response_imp.h
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * stream_output_get_tx_state_response_imp.h
+ *
+ * STREAM OUTPUT tx state response implementation class
+ */
+
+#pragma once
+
+#include "stream_output_get_tx_state_response.h"
+#include "jdksavdecc_acmp.h"
+
+namespace avdecc_lib
+{
+    class stream_output_get_tx_state_response_imp : public stream_output_get_tx_state_response
+    {
+    private:
+        uint8_t * m_frame;
+        size_t m_size;
+        ssize_t m_position;
+    public:
+        stream_output_get_tx_state_response_imp(uint8_t *frame, size_t frame_len, ssize_t pos);
+        virtual ~stream_output_get_tx_state_response_imp();
+        
+        uint64_t STDCALL get_tx_state_stream_id();
+        uint64_t STDCALL get_tx_state_stream_dest_mac();
+        uint16_t STDCALL get_tx_state_connection_count();
+        uint16_t STDCALL get_tx_state_stream_vlan_id();
+    };
+}

--- a/controller/lib/src/stream_output_get_tx_state_response_imp.h
+++ b/controller/lib/src/stream_output_get_tx_state_response_imp.h
@@ -24,7 +24,7 @@
 /**
  * stream_output_get_tx_state_response_imp.h
  *
- * STREAM OUTPUT tx state response implementation class
+ * STREAM OUTPUT get tx state response implementation class
  */
 
 #pragma once

--- a/controller/lib/src/stream_port_input_descriptor_imp.cpp
+++ b/controller/lib/src/stream_port_input_descriptor_imp.cpp
@@ -42,18 +42,7 @@ namespace avdecc_lib
     stream_port_input_descriptor_response * STDCALL stream_port_input_descriptor_imp::get_stream_port_input_response()
     {
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
-        return resp = new stream_port_input_descriptor_response_imp(resp_ref->get_buffer(),
-                                                             resp_ref->get_size(), resp_ref->get_pos());
-    }
-
-    uint16_t STDCALL stream_port_input_descriptor_imp::descriptor_type() const
-    {
-        assert(jdksavdecc_descriptor_stream_port_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos()) == JDKSAVDECC_DESCRIPTOR_STREAM_PORT_INPUT);
-        return jdksavdecc_descriptor_stream_port_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
-    }
-
-    uint16_t STDCALL stream_port_input_descriptor_imp::descriptor_index() const
-    {
-        return jdksavdecc_descriptor_stream_port_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
+        return resp = new stream_port_input_descriptor_response_imp(resp_ref->get_desc_buffer(),
+                                                                    resp_ref->get_desc_size(), resp_ref->get_desc_pos());
     }
 }

--- a/controller/lib/src/stream_port_input_descriptor_imp.cpp
+++ b/controller/lib/src/stream_port_input_descriptor_imp.cpp
@@ -27,6 +27,8 @@
  * Stream Port Input descriptor implementation
  */
 
+#include <mutex>
+
 #include "avdecc_error.h"
 #include "enumeration.h"
 #include "log_imp.h"

--- a/controller/lib/src/stream_port_input_descriptor_imp.cpp
+++ b/controller/lib/src/stream_port_input_descriptor_imp.cpp
@@ -35,67 +35,30 @@
 
 namespace avdecc_lib
 {
-    stream_port_input_descriptor_imp::stream_port_input_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj)
+    stream_port_input_descriptor_imp::stream_port_input_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos)
     {
-        ssize_t ret = jdksavdecc_descriptor_stream_port_read(&stream_port_input_desc, frame, pos, frame_len);
-
-        if (ret < 0)
-        {
-            throw avdecc_read_descriptor_error("stream_port_input_desc_read error");
-        }
+        m_type = jdksavdecc_descriptor_stream_port_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
+        m_index = jdksavdecc_descriptor_stream_port_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 
     stream_port_input_descriptor_imp::~stream_port_input_descriptor_imp() {}
+    
+    
+    stream_port_input_descriptor_response * STDCALL stream_port_input_descriptor_imp::get_stream_port_input_response()
+    {
+        std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
+        return resp = new stream_port_input_descriptor_response_imp(resp_ref->get_buffer(),
+                                                             resp_ref->get_size(), resp_ref->get_pos());
+    }
 
     uint16_t STDCALL stream_port_input_descriptor_imp::descriptor_type() const
     {
-        assert(stream_port_input_desc.descriptor_type == JDKSAVDECC_DESCRIPTOR_STREAM_PORT_INPUT);
-        return stream_port_input_desc.descriptor_type;
+        assert(m_type == JDKSAVDECC_DESCRIPTOR_STREAM_PORT_INPUT);
+        return m_type;
     }
 
     uint16_t STDCALL stream_port_input_descriptor_imp::descriptor_index() const
     {
-        //assert(stream_port_input_desc.descriptor_index == 0);
-        return stream_port_input_desc.descriptor_index;
-    }
-
-    uint16_t STDCALL stream_port_input_descriptor_imp::clock_domain_index()
-    {
-        return stream_port_input_desc.clock_domain_index;
-    }
-
-    uint16_t STDCALL stream_port_input_descriptor_imp::port_flags()
-    {
-        return stream_port_input_desc.port_flags;
-    }
-
-    uint16_t STDCALL stream_port_input_descriptor_imp::number_of_controls()
-    {
-        return stream_port_input_desc.number_of_controls;
-    }
-
-    uint16_t STDCALL stream_port_input_descriptor_imp::base_control()
-    {
-        return stream_port_input_desc.base_control;
-    }
-
-    uint16_t STDCALL stream_port_input_descriptor_imp::number_of_clusters()
-    {
-        return stream_port_input_desc.number_of_clusters;
-    }
-
-    uint16_t STDCALL stream_port_input_descriptor_imp::base_cluster()
-    {
-        return stream_port_input_desc.base_cluster;
-    }
-
-    uint16_t STDCALL stream_port_input_descriptor_imp::number_of_maps()
-    {
-        return stream_port_input_desc.number_of_maps;
-    }
-
-    uint16_t STDCALL stream_port_input_descriptor_imp::base_map()
-    {
-        return stream_port_input_desc.base_map;
+        return m_index;
     }
 }

--- a/controller/lib/src/stream_port_input_descriptor_imp.cpp
+++ b/controller/lib/src/stream_port_input_descriptor_imp.cpp
@@ -35,15 +35,10 @@
 
 namespace avdecc_lib
 {
-    stream_port_input_descriptor_imp::stream_port_input_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos)
-    {
-        m_type = jdksavdecc_descriptor_stream_port_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
-        m_index = jdksavdecc_descriptor_stream_port_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
-    }
+    stream_port_input_descriptor_imp::stream_port_input_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos) {}
 
     stream_port_input_descriptor_imp::~stream_port_input_descriptor_imp() {}
-    
-    
+
     stream_port_input_descriptor_response * STDCALL stream_port_input_descriptor_imp::get_stream_port_input_response()
     {
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
@@ -53,12 +48,12 @@ namespace avdecc_lib
 
     uint16_t STDCALL stream_port_input_descriptor_imp::descriptor_type() const
     {
-        assert(m_type == JDKSAVDECC_DESCRIPTOR_STREAM_PORT_INPUT);
-        return m_type;
+        assert(jdksavdecc_descriptor_stream_port_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos()) == JDKSAVDECC_DESCRIPTOR_STREAM_PORT_INPUT);
+        return jdksavdecc_descriptor_stream_port_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 
     uint16_t STDCALL stream_port_input_descriptor_imp::descriptor_index() const
     {
-        return m_index;
+        return jdksavdecc_descriptor_stream_port_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 }

--- a/controller/lib/src/stream_port_input_descriptor_imp.h
+++ b/controller/lib/src/stream_port_input_descriptor_imp.h
@@ -31,29 +31,24 @@
 
 #include "descriptor_base_imp.h"
 #include "stream_port_input_descriptor.h"
+#include "stream_port_input_descriptor_response_imp.h"
 
 namespace avdecc_lib
 {
     class stream_port_input_descriptor_imp : public stream_port_input_descriptor, public virtual descriptor_base_imp
     {
     private:
-        struct jdksavdecc_descriptor_stream_port stream_port_input_desc; // Structure containing the stream_port_input_desc fields
-
+        uint16_t m_type;
+        uint16_t m_index;
     public:
         stream_port_input_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
 		virtual ~stream_port_input_descriptor_imp();
+        
+        stream_port_input_descriptor_response_imp *resp;
 
+        stream_port_input_descriptor_response * STDCALL get_stream_port_input_response();
         uint16_t STDCALL descriptor_type() const;
         uint16_t STDCALL descriptor_index() const;
-        uint16_t STDCALL clock_domain_index();
-
-		uint16_t STDCALL port_flags();
-        uint16_t STDCALL number_of_controls();
-        uint16_t STDCALL base_control();
-        uint16_t STDCALL number_of_clusters();
-        uint16_t STDCALL base_cluster();
-        uint16_t STDCALL number_of_maps();
-        uint16_t STDCALL base_map();
     };
 }
 

--- a/controller/lib/src/stream_port_input_descriptor_imp.h
+++ b/controller/lib/src/stream_port_input_descriptor_imp.h
@@ -44,8 +44,6 @@ namespace avdecc_lib
         stream_port_input_descriptor_response_imp *resp;
 
         stream_port_input_descriptor_response * STDCALL get_stream_port_input_response();
-        uint16_t STDCALL descriptor_type() const;
-        uint16_t STDCALL descriptor_index() const;
     };
 }
 

--- a/controller/lib/src/stream_port_input_descriptor_imp.h
+++ b/controller/lib/src/stream_port_input_descriptor_imp.h
@@ -37,9 +37,6 @@ namespace avdecc_lib
 {
     class stream_port_input_descriptor_imp : public stream_port_input_descriptor, public virtual descriptor_base_imp
     {
-    private:
-        uint16_t m_type;
-        uint16_t m_index;
     public:
         stream_port_input_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
 		virtual ~stream_port_input_descriptor_imp();

--- a/controller/lib/src/stream_port_input_descriptor_response_imp.cpp
+++ b/controller/lib/src/stream_port_input_descriptor_response_imp.cpp
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * stream_port_input_descriptor_response_imp.cpp
+ *
+ * Stream Port Input descriptor response implementation
+ */
+
+#include "avdecc_error.h"
+#include "enumeration.h"
+#include "log_imp.h"
+#include "end_station_imp.h"
+#include "stream_port_input_descriptor_response_imp.h"
+
+namespace avdecc_lib
+{
+    stream_port_input_descriptor_response_imp::stream_port_input_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos) : descriptor_base_imp(nullptr, frame, frame_len, pos)
+    {
+        frame_size = frame_len;
+        buffer = (uint8_t *)malloc(frame_size * sizeof(uint8_t));
+        memcpy(buffer, frame, frame_size);
+        position = pos;
+    }
+    
+    stream_port_input_descriptor_response_imp::~stream_port_input_descriptor_response_imp() {}
+    
+    uint16_t STDCALL stream_port_input_descriptor_response_imp::clock_domain_index()
+    {
+        return jdksavdecc_descriptor_stream_port_get_clock_domain_index(buffer, position);
+    }
+    
+    uint16_t STDCALL stream_port_input_descriptor_response_imp::port_flags()
+    {
+        return jdksavdecc_descriptor_stream_port_get_port_flags(buffer, position);
+    }
+    
+    uint16_t STDCALL stream_port_input_descriptor_response_imp::number_of_controls()
+    {
+        return jdksavdecc_descriptor_stream_port_get_number_of_controls(buffer, position);
+    }
+    
+    uint16_t STDCALL stream_port_input_descriptor_response_imp::base_control()
+    {
+        return jdksavdecc_descriptor_stream_port_get_base_control(buffer, position);
+    }
+    
+    uint16_t STDCALL stream_port_input_descriptor_response_imp::number_of_clusters()
+    {
+        return jdksavdecc_descriptor_stream_port_get_number_of_clusters(buffer, position);
+    }
+    
+    uint16_t STDCALL stream_port_input_descriptor_response_imp::base_cluster()
+    {
+        return jdksavdecc_descriptor_stream_port_get_base_cluster(buffer, position);
+    }
+    
+    uint16_t STDCALL stream_port_input_descriptor_response_imp::number_of_maps()
+    {
+        return jdksavdecc_descriptor_stream_port_get_number_of_maps(buffer, position);
+    }
+    
+    uint16_t STDCALL stream_port_input_descriptor_response_imp::base_map()
+    {
+        return jdksavdecc_descriptor_stream_port_get_base_map(buffer, position);
+    }
+}

--- a/controller/lib/src/stream_port_input_descriptor_response_imp.cpp
+++ b/controller/lib/src/stream_port_input_descriptor_response_imp.cpp
@@ -35,7 +35,7 @@
 
 namespace avdecc_lib
 {
-    stream_port_input_descriptor_response_imp::stream_port_input_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos) : descriptor_base_imp(nullptr, frame, frame_len, pos)
+    stream_port_input_descriptor_response_imp::stream_port_input_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos)
     {
         frame_size = frame_len;
         buffer = (uint8_t *)malloc(frame_size * sizeof(uint8_t));
@@ -43,7 +43,10 @@ namespace avdecc_lib
         position = pos;
     }
     
-    stream_port_input_descriptor_response_imp::~stream_port_input_descriptor_response_imp() {}
+    stream_port_input_descriptor_response_imp::~stream_port_input_descriptor_response_imp()
+    {
+        free(buffer);
+    }
     
     uint16_t STDCALL stream_port_input_descriptor_response_imp::clock_domain_index()
     {

--- a/controller/lib/src/stream_port_input_descriptor_response_imp.h
+++ b/controller/lib/src/stream_port_input_descriptor_response_imp.h
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * stream_port_input_descriptor_response_imp.h
+ *
+ * Stream Port Input descriptor response implementation class
+ */
+
+#pragma once
+
+#include "descriptor_base_imp.h"
+#include "stream_port_input_descriptor_response.h"
+
+namespace avdecc_lib
+{
+    class stream_port_input_descriptor_response_imp : public stream_port_input_descriptor_response, public virtual descriptor_base_imp
+    {
+    private:
+        uint8_t* buffer;
+        ssize_t position;
+        size_t frame_size;
+    public:
+        stream_port_input_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos);
+        virtual ~stream_port_input_descriptor_response_imp();
+        
+        uint16_t STDCALL clock_domain_index();
+        uint16_t STDCALL port_flags();
+        uint16_t STDCALL number_of_controls();
+        uint16_t STDCALL base_control();
+        uint16_t STDCALL number_of_clusters();
+        uint16_t STDCALL base_cluster();
+        uint16_t STDCALL number_of_maps();
+        uint16_t STDCALL base_map();
+    };
+}

--- a/controller/lib/src/stream_port_input_descriptor_response_imp.h
+++ b/controller/lib/src/stream_port_input_descriptor_response_imp.h
@@ -29,12 +29,12 @@
 
 #pragma once
 
-#include "descriptor_base_imp.h"
 #include "stream_port_input_descriptor_response.h"
+#include "jdksavdecc_aem_descriptor.h"
 
 namespace avdecc_lib
 {
-    class stream_port_input_descriptor_response_imp : public stream_port_input_descriptor_response, public virtual descriptor_base_imp
+    class stream_port_input_descriptor_response_imp : public stream_port_input_descriptor_response
     {
     private:
         uint8_t* buffer;

--- a/controller/lib/src/stream_port_output_descriptor_imp.cpp
+++ b/controller/lib/src/stream_port_output_descriptor_imp.cpp
@@ -35,30 +35,25 @@
 
 namespace avdecc_lib
 {
-    stream_port_output_descriptor_imp::stream_port_output_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos)
-    {
-        m_type = jdksavdecc_descriptor_stream_port_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
-        m_index = jdksavdecc_descriptor_stream_port_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
-    }
-    
+    stream_port_output_descriptor_imp::stream_port_output_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos) {}
+
     stream_port_output_descriptor_imp::~stream_port_output_descriptor_imp() {}
-    
-    
+
     stream_port_output_descriptor_response * STDCALL stream_port_output_descriptor_imp::get_stream_port_output_response()
     {
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
         return resp = new stream_port_output_descriptor_response_imp(resp_ref->get_buffer(),
-                                                                    resp_ref->get_size(), resp_ref->get_pos());
+                                                                     resp_ref->get_size(), resp_ref->get_pos());
     }
-    
+
     uint16_t STDCALL stream_port_output_descriptor_imp::descriptor_type() const
     {
-        assert(m_type == JDKSAVDECC_DESCRIPTOR_STREAM_PORT_OUTPUT);
-        return m_type;
+        assert(jdksavdecc_descriptor_stream_port_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos()) == JDKSAVDECC_DESCRIPTOR_STREAM_PORT_OUTPUT);
+        return jdksavdecc_descriptor_stream_port_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
     }
-    
+
     uint16_t STDCALL stream_port_output_descriptor_imp::descriptor_index() const
     {
-        return m_index;
+        return jdksavdecc_descriptor_stream_port_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 }

--- a/controller/lib/src/stream_port_output_descriptor_imp.cpp
+++ b/controller/lib/src/stream_port_output_descriptor_imp.cpp
@@ -42,18 +42,7 @@ namespace avdecc_lib
     stream_port_output_descriptor_response * STDCALL stream_port_output_descriptor_imp::get_stream_port_output_response()
     {
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
-        return resp = new stream_port_output_descriptor_response_imp(resp_ref->get_buffer(),
-                                                                     resp_ref->get_size(), resp_ref->get_pos());
-    }
-
-    uint16_t STDCALL stream_port_output_descriptor_imp::descriptor_type() const
-    {
-        assert(jdksavdecc_descriptor_stream_port_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos()) == JDKSAVDECC_DESCRIPTOR_STREAM_PORT_OUTPUT);
-        return jdksavdecc_descriptor_stream_port_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
-    }
-
-    uint16_t STDCALL stream_port_output_descriptor_imp::descriptor_index() const
-    {
-        return jdksavdecc_descriptor_stream_port_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
+        return resp = new stream_port_output_descriptor_response_imp(resp_ref->get_desc_buffer(),
+                                                                     resp_ref->get_desc_size(), resp_ref->get_desc_pos());
     }
 }

--- a/controller/lib/src/stream_port_output_descriptor_imp.cpp
+++ b/controller/lib/src/stream_port_output_descriptor_imp.cpp
@@ -35,66 +35,30 @@
 
 namespace avdecc_lib
 {
-    stream_port_output_descriptor_imp::stream_port_output_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj)
+    stream_port_output_descriptor_imp::stream_port_output_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos)
     {
-        ssize_t ret = jdksavdecc_descriptor_stream_port_read(&stream_port_output_desc, frame, pos, frame_len);
-
-        if (ret < 0)
-        {
-            throw avdecc_read_descriptor_error("stream_port_output_desc_read error");
-        }
+        m_type = jdksavdecc_descriptor_stream_port_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
+        m_index = jdksavdecc_descriptor_stream_port_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
     }
-
+    
     stream_port_output_descriptor_imp::~stream_port_output_descriptor_imp() {}
-
+    
+    
+    stream_port_output_descriptor_response * STDCALL stream_port_output_descriptor_imp::get_stream_port_output_response()
+    {
+        std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
+        return resp = new stream_port_output_descriptor_response_imp(resp_ref->get_buffer(),
+                                                                    resp_ref->get_size(), resp_ref->get_pos());
+    }
+    
     uint16_t STDCALL stream_port_output_descriptor_imp::descriptor_type() const
     {
-        assert(stream_port_output_desc.descriptor_type == JDKSAVDECC_DESCRIPTOR_STREAM_PORT_OUTPUT);
-        return stream_port_output_desc.descriptor_type;
+        assert(m_type == JDKSAVDECC_DESCRIPTOR_STREAM_PORT_OUTPUT);
+        return m_type;
     }
-
+    
     uint16_t STDCALL stream_port_output_descriptor_imp::descriptor_index() const
     {
-        return stream_port_output_desc.descriptor_index;
-    }
-
-    uint16_t STDCALL stream_port_output_descriptor_imp::clock_domain_index()
-    {
-        return stream_port_output_desc.clock_domain_index;
-    }
-
-    uint16_t STDCALL stream_port_output_descriptor_imp::port_flags()
-    {
-        return stream_port_output_desc.port_flags;
-    }
-
-    uint16_t STDCALL stream_port_output_descriptor_imp::number_of_controls()
-    {
-        return stream_port_output_desc.number_of_controls;
-    }
-
-    uint16_t STDCALL stream_port_output_descriptor_imp::base_control()
-    {
-        return stream_port_output_desc.base_control;
-    }
-
-    uint16_t STDCALL stream_port_output_descriptor_imp::number_of_clusters()
-    {
-        return stream_port_output_desc.number_of_clusters;
-    }
-
-    uint16_t STDCALL stream_port_output_descriptor_imp::base_cluster()
-    {
-        return stream_port_output_desc.base_cluster;
-    }
-
-    uint16_t STDCALL stream_port_output_descriptor_imp::number_of_maps()
-    {
-        return stream_port_output_desc.number_of_maps;
-    }
-
-    uint16_t STDCALL stream_port_output_descriptor_imp::base_map()
-    {
-        return stream_port_output_desc.base_map;
+        return m_index;
     }
 }

--- a/controller/lib/src/stream_port_output_descriptor_imp.h
+++ b/controller/lib/src/stream_port_output_descriptor_imp.h
@@ -44,8 +44,6 @@ namespace avdecc_lib
         stream_port_output_descriptor_response_imp *resp;
         
         stream_port_output_descriptor_response * STDCALL get_stream_port_output_response();
-        uint16_t STDCALL descriptor_type() const;
-        uint16_t STDCALL descriptor_index() const;
     };
 }
 

--- a/controller/lib/src/stream_port_output_descriptor_imp.h
+++ b/controller/lib/src/stream_port_output_descriptor_imp.h
@@ -31,29 +31,24 @@
 
 #include "descriptor_base_imp.h"
 #include "stream_port_output_descriptor.h"
+#include "stream_port_output_descriptor_response_imp.h"
 
 namespace avdecc_lib
 {
     class stream_port_output_descriptor_imp : public stream_port_output_descriptor, public virtual descriptor_base_imp
     {
     private:
-        struct jdksavdecc_descriptor_stream_port stream_port_output_desc; // Structure containing the stream_port_output_desc fields
-
+        uint16_t m_type;
+        uint16_t m_index;
     public:
         stream_port_output_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
         virtual ~stream_port_output_descriptor_imp();
-
+        
+        stream_port_output_descriptor_response_imp *resp;
+        
+        stream_port_output_descriptor_response * STDCALL get_stream_port_output_response();
         uint16_t STDCALL descriptor_type() const;
         uint16_t STDCALL descriptor_index() const;
-        uint16_t STDCALL clock_domain_index();
-
-		uint16_t STDCALL port_flags();
-        uint16_t STDCALL number_of_controls();
-        uint16_t STDCALL base_control();
-        uint16_t STDCALL number_of_clusters();
-        uint16_t STDCALL base_cluster();
-        uint16_t STDCALL number_of_maps();
-        uint16_t STDCALL base_map();
     };
 }
 

--- a/controller/lib/src/stream_port_output_descriptor_imp.h
+++ b/controller/lib/src/stream_port_output_descriptor_imp.h
@@ -37,9 +37,6 @@ namespace avdecc_lib
 {
     class stream_port_output_descriptor_imp : public stream_port_output_descriptor, public virtual descriptor_base_imp
     {
-    private:
-        uint16_t m_type;
-        uint16_t m_index;
     public:
         stream_port_output_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
         virtual ~stream_port_output_descriptor_imp();

--- a/controller/lib/src/stream_port_output_descriptor_response_imp.cpp
+++ b/controller/lib/src/stream_port_output_descriptor_response_imp.cpp
@@ -35,7 +35,7 @@
 
 namespace avdecc_lib
 {
-    stream_port_output_descriptor_response_imp::stream_port_output_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos) : descriptor_base_imp(nullptr, frame, frame_len, pos)
+    stream_port_output_descriptor_response_imp::stream_port_output_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos)
     {
         frame_size = frame_len;
         buffer = (uint8_t *)malloc(frame_size * sizeof(uint8_t));
@@ -43,7 +43,10 @@ namespace avdecc_lib
         position = pos;
     }
     
-    stream_port_output_descriptor_response_imp::~stream_port_output_descriptor_response_imp() {}
+    stream_port_output_descriptor_response_imp::~stream_port_output_descriptor_response_imp()
+    {
+        free(buffer);
+    }
     
     uint16_t STDCALL stream_port_output_descriptor_response_imp::clock_domain_index()
     {

--- a/controller/lib/src/stream_port_output_descriptor_response_imp.cpp
+++ b/controller/lib/src/stream_port_output_descriptor_response_imp.cpp
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * stream_port_output_descriptor_response_imp.cpp
+ *
+ * Stream Port Output descriptor response implementation
+ */
+
+#include "avdecc_error.h"
+#include "enumeration.h"
+#include "log_imp.h"
+#include "end_station_imp.h"
+#include "stream_port_output_descriptor_response_imp.h"
+
+namespace avdecc_lib
+{
+    stream_port_output_descriptor_response_imp::stream_port_output_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos) : descriptor_base_imp(nullptr, frame, frame_len, pos)
+    {
+        frame_size = frame_len;
+        buffer = (uint8_t *)malloc(frame_size * sizeof(uint8_t));
+        memcpy(buffer, frame, frame_size);
+        position = pos;
+    }
+    
+    stream_port_output_descriptor_response_imp::~stream_port_output_descriptor_response_imp() {}
+    
+    uint16_t STDCALL stream_port_output_descriptor_response_imp::clock_domain_index()
+    {
+        return jdksavdecc_descriptor_stream_port_get_clock_domain_index(buffer, position);
+    }
+    
+    uint16_t STDCALL stream_port_output_descriptor_response_imp::port_flags()
+    {
+        return jdksavdecc_descriptor_stream_port_get_port_flags(buffer, position);
+    }
+    
+    uint16_t STDCALL stream_port_output_descriptor_response_imp::number_of_controls()
+    {
+        return jdksavdecc_descriptor_stream_port_get_number_of_controls(buffer, position);
+    }
+    
+    uint16_t STDCALL stream_port_output_descriptor_response_imp::base_control()
+    {
+        return jdksavdecc_descriptor_stream_port_get_base_control(buffer, position);
+    }
+    
+    uint16_t STDCALL stream_port_output_descriptor_response_imp::number_of_clusters()
+    {
+        return jdksavdecc_descriptor_stream_port_get_number_of_clusters(buffer, position);
+    }
+    
+    uint16_t STDCALL stream_port_output_descriptor_response_imp::base_cluster()
+    {
+        return jdksavdecc_descriptor_stream_port_get_base_cluster(buffer, position);
+    }
+    
+    uint16_t STDCALL stream_port_output_descriptor_response_imp::number_of_maps()
+    {
+        return jdksavdecc_descriptor_stream_port_get_number_of_maps(buffer, position);
+    }
+    
+    uint16_t STDCALL stream_port_output_descriptor_response_imp::base_map()
+    {
+        return jdksavdecc_descriptor_stream_port_get_base_map(buffer, position);
+    }
+}

--- a/controller/lib/src/stream_port_output_descriptor_response_imp.h
+++ b/controller/lib/src/stream_port_output_descriptor_response_imp.h
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * stream_port_output_descriptor_response_imp.h
+ *
+ * Stream Port Output descriptor response implementation class
+ */
+
+#pragma once
+
+#include "descriptor_base_imp.h"
+#include "stream_port_output_descriptor_response.h"
+
+namespace avdecc_lib
+{
+    class stream_port_output_descriptor_response_imp : public stream_port_output_descriptor_response, public virtual descriptor_base_imp
+    {
+    private:
+        uint8_t* buffer;
+        ssize_t position;
+        size_t frame_size;
+    public:
+        stream_port_output_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos);
+        virtual ~stream_port_output_descriptor_response_imp();
+        
+        uint16_t STDCALL clock_domain_index();
+        uint16_t STDCALL port_flags();
+        uint16_t STDCALL number_of_controls();
+        uint16_t STDCALL base_control();
+        uint16_t STDCALL number_of_clusters();
+        uint16_t STDCALL base_cluster();
+        uint16_t STDCALL number_of_maps();
+        uint16_t STDCALL base_map();
+    };
+}

--- a/controller/lib/src/stream_port_output_descriptor_response_imp.h
+++ b/controller/lib/src/stream_port_output_descriptor_response_imp.h
@@ -29,12 +29,12 @@
 
 #pragma once
 
-#include "descriptor_base_imp.h"
 #include "stream_port_output_descriptor_response.h"
+#include "jdksavdecc_aem_descriptor.h"
 
 namespace avdecc_lib
 {
-    class stream_port_output_descriptor_response_imp : public stream_port_output_descriptor_response, public virtual descriptor_base_imp
+    class stream_port_output_descriptor_response_imp : public stream_port_output_descriptor_response
     {
     private:
         uint8_t* buffer;

--- a/controller/lib/src/strings_descriptor_imp.cpp
+++ b/controller/lib/src/strings_descriptor_imp.cpp
@@ -35,66 +35,29 @@
 
 namespace avdecc_lib
 {
-    strings_descriptor_imp::strings_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj)
+    strings_descriptor_imp::strings_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos)
     {
-        ssize_t ret = jdksavdecc_descriptor_strings_read(&strings_desc, frame, pos, frame_len);
-
-        if (ret < 0)
-        {
-            throw avdecc_read_descriptor_error("strings_desc_read error");
-        }
+        m_type = jdksavdecc_descriptor_strings_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
+        m_index = jdksavdecc_descriptor_strings_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 
     strings_descriptor_imp::~strings_descriptor_imp() {}
+    
+    strings_descriptor_response * STDCALL strings_descriptor_imp::get_strings_response()
+    {
+        std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
+        return resp = new strings_descriptor_response_imp(resp_ref->get_buffer(),
+                                                                    resp_ref->get_size(), resp_ref->get_pos());
+    }
 
     uint16_t STDCALL strings_descriptor_imp::descriptor_type() const
     {
-        assert(strings_desc.descriptor_type == JDKSAVDECC_DESCRIPTOR_STRINGS);
-        return strings_desc.descriptor_type;
+        assert(m_type == JDKSAVDECC_DESCRIPTOR_STRINGS);
+        return m_type;
     }
 
     uint16_t STDCALL strings_descriptor_imp::descriptor_index() const
     {
-        return strings_desc.descriptor_index;
-    }
-
-    uint8_t * STDCALL strings_descriptor_imp::get_string_by_index(size_t string_index)
-    {
-        switch(string_index)
-        {
-            case 0:
-                return strings_desc.string_0.value;
-                break;
-
-            case 1:
-                return strings_desc.string_1.value;
-                break;
-
-            case 2:
-                return strings_desc.string_2.value;
-                break;
-
-            case 3:
-                return strings_desc.string_3.value;
-                break;
-
-            case 4:
-                return strings_desc.string_4.value;
-                break;
-
-            case 5:
-                return strings_desc.string_5.value;
-                break;
-
-            case 6:
-                return strings_desc.string_6.value;
-                break;
-
-            default:
-                log_imp_ref->post_log_msg(LOGGING_LEVEL_ERROR, "get_string_by_index error");
-                break;
-        }
-
-        return 0;
+        return m_index;
     }
 }

--- a/controller/lib/src/strings_descriptor_imp.cpp
+++ b/controller/lib/src/strings_descriptor_imp.cpp
@@ -27,6 +27,8 @@
  * Strings descriptor implementation
  */
 
+#include <mutex>
+
 #include "avdecc_error.h"
 #include "enumeration.h"
 #include "log_imp.h"

--- a/controller/lib/src/strings_descriptor_imp.cpp
+++ b/controller/lib/src/strings_descriptor_imp.cpp
@@ -42,18 +42,7 @@ namespace avdecc_lib
     strings_descriptor_response * STDCALL strings_descriptor_imp::get_strings_response()
     {
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
-        return resp = new strings_descriptor_response_imp(resp_ref->get_buffer(),
-                                                                    resp_ref->get_size(), resp_ref->get_pos());
-    }
-
-    uint16_t STDCALL strings_descriptor_imp::descriptor_type() const
-    {
-        assert(jdksavdecc_descriptor_strings_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos()) == JDKSAVDECC_DESCRIPTOR_STRINGS);
-        return jdksavdecc_descriptor_strings_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
-    }
-
-    uint16_t STDCALL strings_descriptor_imp::descriptor_index() const
-    {
-        return jdksavdecc_descriptor_strings_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
+        return resp = new strings_descriptor_response_imp(resp_ref->get_desc_buffer(),
+                                                          resp_ref->get_desc_size(), resp_ref->get_desc_pos());
     }
 }

--- a/controller/lib/src/strings_descriptor_imp.cpp
+++ b/controller/lib/src/strings_descriptor_imp.cpp
@@ -35,14 +35,10 @@
 
 namespace avdecc_lib
 {
-    strings_descriptor_imp::strings_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos)
-    {
-        m_type = jdksavdecc_descriptor_strings_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
-        m_index = jdksavdecc_descriptor_strings_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
-    }
+    strings_descriptor_imp::strings_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len) : descriptor_base_imp(end_station_obj, frame, frame_len, pos) {}
 
     strings_descriptor_imp::~strings_descriptor_imp() {}
-    
+
     strings_descriptor_response * STDCALL strings_descriptor_imp::get_strings_response()
     {
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
@@ -52,12 +48,12 @@ namespace avdecc_lib
 
     uint16_t STDCALL strings_descriptor_imp::descriptor_type() const
     {
-        assert(m_type == JDKSAVDECC_DESCRIPTOR_STRINGS);
-        return m_type;
+        assert(jdksavdecc_descriptor_strings_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos()) == JDKSAVDECC_DESCRIPTOR_STRINGS);
+        return jdksavdecc_descriptor_strings_get_descriptor_type(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 
     uint16_t STDCALL strings_descriptor_imp::descriptor_index() const
     {
-        return m_index;
+        return jdksavdecc_descriptor_strings_get_descriptor_index(resp_ref->get_buffer(), resp_ref->get_pos());
     }
 }

--- a/controller/lib/src/strings_descriptor_imp.h
+++ b/controller/lib/src/strings_descriptor_imp.h
@@ -31,20 +31,23 @@
 
 #include "descriptor_base_imp.h"
 #include "strings_descriptor.h"
+#include "strings_descriptor_response_imp.h"
 
 namespace avdecc_lib
 {
     class strings_descriptor_imp : public strings_descriptor, public virtual descriptor_base_imp
     {
     private:
-        struct jdksavdecc_descriptor_strings strings_desc; // Structure containing the strings_desc fields
-
+        uint16_t m_type;
+        uint16_t m_index;
     public:
         strings_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
         virtual ~strings_descriptor_imp();
+        
+        strings_descriptor_response_imp *resp;
 
+        strings_descriptor_response * STDCALL get_strings_response();
         uint16_t STDCALL descriptor_type() const;
         uint16_t STDCALL descriptor_index() const;
-        uint8_t * STDCALL get_string_by_index(size_t string_index);
     };
 }

--- a/controller/lib/src/strings_descriptor_imp.h
+++ b/controller/lib/src/strings_descriptor_imp.h
@@ -44,7 +44,5 @@ namespace avdecc_lib
         strings_descriptor_response_imp *resp;
 
         strings_descriptor_response * STDCALL get_strings_response();
-        uint16_t STDCALL descriptor_type() const;
-        uint16_t STDCALL descriptor_index() const;
     };
 }

--- a/controller/lib/src/strings_descriptor_imp.h
+++ b/controller/lib/src/strings_descriptor_imp.h
@@ -37,9 +37,6 @@ namespace avdecc_lib
 {
     class strings_descriptor_imp : public strings_descriptor, public virtual descriptor_base_imp
     {
-    private:
-        uint16_t m_type;
-        uint16_t m_index;
     public:
         strings_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
         virtual ~strings_descriptor_imp();

--- a/controller/lib/src/strings_descriptor_response_imp.cpp
+++ b/controller/lib/src/strings_descriptor_response_imp.cpp
@@ -31,7 +31,7 @@
 
 namespace avdecc_lib
 {
-    strings_descriptor_response_imp::strings_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos) : descriptor_base_imp(nullptr, frame, frame_len, pos)
+    strings_descriptor_response_imp::strings_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos)
     {
         frame_size = frame_len;
         buffer = (uint8_t *)malloc(frame_size * sizeof(uint8_t));
@@ -39,7 +39,10 @@ namespace avdecc_lib
         position = pos;
     }
     
-    strings_descriptor_response_imp::~strings_descriptor_response_imp() {}
+    strings_descriptor_response_imp::~strings_descriptor_response_imp()
+    {
+        free(buffer);
+    }
     
     uint8_t * STDCALL strings_descriptor_response_imp::get_string_by_index(size_t string_index)
     {

--- a/controller/lib/src/strings_descriptor_response_imp.cpp
+++ b/controller/lib/src/strings_descriptor_response_imp.cpp
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * strings_descriptor_response_imp.cpp
+ *
+ * STRINGS descriptor response implementation
+ */
+
+#include "strings_descriptor_response_imp.h"
+
+namespace avdecc_lib
+{
+    strings_descriptor_response_imp::strings_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos) : descriptor_base_imp(nullptr, frame, frame_len, pos)
+    {
+        frame_size = frame_len;
+        buffer = (uint8_t *)malloc(frame_size * sizeof(uint8_t));
+        memcpy(buffer, frame, frame_size);
+        position = pos;
+    }
+    
+    strings_descriptor_response_imp::~strings_descriptor_response_imp() {}
+    
+    uint8_t * STDCALL strings_descriptor_response_imp::get_string_by_index(size_t string_index)
+    {
+        switch(string_index)
+        {
+            case 0:
+                return (uint8_t *) &buffer[position + JDKSAVDECC_DESCRIPTOR_STRINGS_OFFSET_STRING_0];
+                break;
+                
+            case 1:
+                return (uint8_t *) &buffer[position + JDKSAVDECC_DESCRIPTOR_STRINGS_OFFSET_STRING_1];
+                break;
+                
+            case 2:
+                return (uint8_t *) &buffer[position + JDKSAVDECC_DESCRIPTOR_STRINGS_OFFSET_STRING_2];
+                break;
+                
+            case 3:
+                return (uint8_t *) &buffer[position + JDKSAVDECC_DESCRIPTOR_STRINGS_OFFSET_STRING_3];
+                break;
+                
+            case 4:
+                return (uint8_t *) &buffer[position + JDKSAVDECC_DESCRIPTOR_STRINGS_OFFSET_STRING_4];
+                break;
+                
+            case 5:
+                return (uint8_t *) &buffer[position + JDKSAVDECC_DESCRIPTOR_STRINGS_OFFSET_STRING_5];
+                break;
+                
+            case 6:
+                return (uint8_t *) &buffer[position + JDKSAVDECC_DESCRIPTOR_STRINGS_OFFSET_STRING_6];
+                break;
+                
+            default:
+                log_imp_ref->post_log_msg(LOGGING_LEVEL_ERROR, "get_string_by_index error");
+                break;
+        }
+        return 0;
+    }
+}

--- a/controller/lib/src/strings_descriptor_response_imp.h
+++ b/controller/lib/src/strings_descriptor_response_imp.h
@@ -24,19 +24,19 @@
 /**
  * strings_descriptor_response_imp.h
  *
- * STREAM OUTPUT descriptor response implementation class
+ * STRINGS descriptor response implementation class
  */
 
 #pragma once
 
-#include "descriptor_base_imp.h"
 #include "strings_descriptor_response.h"
 #include "log_imp.h"
+#include "jdksavdecc_aem_descriptor.h"
 #include "enumeration.h"
 
 namespace avdecc_lib
 {
-    class strings_descriptor_response_imp : public strings_descriptor_response, public virtual descriptor_base_imp
+    class strings_descriptor_response_imp : public strings_descriptor_response
     {
     private:
         uint8_t * buffer;

--- a/controller/lib/src/strings_descriptor_response_imp.h
+++ b/controller/lib/src/strings_descriptor_response_imp.h
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 AudioScience Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * strings_descriptor_response_imp.h
+ *
+ * STREAM OUTPUT descriptor response implementation class
+ */
+
+#pragma once
+
+#include "descriptor_base_imp.h"
+#include "strings_descriptor_response.h"
+#include "log_imp.h"
+#include "enumeration.h"
+
+namespace avdecc_lib
+{
+    class strings_descriptor_response_imp : public strings_descriptor_response, public virtual descriptor_base_imp
+    {
+    private:
+        uint8_t * buffer;
+        ssize_t position;
+        size_t frame_size;
+    public:
+        strings_descriptor_response_imp(const uint8_t *frame, size_t frame_len, ssize_t pos);
+        virtual ~strings_descriptor_response_imp();
+        
+        uint8_t * STDCALL get_string_by_index(size_t string_index);
+    };
+}


### PR DESCRIPTION
Descriptors and get_ commands are now read from response classes, mutexing the end station whenever created, to avoid the possible issue of an asynchronous thread writing to a memory location while the cmdline is reading from it.