### PR TITLE
controller: lib: src: avb_inteface, remove assert if get_counters fails

### DIFF
--- a/controller/lib/src/avb_interface_descriptor_imp.cpp
+++ b/controller/lib/src/avb_interface_descriptor_imp.cpp
@@ -125,7 +125,6 @@ namespace avdecc_lib
         if(aem_cmd_get_counters_resp_returned < 0)
         {
             log_imp_ref->post_log_msg(LOGGING_LEVEL_ERROR, "aem_cmd_get_avb_counters_resp_read error\n");
-            assert(aem_cmd_get_counters_resp_returned >= 0);
             return -1;
         }
 


### PR DESCRIPTION
This assert is removed because we don't want an application to halt due
to one bad AVDECC entity on the network.