### PR TITLE
audio_map and audio_cluster

### DIFF
--- a/controller/lib/src/audio_cluster_descriptor_imp.cpp
+++ b/controller/lib/src/audio_cluster_descriptor_imp.cpp
@@ -45,7 +45,7 @@ namespace avdecc_lib
     audio_cluster_descriptor_response * STDCALL audio_cluster_descriptor_imp::get_audio_cluster_response()
     {
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
-        return resp = new audio_cluster_descriptor_response_imp(resp_ref->get_buffer(),
-                                                                resp_ref->get_size(), resp_ref->get_pos());
+        return resp = new audio_cluster_descriptor_response_imp(resp_ref->get_desc_buffer(),
+                                                                resp_ref->get_desc_size(), resp_ref->get_desc_pos());
     }
 }

--- a/controller/lib/src/audio_map_descriptor_imp.cpp
+++ b/controller/lib/src/audio_map_descriptor_imp.cpp
@@ -44,7 +44,7 @@ namespace avdecc_lib
     audio_map_descriptor_response * STDCALL audio_map_descriptor_imp::get_audio_map_response()
     {
         std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
-        return resp = new audio_map_descriptor_response_imp(resp_ref->get_buffer(),
-                                                            resp_ref->get_size(), resp_ref->get_pos());
+        return resp = new audio_map_descriptor_response_imp(resp_ref->get_desc_buffer(),
+                                                            resp_ref->get_desc_size(), resp_ref->get_desc_pos());
     }
 }


### PR DESCRIPTION
Audio_map and audio_cluster were not reading the response frame from the descriptor buffer.