### PR TITLE
get_stream_info flags

### DIFF
--- a/controller/app/cmdline/src/cmd_line.cpp
+++ b/controller/app/cmdline/src/cmd_line.cpp
@@ -3753,8 +3753,22 @@ int cmd_line::cmd_get_stream_info(int total_matched, std::vector<cli_argument*> 
                 atomic_cout << "Stream format: " << stream_format << std::endl;
             }
 
-            atomic_cout << "Stream ID: 0x" << std::hex << stream_input_resp_ref->get_stream_info_stream_id() << std::endl;
-            atomic_cout << "MSRP Accumulated Latency: " << std::dec << stream_input_resp_ref->get_stream_info_msrp_accumulated_latency() << std::endl;
+            if (stream_input_resp_ref->get_stream_info_flags_stream_id_valid())
+                atomic_cout << "Stream ID: 0x" << std::hex << std::setfill('0') << std::setw(16) <<
+                            stream_input_resp_ref->get_stream_info_stream_id() << std::endl;
+            if (stream_input_resp_ref->get_stream_info_flags_stream_dest_mac_valid())
+                atomic_cout << "Stream Destination MAC: " << std::hex <<
+                            stream_input_resp_ref->get_stream_info_stream_dest_mac() << std::endl;
+            if (stream_input_resp_ref->get_stream_info_flags_msrp_failure_valid())
+            {
+                atomic_cout << "Stream MSRP failure code: " <<
+                            stream_input_resp_ref->get_stream_info_msrp_failure_code() << std::endl;
+                atomic_cout << "Stream MSRP failure bridge id " <<
+                            stream_input_resp_ref->get_stream_info_msrp_failure_bridge_id() << std::endl;
+            }
+            if (stream_input_resp_ref->get_stream_info_flags_msrp_acc_lat_valid())
+                atomic_cout << "Stream MSRP accumulated latency: " <<
+                            stream_input_resp_ref->get_stream_info_msrp_accumulated_latency() << std::endl;
         }
     }
     else if(desc_type_value == avdecc_lib::AEM_DESC_STREAM_OUTPUT)
@@ -3762,14 +3776,17 @@ int cmd_line::cmd_get_stream_info(int total_matched, std::vector<cli_argument*> 
         intptr_t cmd_notification_id = get_next_notification_id();
         sys->set_wait_for_next_cmd((void *)cmd_notification_id);
         avdecc_lib::stream_output_descriptor *stream_output_desc_ref = configuration->get_stream_output_desc_by_index(desc_index);
-        avdecc_lib::stream_output_descriptor_response *stream_output_desc_resp = stream_output_desc_ref->get_stream_output_response();
         stream_output_desc_ref->send_get_stream_info_cmd((void *)cmd_notification_id);
         int status = sys->get_last_resp_status();
 
         if(status == avdecc_lib::AEM_STATUS_SUCCESS)
         {
-            avdecc_lib::stream_output_get_stream_info_response *stream_output_resp_ref = stream_output_desc_ref->get_stream_output_get_stream_info_response();
-            stream_format = avdecc_lib::utility::ieee1722_format_value_to_name(stream_output_resp_ref->get_stream_info_stream_format());
+            avdecc_lib::stream_output_get_stream_info_response
+                *stream_output_resp_ref = stream_output_desc_ref->get_stream_output_get_stream_info_response();
+            
+            stream_format = avdecc_lib::utility::ieee1722_format_value_to_name(stream_output_resp_ref->
+                                                                               get_stream_info_stream_format());
+            
             if(stream_format == "UNKNOWN")
             {
                 atomic_cout << "Stream format: 0x" << std::hex << stream_output_resp_ref->get_stream_info_stream_format() << std::endl;
@@ -3778,16 +3795,26 @@ int cmd_line::cmd_get_stream_info(int total_matched, std::vector<cli_argument*> 
             {
                 atomic_cout << "Stream format: " << stream_format << std::endl;
             }
-            atomic_cout << "Flags: 0x" << std::hex << stream_output_resp_ref->get_stream_info_flags() << std::endl;
-            if (stream_output_desc_resp->get_stream_info_flag("STREAM_ID_VALID"))
+
+            if (stream_output_resp_ref->get_stream_info_flags_stream_id_valid())
                 atomic_cout << "Stream ID: 0x" << std::hex << std::setfill('0') << std::setw(16) <<
                             stream_output_resp_ref->get_stream_info_stream_id() << std::endl;
-            if (stream_output_desc_resp->get_stream_info_flag("STREAM_DEST_MAC_VALID"))
+            if (stream_output_resp_ref->get_stream_info_flags_stream_dest_mac_valid())
                 atomic_cout << "Stream Destination MAC: " << std::hex <<
                             stream_output_resp_ref->get_stream_info_stream_dest_mac() << std::endl;
-            if (stream_output_desc_resp->get_stream_info_flag("STREAM_VLAN_ID_VALID"))
+            if (stream_output_resp_ref->get_stream_info_flags_stream_vlan_id_valid())
                 atomic_cout << "Stream VLAN ID: " <<
                             stream_output_resp_ref->get_stream_info_stream_vlan_id() << std::endl;
+            if (stream_output_resp_ref->get_stream_info_flags_msrp_failure_valid())
+            {
+                atomic_cout << "Stream MSRP failure code: " <<
+                            stream_output_resp_ref->get_stream_info_msrp_failure_code() << std::endl;
+                atomic_cout << "Stream MSRP failure bridge id " <<
+                            stream_output_resp_ref->get_stream_info_msrp_failure_bridge_id() << std::endl;
+            }
+            if (stream_output_resp_ref->get_stream_info_flags_msrp_acc_lat_valid())
+                atomic_cout << "Stream MSRP accumulated latency: " <<
+                            stream_output_resp_ref->get_stream_info_msrp_accumulated_latency() << std::endl;
         }
     }
     else

--- a/controller/lib/include/stream_input_get_stream_info_response.h
+++ b/controller/lib/include/stream_input_get_stream_info_response.h
@@ -45,6 +45,30 @@ namespace avdecc_lib
         AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_stream_info_flags() = 0;
         
         /**
+         * \return True if the stream's msrp_failure_code and msrp_failure_id fields are valid.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL get_stream_info_flags_msrp_failure_valid() = 0;
+        
+        /**
+         * \return True if the stream's stream_dest_mac field is valid.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL get_stream_info_flags_stream_dest_mac_valid() = 0;
+        
+        /**
+         * \return True if the stream's msrp_accumulated_latency field is valid.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL get_stream_info_flags_msrp_acc_lat_valid() = 0;
+        
+        /**
+         * \return True if the stream's stream_id field is valid.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL get_stream_info_flags_stream_id_valid() = 0;
+        
+        /**
+         * \return True if the stream's stream_format field is valid.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL get_stream_info_flags_stream_format_valid() = 0;
+        /**
          * \return The stream info stream format of a stream after sending a GET_STREAM_INFO command and
          *	       receiving a response back for the command.
          */

--- a/controller/lib/include/stream_output_get_stream_info_response.h
+++ b/controller/lib/include/stream_output_get_stream_info_response.h
@@ -45,6 +45,36 @@ namespace avdecc_lib
         AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_stream_info_flags() = 0;
         
         /**
+         * \return True if the stream's stream_vlan_id field is valid.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL get_stream_info_flags_stream_vlan_id_valid() = 0;
+        
+        /**
+         * \return True if the stream's msrp_failure_code and msrp_failure_id fields are valid.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL get_stream_info_flags_msrp_failure_valid() = 0;
+        
+        /**
+         * \return True if the stream's stream_dest_mac field is valid.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL get_stream_info_flags_stream_dest_mac_valid() = 0;
+        
+        /**
+         * \return True if the stream's msrp_accumulated_latency field is valid.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL get_stream_info_flags_msrp_acc_lat_valid() = 0;
+        
+        /**
+         * \return True if the stream's stream_id field is valid.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL get_stream_info_flags_stream_id_valid() = 0;
+        
+        /**
+         * \return True if the stream's stream_format field is valid.
+         */
+        AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL get_stream_info_flags_stream_format_valid() = 0;
+        
+        /**
          * \return The stream info stream format of a stream after sending a GET_STREAM_INFO command and
          *	       receiving a response back for the command.
          */

--- a/controller/lib/src/stream_input_get_stream_info_response_imp.cpp
+++ b/controller/lib/src/stream_input_get_stream_info_response_imp.cpp
@@ -40,11 +40,52 @@ namespace avdecc_lib
         m_size = frame_len;
         m_frame = (uint8_t *)malloc(m_size * sizeof(uint8_t));
         memcpy(m_frame, frame, m_size);
+        stream_input_get_info_flags_init();
     }
     
     stream_input_get_stream_info_response_imp::~stream_input_get_stream_info_response_imp()
     {
         free(m_frame);
+    }
+    
+    void stream_input_get_stream_info_response_imp::stream_input_get_info_flags_init()
+    {
+        stream_input_info_flags.class_b = get_stream_info_flags() & 0x01;
+        stream_input_info_flags.fast_connect = get_stream_info_flags() >> 1 & 0x01;
+        stream_input_info_flags.saved_state = get_stream_info_flags() >> 2 & 0x01;
+        stream_input_info_flags.streaming_wait = get_stream_info_flags() >> 3 & 0x01;
+        stream_input_info_flags.encrypted_pdu = get_stream_info_flags() >> 4 & 0x01;
+        stream_input_info_flags.connected = get_stream_info_flags() >> 26 & 0x01;
+        stream_input_info_flags.msrp_failure_valid = get_stream_info_flags() >> 27 & 0x01;
+        stream_input_info_flags.stream_dest_mac_valid = get_stream_info_flags() >> 28 & 0x01;
+        stream_input_info_flags.msrp_acc_lat_valid = get_stream_info_flags() >> 29 & 0x01;
+        stream_input_info_flags.stream_id_valid = get_stream_info_flags() >> 30 & 0x01;
+        stream_input_info_flags.stream_format_valid = get_stream_info_flags() >> 31 & 0x01;
+    }
+
+    bool STDCALL stream_input_get_stream_info_response_imp::get_stream_info_flags_msrp_failure_valid()
+    {
+        return stream_input_info_flags.msrp_failure_valid;
+    }
+    
+    bool STDCALL stream_input_get_stream_info_response_imp::get_stream_info_flags_stream_dest_mac_valid()
+    {
+        return stream_input_info_flags.stream_dest_mac_valid;
+    }
+    
+    bool STDCALL stream_input_get_stream_info_response_imp::get_stream_info_flags_msrp_acc_lat_valid()
+    {
+        return stream_input_info_flags.msrp_acc_lat_valid;
+    }
+    
+    bool STDCALL stream_input_get_stream_info_response_imp::get_stream_info_flags_stream_id_valid()
+    {
+        return stream_input_info_flags.stream_id_valid;
+    }
+    
+    bool STDCALL stream_input_get_stream_info_response_imp::get_stream_info_flags_stream_format_valid()
+    {
+        return stream_input_info_flags.stream_format_valid;
     }
     
     uint32_t STDCALL stream_input_get_stream_info_response_imp::get_stream_info_flags()

--- a/controller/lib/src/stream_input_get_stream_info_response_imp.h
+++ b/controller/lib/src/stream_input_get_stream_info_response_imp.h
@@ -40,10 +40,33 @@ namespace avdecc_lib
         uint8_t * m_frame;
         size_t m_size;
         ssize_t m_position;
+
+        struct stream_input_stream_info_flags
+        {
+            bool class_b;
+            bool fast_connect;
+            bool saved_state;
+            bool streaming_wait;
+            bool encrypted_pdu;
+            bool connected;
+            bool msrp_failure_valid;
+            bool stream_dest_mac_valid;
+            bool msrp_acc_lat_valid;
+            bool stream_id_valid;
+            bool stream_format_valid;
+        };
+        struct stream_input_stream_info_flags stream_input_info_flags;
+
     public:
         stream_input_get_stream_info_response_imp(uint8_t *frame, size_t frame_len, ssize_t pos);
         virtual ~stream_input_get_stream_info_response_imp();
         
+        bool STDCALL get_stream_info_flags_stream_vlan_id_valid();
+        bool STDCALL get_stream_info_flags_msrp_failure_valid();
+        bool STDCALL get_stream_info_flags_stream_dest_mac_valid();
+        bool STDCALL get_stream_info_flags_msrp_acc_lat_valid();
+        bool STDCALL get_stream_info_flags_stream_id_valid();
+        bool STDCALL get_stream_info_flags_stream_format_valid();
         uint64_t STDCALL get_stream_format_stream_format();
         uint32_t STDCALL get_stream_info_flags();
         uint64_t STDCALL get_stream_info_stream_format();
@@ -52,5 +75,8 @@ namespace avdecc_lib
         uint64_t STDCALL get_stream_info_stream_dest_mac();
         uint8_t STDCALL get_stream_info_msrp_failure_code();
         uint64_t STDCALL get_stream_info_msrp_failure_bridge_id();
+
+    private:
+        void stream_input_get_info_flags_init();
     };
 }

--- a/controller/lib/src/stream_output_get_stream_info_response_imp.cpp
+++ b/controller/lib/src/stream_output_get_stream_info_response_imp.cpp
@@ -40,11 +40,58 @@ namespace avdecc_lib
         m_size = frame_len;
         m_frame = (uint8_t *)malloc(m_size * sizeof(uint8_t));
         memcpy(m_frame, frame, m_size);
+        stream_output_get_info_flags_init();
     }
     
     stream_output_get_stream_info_response_imp::~stream_output_get_stream_info_response_imp()
     {
         free(m_frame);
+    }
+    
+    void stream_output_get_stream_info_response_imp::stream_output_get_info_flags_init()
+    {
+        stream_output_info_flags.class_b = get_stream_info_flags() & 0x01;
+        stream_output_info_flags.fast_connect = get_stream_info_flags() >> 1 & 0x01;
+        stream_output_info_flags.saved_state = get_stream_info_flags() >> 2 & 0x01;
+        stream_output_info_flags.streaming_wait = get_stream_info_flags() >> 3 & 0x01;
+        stream_output_info_flags.encrypted_pdu = get_stream_info_flags() >> 4 & 0x01;
+        stream_output_info_flags.stream_vlan_id_valid = get_stream_info_flags() >> 25 & 0x01;
+        stream_output_info_flags.connected = get_stream_info_flags() >> 26 & 0x01;
+        stream_output_info_flags.msrp_failure_valid = get_stream_info_flags() >> 27 & 0x01;
+        stream_output_info_flags.stream_dest_mac_valid = get_stream_info_flags() >> 28 & 0x01;
+        stream_output_info_flags.msrp_acc_lat_valid = get_stream_info_flags() >> 29 & 0x01;
+        stream_output_info_flags.stream_id_valid = get_stream_info_flags() >> 30 & 0x01;
+        stream_output_info_flags.stream_format_valid = get_stream_info_flags() >> 31 & 0x01;
+    }
+    
+    bool STDCALL stream_output_get_stream_info_response_imp::get_stream_info_flags_stream_vlan_id_valid()
+    {
+        return stream_output_info_flags.stream_vlan_id_valid;
+    }
+    
+    bool STDCALL stream_output_get_stream_info_response_imp::get_stream_info_flags_msrp_failure_valid()
+    {
+        return stream_output_info_flags.msrp_failure_valid;
+    }
+    
+    bool STDCALL stream_output_get_stream_info_response_imp::get_stream_info_flags_stream_dest_mac_valid()
+    {
+        return stream_output_info_flags.stream_dest_mac_valid;
+    }
+    
+    bool STDCALL stream_output_get_stream_info_response_imp::get_stream_info_flags_msrp_acc_lat_valid()
+    {
+        return stream_output_info_flags.msrp_acc_lat_valid;
+    }
+    
+    bool STDCALL stream_output_get_stream_info_response_imp::get_stream_info_flags_stream_id_valid()
+    {
+        return stream_output_info_flags.stream_id_valid;
+    }
+    
+    bool STDCALL stream_output_get_stream_info_response_imp::get_stream_info_flags_stream_format_valid()
+    {
+        return stream_output_info_flags.stream_format_valid;
     }
     
     uint32_t STDCALL stream_output_get_stream_info_response_imp::get_stream_info_flags()

--- a/controller/lib/src/stream_output_get_stream_info_response_imp.h
+++ b/controller/lib/src/stream_output_get_stream_info_response_imp.h
@@ -40,10 +40,33 @@ namespace avdecc_lib
         uint8_t * m_frame;
         size_t m_size;
         ssize_t m_position;
+        
+        struct stream_output_stream_info_flags
+        {
+            bool class_b;
+            bool fast_connect;
+            bool saved_state;
+            bool streaming_wait;
+            bool encrypted_pdu;
+            bool stream_vlan_id_valid;
+            bool connected;
+            bool msrp_failure_valid;
+            bool stream_dest_mac_valid;
+            bool msrp_acc_lat_valid;
+            bool stream_id_valid;
+            bool stream_format_valid;
+        };
+        struct stream_output_stream_info_flags stream_output_info_flags;
     public:
         stream_output_get_stream_info_response_imp(uint8_t *frame, size_t frame_len, ssize_t pos);
         virtual ~stream_output_get_stream_info_response_imp();
         
+        bool STDCALL get_stream_info_flags_stream_vlan_id_valid();
+        bool STDCALL get_stream_info_flags_msrp_failure_valid();
+        bool STDCALL get_stream_info_flags_stream_dest_mac_valid();
+        bool STDCALL get_stream_info_flags_msrp_acc_lat_valid();
+        bool STDCALL get_stream_info_flags_stream_id_valid();
+        bool STDCALL get_stream_info_flags_stream_format_valid();
         uint64_t STDCALL get_stream_format_stream_format();
         uint32_t STDCALL get_stream_info_flags();
         uint64_t STDCALL get_stream_info_stream_format();
@@ -53,5 +76,8 @@ namespace avdecc_lib
         uint8_t STDCALL get_stream_info_msrp_failure_code();
         uint64_t STDCALL get_stream_info_msrp_failure_bridge_id();
         uint16_t STDCALL get_stream_info_stream_vlan_id();
+
+    private:
+        void stream_output_get_info_flags_init();
     };
 }


### PR DESCRIPTION
Add API's to read stream flags returned from a get_stream_info command, printing only the valid fields.