### PR TITLE
Revise currently implemented SET_ commands

### DIFF
--- a/controller/app/cmdline/src/cmd_line.cpp
+++ b/controller/app/cmdline/src/cmd_line.cpp
@@ -2930,15 +2930,17 @@ int cmd_line::cmd_set_stream_format(int total_matched, std::vector<cli_argument*
 
         if(status == avdecc_lib::AEM_STATUS_SUCCESS)
         {
-            stream_format = avdecc_lib::utility::ieee1722_format_value_to_name(stream_input_desc_ref->set_stream_format_stream_format());
+            avdecc_lib::stream_input_descriptor_response *stream_input_resp_ref = stream_input_desc_ref->get_stream_input_response();
+            stream_format = stream_input_resp_ref->current_format();
             if(stream_format == "UNKNOWN")
             {
-                atomic_cout << "Stream format: 0x" << std::hex << stream_input_desc_ref->set_stream_format_stream_format() << std::endl;
+                atomic_cout << "Stream format: 0x" << std::hex << stream_input_resp_ref->current_format() << std::endl;
             }
             else
             {
                 atomic_cout << "Stream format: " << stream_format << std::endl;
             }
+            delete stream_input_resp_ref;
         }
     }
     else if(desc_type_value == avdecc_lib::AEM_DESC_STREAM_OUTPUT)
@@ -2951,15 +2953,17 @@ int cmd_line::cmd_set_stream_format(int total_matched, std::vector<cli_argument*
 
         if(status == avdecc_lib::AEM_STATUS_SUCCESS)
         {
-            stream_format = avdecc_lib::utility::ieee1722_format_value_to_name(stream_output_desc_ref->set_stream_format_stream_format());
+            avdecc_lib::stream_output_descriptor_response *stream_output_resp_ref = stream_output_desc_ref->get_stream_output_response();
+            stream_format = stream_output_resp_ref->current_format();
             if(stream_format == "UNKNOWN")
             {
-                atomic_cout << "Stream format: 0x" << std::hex << stream_output_desc_ref->set_stream_format_stream_format() << std::endl;
+                atomic_cout << "Stream format: 0x" << std::hex << stream_output_resp_ref->current_format() << std::endl;
             }
             else
             {
                 atomic_cout << "Stream format: " << stream_format << std::endl;
             }
+            delete stream_output_resp_ref;
         }
     }
     else
@@ -3205,9 +3209,9 @@ int cmd_line::cmd_set_sampling_rate(int total_matched, std::vector<cli_argument*
 
         if(status == avdecc_lib::AEM_STATUS_SUCCESS)
         {
-            /*
-            atomic_cout << "Sampling rate: " << std::dec << audio_unit_desc_ref->set_sampling_rate_sampling_rate();
-            */
+            avdecc_lib::audio_unit_descriptor_response *audio_unit_resp_ref = audio_unit_desc_ref->get_audio_unit_response();
+            atomic_cout << "Sampling rate: " << std::dec << audio_unit_resp_ref->current_sampling_rate();
+            delete audio_unit_resp_ref;
         }
     }
     else if(desc_type_value == avdecc_lib::AEM_DESC_VIDEO_CLUSTER)
@@ -3249,8 +3253,8 @@ int cmd_line::cmd_get_sampling_rate(int total_matched, std::vector<cli_argument*
 
         if(status == avdecc_lib::AEM_STATUS_SUCCESS)
         {
-            avdecc_lib::audio_unit_get_sampling_rate_response *audio_unit_resp_ref = audio_unit_desc_ref->get_audio_unit_get_sampling_rate_response();
-            atomic_cout << "Sampling rate: " << std::dec << audio_unit_resp_ref->get_sampling_rate_sampling_rate();
+            avdecc_lib::audio_unit_descriptor_response *audio_unit_resp_ref = audio_unit_desc_ref->get_audio_unit_response();
+            atomic_cout << "Set sampling rate: " << std::dec << audio_unit_resp_ref->current_sampling_rate();
             delete audio_unit_resp_ref;
         }
     }
@@ -3418,9 +3422,10 @@ int cmd_line::cmd_set_clock_source(int total_matched, std::vector<cli_argument*>
     int status = sys->get_last_resp_status();
 
     if(status == avdecc_lib::AEM_STATUS_SUCCESS)
-    {   /*
-        atomic_cout << "Clock source index : " << std::dec << clk_domain_desc_ref->set_clock_source_clock_source_index() << std::endl;
-        */
+    {
+        avdecc_lib::clock_domain_descriptor_response *clk_domain_resp_ref = clk_domain_desc_ref->get_clock_domain_response();
+        atomic_cout << "Set clock source index : " << std::dec << clk_domain_resp_ref->clock_source_index() << std::endl;
+        delete clk_domain_resp_ref;
     }
 
     return 0;

--- a/controller/lib/include/stream_input_descriptor.h
+++ b/controller/lib/include/stream_input_descriptor.h
@@ -70,12 +70,6 @@ namespace avdecc_lib
         AVDECC_CONTROLLER_LIB32_API virtual stream_input_get_rx_state_response * STDCALL get_stream_input_get_rx_state_response() = 0;
 
         /**
-         * \return The stream format of a stream after sending a SET_STREAM_FORMAT command and
-         *	       receiving a response back for the command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL set_stream_format_stream_format() = 0;
-
-        /**
          * Send a SET_STREAM_FORMAT command with a notification id to change the format of a stream.
          *
          * \param notification_id A void pointer to the unique identifier associated with the command.

--- a/controller/lib/include/stream_output_descriptor.h
+++ b/controller/lib/include/stream_output_descriptor.h
@@ -70,12 +70,6 @@ namespace avdecc_lib
         AVDECC_CONTROLLER_LIB32_API virtual stream_output_get_tx_connection_response * STDCALL get_stream_output_get_tx_connection_response() = 0;
 
         /**
-         * \return The stream format of a stream after sending a SET_STREAM_FORMAT command and
-         *	       receiving a response back for the command.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL set_stream_format_stream_format() = 0;
-
-        /**
          * Send a SET_STREAM_FORMAT command with a notification id to change the format of a stream.
          *
          * \param notification_id A void pointer to the unique identifier associated with the command.

--- a/controller/lib/src/audio_unit_descriptor_imp.h
+++ b/controller/lib/src/audio_unit_descriptor_imp.h
@@ -38,8 +38,6 @@ namespace avdecc_lib
 {
     class audio_unit_descriptor_imp : public audio_unit_descriptor, public virtual descriptor_base_imp
     {
-    private:
-        struct jdksavdecc_aem_command_set_sampling_rate_response aem_cmd_set_sampling_rate_resp; // Store the response received after sending a SET_SAMPLING_RATE command.
     public:
         audio_unit_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
         virtual ~audio_unit_descriptor_imp();

--- a/controller/lib/src/audio_unit_get_sampling_rate_response_imp.cpp
+++ b/controller/lib/src/audio_unit_get_sampling_rate_response_imp.cpp
@@ -50,8 +50,6 @@ namespace avdecc_lib
     uint32_t STDCALL audio_unit_get_sampling_rate_response_imp::get_sampling_rate_sampling_rate()
     {
         uint32_t sampling_rate;
-        sampling_rate = jdksavdecc_aem_command_get_sampling_rate_response_get_sampling_rate(m_frame, m_position);
-        
-        return sampling_rate;
+        return sampling_rate = jdksavdecc_aem_command_get_sampling_rate_response_get_sampling_rate(m_frame, m_position);
     }
 }

--- a/controller/lib/src/clock_domain_descriptor_imp.h
+++ b/controller/lib/src/clock_domain_descriptor_imp.h
@@ -39,8 +39,6 @@ namespace avdecc_lib
 {
     class clock_domain_descriptor_imp : public clock_domain_descriptor, public virtual descriptor_base_imp
     {
-    private:
-        struct jdksavdecc_aem_command_set_clock_source_response aem_cmd_set_clk_src_resp; // Store the response received after sending a SET_CLOCK_SOURCE command
     public:
         clock_domain_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
         virtual ~clock_domain_descriptor_imp();

--- a/controller/lib/src/stream_input_descriptor_imp.cpp
+++ b/controller/lib/src/stream_input_descriptor_imp.cpp
@@ -82,11 +82,6 @@ namespace avdecc_lib
                                                                               resp_ref->get_size(), resp_ref->get_pos());
     }
 
-    uint64_t STDCALL stream_input_descriptor_imp::set_stream_format_stream_format()
-    {
-        return jdksavdecc_uint64_get(&aem_cmd_set_stream_format_resp.stream_format, 0);
-    }
-
     int STDCALL stream_input_descriptor_imp::send_set_stream_format_cmd(void *notification_id, uint64_t new_stream_format)
     {
         struct jdksavdecc_frame cmd_frame;
@@ -132,11 +127,14 @@ namespace avdecc_lib
     int stream_input_descriptor_imp::proc_set_stream_format_resp(void *&notification_id, const uint8_t *frame, size_t frame_len, int &status)
     {
         struct jdksavdecc_frame cmd_frame;
+        struct jdksavdecc_aem_command_set_stream_format_response aem_cmd_set_stream_format_resp;
         ssize_t aem_cmd_set_stream_format_resp_returned;
         uint32_t msg_type;
         bool u_field;
+        uint8_t * buffer;
 
         memcpy(cmd_frame.payload, frame, frame_len);
+        memset(&aem_cmd_set_stream_format_resp, 0, sizeof(jdksavdecc_aem_command_set_stream_format_response));
 
         aem_cmd_set_stream_format_resp_returned = jdksavdecc_aem_command_set_stream_format_response_read(&aem_cmd_set_stream_format_resp,
                                                                                                          frame,
@@ -150,12 +148,20 @@ namespace avdecc_lib
             return -1;
         }
 
+        buffer = (uint8_t *)malloc(resp_ref->get_desc_size() * sizeof(uint8_t)); //fetch current desc frame
+        memcpy(buffer, resp_ref->get_desc_buffer(), resp_ref->get_desc_size());
+        jdksavdecc_descriptor_stream_set_current_format(aem_cmd_set_stream_format_resp.stream_format,
+                                                        buffer, resp_ref->get_desc_pos()); //set stream format
+        
+        replace_desc_frame(buffer, resp_ref->get_desc_pos(), resp_ref->get_desc_size()); //replace frame
+        
         msg_type = aem_cmd_set_stream_format_resp.aem_header.aecpdu_header.header.message_type;
         status = aem_cmd_set_stream_format_resp.aem_header.aecpdu_header.header.status;
         u_field = aem_cmd_set_stream_format_resp.aem_header.command_type >> 15 & 0x01; // u_field = the msb of the uint16_t command_type
 
         aecp_controller_state_machine_ref->update_inflight_for_rcvd_resp(notification_id, msg_type, u_field, &cmd_frame);
 
+        free(buffer);
         return 0;
     }
 

--- a/controller/lib/src/stream_input_descriptor_imp.h
+++ b/controller/lib/src/stream_input_descriptor_imp.h
@@ -43,7 +43,6 @@ namespace avdecc_lib
     class stream_input_descriptor_imp : public stream_input_descriptor, public virtual descriptor_base_imp
     {
     private:
-        struct jdksavdecc_aem_command_set_stream_format_response aem_cmd_set_stream_format_resp; // Store the response received after sending a SET_STREAM_FORMAT command.
         struct jdksavdecc_acmpdu acmp_cmd_connect_rx_resp; // Store the response received after sending a CONNECT_RX command.
         struct jdksavdecc_acmpdu acmp_cmd_disconnect_rx_resp; // Store the response received after sending a DISCONNECT_RX command.
     public:
@@ -61,9 +60,7 @@ namespace avdecc_lib
         stream_input_get_stream_format_response * STDCALL get_stream_input_get_stream_format_response();
         stream_input_get_stream_info_response * STDCALL get_stream_input_get_stream_info_response();
         stream_input_get_rx_state_response * STDCALL get_stream_input_get_rx_state_response();
-        
-        uint64_t STDCALL set_stream_format_stream_format();
-        
+
 		int STDCALL send_set_stream_format_cmd(void *notification_id, uint64_t new_stream_format);
         int proc_set_stream_format_resp(void *&notification_id, const uint8_t *frame, size_t frame_len, int &status);
         

--- a/controller/lib/src/stream_output_descriptor_imp.h
+++ b/controller/lib/src/stream_output_descriptor_imp.h
@@ -48,7 +48,6 @@ namespace avdecc_lib
     class stream_output_descriptor_imp : public stream_output_descriptor, public virtual descriptor_base_imp
     {
     private:
-        struct jdksavdecc_aem_command_set_stream_format_response aem_cmd_set_stream_format_resp; // Store the response received after sending a SET_STREAM_FORMAT command.
         struct jdksavdecc_aem_command_set_stream_info_response aem_cmd_set_stream_info_resp; // Store the response received after sending a SET_STREAM_INFO command.
     public:
         stream_output_descriptor_imp(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
@@ -65,8 +64,6 @@ namespace avdecc_lib
         stream_output_get_stream_info_response * STDCALL get_stream_output_get_stream_info_response();
         stream_output_get_tx_state_response * STDCALL get_stream_output_get_tx_state_response();
         stream_output_get_tx_connection_response * STDCALL get_stream_output_get_tx_connection_response();
-        
-        uint64_t STDCALL set_stream_format_stream_format();
 
 		int STDCALL send_set_stream_format_cmd(void *notification_id, uint64_t new_stream_format);
         int proc_set_stream_format_resp(void *&notification_id, const uint8_t *frame, size_t frame_len, int &status);


### PR DESCRIPTION
 Now each set command response updates the corresponding descriptor frame with the new set value.  The UI returns this updated value from the descriptor response class.  Set stream_format, set sampling_rate were unable to be tested.