### PR TITLE
Store Pending Audio Maps revision

### DIFF
--- a/controller/lib/src/stream_port_input_descriptor_imp.cpp
+++ b/controller/lib/src/stream_port_input_descriptor_imp.cpp
@@ -62,7 +62,6 @@ namespace avdecc_lib
     int stream_port_input_descriptor_imp::store_pending_map(struct audio_map_mapping &map)
     {
         pending_maps.push_back(map);
-        std::cout << "new map pending, total maps pending: " << pending_maps.size() << std::endl;
 
         return 0;
     }

--- a/controller/lib/src/stream_port_input_descriptor_imp.cpp
+++ b/controller/lib/src/stream_port_input_descriptor_imp.cpp
@@ -61,15 +61,8 @@ namespace avdecc_lib
     
     int stream_port_input_descriptor_imp::store_pending_map(struct audio_map_mapping &map)
     {
-        if (pending_maps.size() >= MAX_MAPPINGS_PER_FRAME) //max number of pending maps (1722.1 fig. 7.2)
-        {
-            log_imp_ref->post_log_msg(LOGGING_LEVEL_ERROR, "Too many pending audio maps.\n");
-        }
-        else
-        {
-            pending_maps.push_back(map);
-            std::cout << "new map pending, total maps pending: " << pending_maps.size() << std::endl;
-        }
+        pending_maps.push_back(map);
+        std::cout << "new map pending, total maps pending: " << pending_maps.size() << std::endl;
 
         return 0;
     }

--- a/controller/lib/src/stream_port_output_descriptor_imp.cpp
+++ b/controller/lib/src/stream_port_output_descriptor_imp.cpp
@@ -58,16 +58,9 @@ namespace avdecc_lib
     
     int stream_port_output_descriptor_imp::store_pending_map(struct audio_map_mapping &map)
     {
-        if (pending_maps.size() >= MAX_MAPPINGS_PER_FRAME) //max number of pending maps for a frame
-        {
-            log_imp_ref->post_log_msg(LOGGING_LEVEL_ERROR, "Too many pending audio maps.\n");
-        }
-        else
-        {
-            pending_maps.push_back(map);
-            std::cout << "new map pending, total maps pending: " << pending_maps.size() << std::endl;
-        }
-        
+        pending_maps.push_back(map);
+        std::cout << "new map pending, total maps pending: " << pending_maps.size() << std::endl;
+
         return 0;
     }
 

--- a/controller/lib/src/stream_port_output_descriptor_imp.cpp
+++ b/controller/lib/src/stream_port_output_descriptor_imp.cpp
@@ -59,7 +59,6 @@ namespace avdecc_lib
     int stream_port_output_descriptor_imp::store_pending_map(struct audio_map_mapping &map)
     {
         pending_maps.push_back(map);
-        std::cout << "new map pending, total maps pending: " << pending_maps.size() << std::endl;
 
         return 0;
     }


### PR DESCRIPTION
 Now we can queue pending maps past the number of maps allowed for one command.