### PR TITLE
avdecc - make Doxygen comments more clang-format compatible

### DIFF
--- a/controller/app/cmdline/src/cli_argument.h
+++ b/controller/app/cmdline/src/cli_argument.h
@@ -54,17 +54,17 @@ public:
     virtual bool set_value(std::string value_str) = 0;
     virtual void get_completion_options(std::set<std::string> &options) = 0;
 
-    /**
-     * The get_ functions return the first matching value.
-     */
+    ///
+    /// The get_ functions return the first matching value.
+    ///
     virtual int get_value_int() const;
     virtual uint32_t get_value_uint() const;
     virtual std::string get_value_str() const;
 
-    /**
-     * The get_all_ functions return all matching values where an argument has
-     * matched more than once
-     */
+    ///
+    /// The get_all_ functions return all matching values where an argument has
+    /// matched more than once
+    ///
     virtual size_t get_all_value_count() const = 0;
     virtual std::vector<int> get_all_value_int() const;
     virtual std::vector<uint32_t> get_all_value_uint() const;

--- a/controller/app/cmdline/src/cmd_line.h
+++ b/controller/app/cmdline/src/cmd_line.h
@@ -90,9 +90,9 @@ public:
 
     cmd_line();
 
-    /**
-     * Constructor for cmd_line used for constructing an object with notification and log callback functions.
-     */
+    ///
+    /// Constructor for cmd_line used for constructing an object with notification and log callback functions.
+    ///
     cmd_line(void (*notification_callback) (void *, int32_t, uint64_t, uint16_t, uint16_t, uint16_t, uint32_t, void *),
              void (*log_callback) (void *, int32_t, const char *, int32_t),
              bool test_mode, char *interface, int32_t log_level);
@@ -117,342 +117,342 @@ private:
 
 public:
 
-    /**
-     * Access methods used for command-line completion
-     */
+    ///
+    /// Access methods used for command-line completion
+    ///
     const cli_command *get_commands() const;
     avdecc_lib::controller *get_controller() const;
 
-    /**
-     * Try to execute a command
-     */
+    ///
+    /// Try to execute a command
+    ///
     bool handle(std::vector<std::string> &args);
 
-    /**
-     * Find an endstation index from an argument string.
-     */
+    ///
+    /// Find an endstation index from an argument string.
+    ///
     bool get_end_station_index(std::string arg, uint32_t &end_station_index) const;
 
     bool is_output_redirected() const;
 
 private:
 
-    /**
-     * Display summary help for all commands.
-     */
+    ///
+    /// Display summary help for all commands.
+    ///
     int cmd_help_all(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Display a detailed description of a command.
-     */
+    ///
+    /// Display a detailed description of a command.
+    ///
     int cmd_help_one(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Display a detailed description of a command.
-     */
+    ///
+    /// Display a detailed description of a command.
+    ///
     int cmd_quit(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Display the name at index name_index for a given descriptor.
-     */
+    ///
+    /// Display the name at index name_index for a given descriptor.
+    ///
     int cmd_display_desc_name(avdecc_lib::descriptor_base *desc, uint16_t name_index, bool is_entity);
 
-    /**
-     * Display the current build release version.
-     */
+    ///
+    /// Display the current build release version.
+    ///
     int cmd_version(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Display a table with information about each end station discovered with ADP.
-     */
+    ///
+    /// Display a table with information about each end station discovered with ADP.
+    ///
     int cmd_list(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Display the current end station and configuration setting.
-     */
+    ///
+    /// Display the current end station and configuration setting.
+    ///
     int cmd_show_select(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Change the setting of end station, entity, and configuration.
-     */
+    ///
+    /// Change the setting of end station, entity, and configuration.
+    ///
     int cmd_select(int total_matched, std::vector<cli_argument*> args);
 
     int do_select(uint32_t new_end_station, uint16_t new_entity, uint16_t new_config);
 
-    /**
-     * Change the base log level for messages to be logged by the logging callback.
-     */
+    ///
+    /// Change the base log level for messages to be logged by the logging callback.
+    ///
     int cmd_log_level(int total_matched, std::vector<cli_argument*> args);
 
-    /*
-     * Re-direct logging to a file.
-     */
+    ///
+    /// Re-direct logging to a file.
+    ///
     int cmd_log(int total_matched, std::vector<cli_argument*> args);
 
-    /*
-     * Re-direct logging back to stdout
-     */
+    ///
+    /// Re-direct logging back to stdout
+    ///
     int cmd_unlog(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Display all the descriptors in each end station.
-     */
+    ///
+    /// Display all the descriptors in each end station.
+    ///
     int cmd_view_all(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Display a list of descriptors that has the Clock Sync Source flag set.
-     */
+    ///
+    /// Display a list of descriptors that has the Clock Sync Source flag set.
+    ///
     int cmd_view_media_clock(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Display all the descriptors with details in the end station.
-     */
+    ///
+    /// Display all the descriptors with details in the end station.
+    ///
     int cmd_view_details(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Display all stream formats.
-     */
+    ///
+    /// Display all stream formats.
+    ///
     int cmd_view_stream_formats(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Display information for the specified descriptor using the current end station, entity, and configuration setting.
-     */
+    ///
+    /// Display information for the specified descriptor using the current end station, entity, and configuration setting.
+    ///
     int cmd_view_descriptor(int total_matched, std::vector<cli_argument*> args);
 
     int do_view_descriptor(std::string desc_name, uint16_t desc_index);
 
-    /**
-     * Display all the available instreams for all End Stations.
-     */
+    ///
+    /// Display all the available instreams for all End Stations.
+    ///
     int cmd_connect(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Display all the available outstreams for all End Stations that can connect with the instreams.
-     */
+    ///
+    /// Display all the available outstreams for all End Stations that can connect with the instreams.
+    ///
     int cmd_connect_dst(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Send a CONNECT_RX command to connect Listener sink stream.
-     */
+    ///
+    /// Send a CONNECT_RX command to connect Listener sink stream.
+    ///
     int cmd_connect_rx(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Send a CONNECT_RX command to disconnect Listener sink stream.
-     */
+    ///
+    /// Send a CONNECT_RX command to disconnect Listener sink stream.
+    ///
     int cmd_disconnect_rx(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Display all current connections.
-     */
+    ///
+    /// Display all current connections.
+    ///
     int cmd_show_connections(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Send a GET_TX_STATE command to get Talker source stream connection state.
-     */
+    ///
+    /// Send a GET_TX_STATE command to get Talker source stream connection state.
+    ///
     int cmd_get_tx_state(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Send a GET_RX_STATE command to get Listener sink stream connection state.
-     */
+    ///
+    /// Send a GET_RX_STATE command to get Listener sink stream connection state.
+    ///
     int cmd_get_rx_state(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Send a GET_TX_CONNECTION command with a notification id to get a specific Talker connection information.
-     */
+    ///
+    /// Send a GET_TX_CONNECTION command with a notification id to get a specific Talker connection information.
+    ///
     int cmd_get_tx_connection(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Send an ACQUIRE_ENTITY command to obtain exclusive access to an entire Entity or a sub-tree of objects.
-     */
+    ///
+    /// Send an ACQUIRE_ENTITY command to obtain exclusive access to an entire Entity or a sub-tree of objects.
+    ///
     int cmd_acquire_entity(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Send a LOCK_ENTITY command to provide short term exclusive access to the AVDECC Entity to perform atomic operations.
-     */
+    ///
+    /// Send a LOCK_ENTITY command to provide short term exclusive access to the AVDECC Entity to perform atomic operations.
+    ///
     int cmd_lock_entity(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Send a ENTITY_AVAILABLE command to determine if another AVDECC Entity is still alive.
-     */
+    ///
+    /// Send a ENTITY_AVAILABLE command to determine if another AVDECC Entity is still alive.
+    ///
     int cmd_entity_avail(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Send a REGISTER_UNSOLICITED_NOTIFICATION command to add the controller as being interested
-     * in receiving unsolicited response notifications.
-     */
+    ///
+    /// Send a REGISTER_UNSOLICITED_NOTIFICATION command to add the controller as being interested
+    /// in receiving unsolicited response notifications.
+    ///
     int cmd_register_unsolicited_notif(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Send a DEREGISTER_UNSOLICITED_NOTIFICATION command to remove the controller as being interested
-     * in receiving unsolicited response notifications.
-     */
+    ///
+    /// Send a DEREGISTER_UNSOLICITED_NOTIFICATION command to remove the controller as being interested
+    /// in receiving unsolicited response notifications.
+    ///
     int cmd_deregister_unsolicited_notif(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Send a REBOOT command to reboot the entity
-     */
+    ///
+    /// Send a REBOOT command to reboot the entity
+    ///
     int cmd_reboot(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Send a CONTROLLER_AVAILABLE command to determine if an AVDECC Controller is still alive.
-     */
+    ///
+    /// Send a CONTROLLER_AVAILABLE command to determine if an AVDECC Controller is still alive.
+    ///
     int cmd_controller_avail(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Send a READ_DESCRIPTOR command to read a descriptor from an AVDECC Entity.
-     */
+    ///
+    /// Send a READ_DESCRIPTOR command to read a descriptor from an AVDECC Entity.
+    ///
     int cmd_read_descriptor(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Send a GET_AUDIO_MAP command to fetch the dynamic mapping between the Audio Clusters and
-     * the input or output Streams.
-     */
+    ///
+    /// Send a GET_AUDIO_MAP command to fetch the dynamic mapping between the Audio Clusters and
+    /// the input or output Streams.
+    ///
     int cmd_get_audio_map(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Send a ADD_PENDING_AUDIO_MAPPING command to add a mapping entry to a library queue.
-     */
+    ///
+    /// Send a ADD_PENDING_AUDIO_MAPPING command to add a mapping entry to a library queue.
+    ///
     int cmd_store_pending_audio_mapping(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Send a GET_PENDING_AUDIO_MAPPINGS command to view queued mappings.
-     */
+    ///
+    /// Send a GET_PENDING_AUDIO_MAPPINGS command to view queued mappings.
+    ///
     int cmd_get_pending_audio_mappings(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Send a CLEAR_PENDING_AUDIO_MAPPINGS command to clear queued mappings.
-     */
+    ///
+    /// Send a CLEAR_PENDING_AUDIO_MAPPINGS command to clear queued mappings.
+    ///
     int cmd_clear_pending_audio_mappings(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Send a ADD_AUDIO_MAPPINGS command to send queued mapping entries indicating dynamic mappings
-     * between the Audio Clusters and the input or output Streams
-     */
+    ///
+    /// Send a ADD_AUDIO_MAPPINGS command to send queued mapping entries indicating dynamic mappings
+    /// between the Audio Clusters and the input or output Streams
+    ///
     int cmd_add_audio_mappings(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Send a REMOVE_AUDIO_MAPPINGS command to remove the queued selected dynamic mappings.
-     */
+    ///
+    /// Send a REMOVE_AUDIO_MAPPINGS command to remove the queued selected dynamic mappings.
+    ///
     int cmd_remove_audio_mappings(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Send a SET_STREAM_FORMAT command to change the format of a stream.
-     */
+    ///
+    /// Send a SET_STREAM_FORMAT command to change the format of a stream.
+    ///
     int cmd_set_stream_format(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Send a GET_STREAM_FORMAT command with nofitication id to fetch the current format of a stream.
-     */
+    ///
+    /// Send a GET_STREAM_FORMAT command with nofitication id to fetch the current format of a stream.
+    ///
     int cmd_get_stream_format(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Send a SET_STREAM_INFO command to change a stream info field value to a new value.
-     */
+    ///
+    /// Send a SET_STREAM_INFO command to change a stream info field value to a new value.
+    ///
     int cmd_set_stream_info(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Send a GET_STREAM_INFO command to fetch the current information of a stream.
-     */
+    ///
+    /// Send a GET_STREAM_INFO command to fetch the current information of a stream.
+    ///
     int cmd_get_stream_info(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Send a SET_NAME command to change the value of a name field within a descriptor.
-     */
+    ///
+    /// Send a SET_NAME command to change the value of a name field within a descriptor.
+    ///
     int cmd_set_name(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Send a SET_GROUP_NAME command to change the value of the Entity descriptor group name.
-     */
+    ///
+    /// Send a SET_GROUP_NAME command to change the value of the Entity descriptor group name.
+    ///
     int cmd_set_group_name(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Send a GET_NAME command to fetch the value of a name field within a descriptor.
-     */
+    ///
+    /// Send a GET_NAME command to fetch the value of a name field within a descriptor.
+    ///
     int cmd_get_name(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Send a GET_GROUP_NAME command to fetch the group name of the ENTITY descriptor.
-     */
+    ///
+    /// Send a GET_GROUP_NAME command to fetch the group name of the ENTITY descriptor.
+    ///
     int cmd_get_group_name(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Send a SET_SAMPLING_RATE command to change the sampling rate of a port or unit.
-     */
+    ///
+    /// Send a SET_SAMPLING_RATE command to change the sampling rate of a port or unit.
+    ///
     int cmd_set_sampling_rate(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Send a GET_SAMPLING_RATE command to get the current sampling rate of a port or unit.
-     */
+    ///
+    /// Send a GET_SAMPLING_RATE command to get the current sampling rate of a port or unit.
+    ///
     int cmd_get_sampling_rate(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Send a GET_COUNTERS command to get the current counters of a descriptor.
-     */
+    ///
+    /// Send a GET_COUNTERS command to get the current counters of a descriptor.
+    ///
     int cmd_get_counters(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Send a SET_CLOCK_SOURCE command to change the clock source of a clock domain.
-     */
+    ///
+    /// Send a SET_CLOCK_SOURCE command to change the clock source of a clock domain.
+    ///
     int cmd_set_clock_source(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Send a GET_CLOCK_SOURCE command to get the current clock source of a clock domain.
-     */
+    ///
+    /// Send a GET_CLOCK_SOURCE command to get the current clock source of a clock domain.
+    ///
     int cmd_get_clock_source(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Send a GET_AVB_INFO command to get the dynamic AVB information for an AVB_INTERFACE.
-     */
+    ///
+    /// Send a GET_AVB_INFO command to get the dynamic AVB information for an AVB_INTERFACE.
+    ///
     int cmd_get_avb_info(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Send a START_STREAMING command with a notification id to start streaming on a previously connected stream that was connected
-     * via ACMP or has previously been stopped with the STOP_STREAMING command.
-     */
+    ///
+    /// Send a START_STREAMING command with a notification id to start streaming on a previously connected stream that was connected
+    /// via ACMP or has previously been stopped with the STOP_STREAMING command.
+    ///
     int cmd_start_streaming(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Send a STOP_STREAMING command with a notification id to stop a connected stream for streaming media.
-     */
+    ///
+    /// Send a STOP_STREAMING command with a notification id to stop a connected stream for streaming media.
+    ///
     int cmd_stop_streaming(int total_matched, std::vector<cli_argument*> args);
 
     int cmd_firmware_upgrade(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Send a IDENTIFY command to enable identification.
-     */
+    ///
+    /// Send a IDENTIFY command to enable identification.
+    ///
     int cmd_identify_on(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Send a IDENTIFY command to disable identification.
-     */
+    ///
+    /// Send a IDENTIFY command to disable identification.
+    ///
     int cmd_identify_off(int total_matched, std::vector<cli_argument*> args);
 
     void do_identify(uint32_t end_station_index, bool turn_on);
 
-    /**
-     * Display the location of the redirected output file.
-     */
+    ///
+    /// Display the location of the redirected output file.
+    ///
     int cmd_show_path(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Change the path of the redirected output file.
-     */
+    ///
+    /// Change the path of the redirected output file.
+    ///
     int cmd_set_path(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Clear the screen.
-     */
+    ///
+    /// Clear the screen.
+    ///
     int cmd_clr(int total_matched, std::vector<cli_argument*> args);
 
-    /**
-     * Get the next unique notification id.
-     */
+    ///
+    /// Get the next unique notification id.
+    ///
     uint32_t get_next_notification_id();
 
-    /**
-     * Check if end station, entity, and configuration setting is in range and valid.
-     */
+    ///
+    /// Check if end station, entity, and configuration setting is in range and valid.
+    ///
     bool is_setting_valid(uint32_t end_station, uint16_t entity, uint16_t config);
 };
 

--- a/controller/app/cmdline/src/cmd_line_help.h
+++ b/controller/app/cmdline/src/cmd_line_help.h
@@ -38,24 +38,24 @@ private:
 public:
     cmd_line_help();
 
-    /**
-     * Constructor for cmd_line_help used for constructing an object with a command and description.
-     */
+    ///
+    /// Constructor for cmd_line_help used for constructing an object with a command and description.
+    ///
     cmd_line_help(const std::string cmd, const std::string desc);
 
-    /**
-     * Destructor for cmd_line_help used for destroying objects
-     */
+    ///
+    /// Destructor for cmd_line_help used for destroying objects
+    ///
     ~cmd_line_help();
 
-    /**
-     * Get the command name.
-     */
+    ///
+    /// Get the command name.
+    ///
     const std::string get_command();
 
-    /**
-     * Get the command description.
-     */
+    ///
+    /// Get the command description.
+    ///
     const std::string get_description();
 };
 

--- a/controller/lib/include/audio_cluster_descriptor.h
+++ b/controller/lib/include/audio_cluster_descriptor.h
@@ -42,9 +42,9 @@ namespace avdecc_lib
     class audio_cluster_descriptor : public virtual descriptor_base
     {
     public:
-        /**
-         * \return the audio_cluster descriptor response class.
-         */
+        ///
+        /// \return the audio_cluster descriptor response class.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual audio_cluster_descriptor_response * STDCALL get_audio_cluster_response() = 0;
     };
 }

--- a/controller/lib/include/audio_cluster_descriptor_response.h
+++ b/controller/lib/include/audio_cluster_descriptor_response.h
@@ -42,60 +42,60 @@ namespace avdecc_lib
     {
     public:
         virtual ~audio_cluster_descriptor_response() {};
-        /**
-         * \return The localized string reference pointing to the localized descriptor name.
-         */
+        ///
+        /// \return The localized string reference pointing to the localized descriptor name.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL localized_description() = 0;
 
-        /**
-         * \return The descriptor type for the signal source of the cluster.
-         */
+        ///
+        /// \return The descriptor type for the signal source of the cluster.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL signal_type() = 0;
 
-        /**
-         * \return The descriptor index for the signal source of the cluster.
-         */
+        ///
+        /// \return The descriptor index for the signal source of the cluster.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL signal_index() = 0;
 
-        /**
-         * \return The index of the output of the signal source of the cluster. For a signal type of
-         *	       Signal Splitter or Signal Demultiplexer, this is which output of the object it is
-         *	       being source from, for a signal type of Matrix, this is the column the signal is
-         *	       from and for any other signal type this is 0.
-         */
+        ///
+        /// \return The index of the output of the signal source of the cluster. For a signal type of
+        ///	       Signal Splitter or Signal Demultiplexer, this is which output of the object it is
+        ///	       being source from, for a signal type of Matrix, this is the column the signal is
+        ///	       from and for any other signal type this is 0.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL signal_output() = 0;
 
-        /**
-         * \return The latency in nanoseconds between the timing reference plane and the opposite end
-         *	       of the currently selected signal path. This does not include any latency added by a
-         *	       delay control. The path latency is used to inform smart Controllers of the extra
-         *	       latency to get the samples to the output, so that output across multiple entries
-         *	       can be sample aligned.
-         */
+        ///
+        /// \return The latency in nanoseconds between the timing reference plane and the opposite end
+        ///	       of the currently selected signal path. This does not include any latency added by a
+        ///	       delay control. The path latency is used to inform smart Controllers of the extra
+        ///	       latency to get the samples to the output, so that output across multiple entries
+        ///	       can be sample aligned.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL path_latency() = 0;
 
-        /**
-         * \return The block latency of the Audio Cluster. For an Aduio Cluster attached to a Stream Port Input,
-         *	       this is the latency in nanoseconds between the reference plane and the output of the cluster. For
-         *	       an Audio Cluster attached to a Stream Port Output, this is the latency in nanoseconds between the
-         *	       output of the previous block's output and the reference plane. The previous block is the object
-         *	       identified by the signal type and signal index fields.
-         */
+        ///
+        /// \return The block latency of the Audio Cluster. For an Aduio Cluster attached to a Stream Port Input,
+        ///	       this is the latency in nanoseconds between the reference plane and the output of the cluster. For
+        ///	       an Audio Cluster attached to a Stream Port Output, this is the latency in nanoseconds between the
+        ///	       output of the previous block's output and the reference plane. The previous block is the object
+        ///	       identified by the signal type and signal index fields.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL block_latency() = 0;
 
-        /**
-         * \return The number of channels within the cluster.
-         */
+        ///
+        /// \return The number of channels within the cluster.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL channel_count() = 0;
 
-        /**
-         * The format for each channel of this cluster, all channels within the cluster have the same format.
-         *
-         * \return 0x00 (IEC 60958) for IEC 60958 encoded Audio Cluster. \n
-         *	       0x40 (MBLA) for Multi-bit Linear Audio. \n
-         *	       0x80 (MIDI) for MIDI data. \n
-         *	       0x88 (SMPTE) for SMPTE data.
-         */
+        ///
+        /// The format for each channel of this cluster, all channels within the cluster have the same format.
+        ///
+        /// \return 0x00 (IEC 60958) for IEC 60958 encoded Audio Cluster. \n
+        ///	       0x40 (MBLA) for Multi-bit Linear Audio. \n
+        ///	       0x80 (MIDI) for MIDI data. \n
+        ///	       0x88 (SMPTE) for SMPTE data.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint8_t STDCALL format() = 0;
     };
 }

--- a/controller/lib/include/audio_map_descriptor.h
+++ b/controller/lib/include/audio_map_descriptor.h
@@ -44,9 +44,9 @@ namespace avdecc_lib
     class audio_map_descriptor : public virtual descriptor_base
     {
     public:
-        /**
-         * \return the audio_map descriptor response class.
-         */
+        ///
+        /// \return the audio_map descriptor response class.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual audio_map_descriptor_response * STDCALL get_audio_map_response() = 0;
     };
 }

--- a/controller/lib/include/audio_map_descriptor_response.h
+++ b/controller/lib/include/audio_map_descriptor_response.h
@@ -52,16 +52,16 @@ namespace avdecc_lib
     {
     public:
         virtual ~audio_map_descriptor_response() {};
-        /**
-         * \return The number of channel mappings within the Audio Map. The maximum value
-         *	       of this field is 62 for this version of AEM.
-         */
+        ///
+        /// \return The number of channel mappings within the Audio Map. The maximum value
+        ///	       of this field is 62 for this version of AEM.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_mappings() = 0;
-        /**
-         * \param index The index of the mapping to return.
-         * \param mapping The mapping structure that is filled in by this funtion.
-         * \return Returns 0 on success.
-         */
+        ///
+        /// \param index The index of the mapping to return.
+        /// \param mapping The mapping structure that is filled in by this funtion.
+        /// \return Returns 0 on success.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int const STDCALL mapping(size_t index, struct audio_map_mapping &mapping) = 0;
     };
 }

--- a/controller/lib/include/audio_unit_descriptor.h
+++ b/controller/lib/include/audio_unit_descriptor.h
@@ -42,39 +42,39 @@ namespace avdecc_lib
     class audio_unit_descriptor : public virtual descriptor_base
     {
     public:
-        /**
-         * \return the audio_unit descriptor response class.
-         */
+        ///
+        /// \return the audio_unit descriptor response class.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual audio_unit_descriptor_response * STDCALL get_audio_unit_response() = 0;
 
-        /**
-         * \return the audio_unit get_sampling_rate response class.
-         */
+        ///
+        /// \return the audio_unit get_sampling_rate response class.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual audio_unit_get_sampling_rate_response * STDCALL get_audio_unit_get_sampling_rate_response() = 0;
 
-        /**
-         * Send a SET_SAMPLING_RATE command to change the sampling rate of a port or unit.
-         *
-         * \param notification_id A void pointer to the unique identifier associated with the command.
-         * \param new_sampling_rate The sampling rate field is set to the new sampling rate.
-         *
-         * The new sampling rates can be retrieved by calling the following function after successfully
-         * receiving a response back for the SET_SAMPLING_RATE command sent.
-         *
-         * \see set_sampling_rate_sampling_rate()
-         */
+        ///
+        /// Send a SET_SAMPLING_RATE command to change the sampling rate of a port or unit.
+        ///
+        /// \param notification_id A void pointer to the unique identifier associated with the command.
+        /// \param new_sampling_rate The sampling rate field is set to the new sampling rate.
+        ///
+        /// The new sampling rates can be retrieved by calling the following function after successfully
+        /// receiving a response back for the SET_SAMPLING_RATE command sent.
+        ///
+        /// \see set_sampling_rate_sampling_rate()
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_set_sampling_rate_cmd(void *notification_id, uint32_t new_sampling_rate) = 0;
 
-        /**
-         * Send a GET_SAMPLING_RATE command to get the current sampling rate of a port or unit.
-         *
-         * \param notification_id A void pointer to the unique identifier associated with the command.
-         *
-         * The sampling rates can be retrieved by calling the following function after successfully
-         * receiving a response back for the GET_SAMPLING_RATE command sent.
-         *
-         * \see get_sampling_rate_sampling_rate()
-         */
+        ///
+        /// Send a GET_SAMPLING_RATE command to get the current sampling rate of a port or unit.
+        ///
+        /// \param notification_id A void pointer to the unique identifier associated with the command.
+        ///
+        /// The sampling rates can be retrieved by calling the following function after successfully
+        /// receiving a response back for the GET_SAMPLING_RATE command sent.
+        ///
+        /// \see get_sampling_rate_sampling_rate()
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_get_sampling_rate_cmd(void *notification_id) = 0;
     };
 }

--- a/controller/lib/include/audio_unit_descriptor_response.h
+++ b/controller/lib/include/audio_unit_descriptor_response.h
@@ -41,189 +41,189 @@ namespace avdecc_lib
     {
     public:
         virtual ~audio_unit_descriptor_response() {};
-        /**
-         * \return The localized string reference pointing to the localized descriptor name.
-         */
+        ///
+        /// \return The localized string reference pointing to the localized descriptor name.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL localized_description() = 0;
 
-        /**
-         * \return The descriptor index of the Clock Domain descriptor describing the clock domain for the Audio Unit.
-         */
+        ///
+        /// \return The descriptor index of the Clock Domain descriptor describing the clock domain for the Audio Unit.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL clock_domain_index() = 0;
 
-        /**
-         * \return The number of Input Stream Ports used by this Audio Unit.
-         */
+        ///
+        /// \return The number of Input Stream Ports used by this Audio Unit.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_stream_input_ports() = 0;
 
-        /**
-         * \return The index of the first Stream Port Input descriptor.
-         */
+        ///
+        /// \return The index of the first Stream Port Input descriptor.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_stream_input_port() = 0;
 
-        /**
-         * \return The number of Output Stream Ports used by this Audio Unit.
-         */
+        ///
+        /// \return The number of Output Stream Ports used by this Audio Unit.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_stream_output_ports() = 0;
 
-        /**
-         * \return The index of the first Stream Port Output descriptor.
-         */
+        ///
+        /// \return The index of the first Stream Port Output descriptor.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_stream_output_port() = 0;
 
-        /**
-         * \return The number of external Input Ports used by this Audio Unit.
-         */
+        ///
+        /// \return The number of external Input Ports used by this Audio Unit.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_external_input_ports() = 0;
 
-        /**
-         * \return The index of the first External Port Input descriptor.
-         */
+        ///
+        /// \return The index of the first External Port Input descriptor.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_external_input_port() = 0;
 
-        /**
-         * \return The number of external Output Ports used by this Audio Unit.
-         */
+        ///
+        /// \return The number of external Output Ports used by this Audio Unit.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_external_output_ports() = 0;
 
-        /**
-         * \return The index of the first External Port Output descriptor.
-         */
+        ///
+        /// \return The index of the first External Port Output descriptor.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_external_output_port() = 0;
 
-        /**
-         * \return The number of internal Input Ports used by this Audio Unit.
-         */
+        ///
+        /// \return The number of internal Input Ports used by this Audio Unit.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_internal_input_ports() = 0;
 
-        /**
-         * \return The index of the first input Internal JACK INPUT and Internal Port Input descriptors.
-         */
+        ///
+        /// \return The index of the first input Internal JACK INPUT and Internal Port Input descriptors.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_internal_input_port() = 0;
 
-        /**
-         * \return The number of internal Output Ports used by this Audio Unit.
-         */
+        ///
+        /// \return The number of internal Output Ports used by this Audio Unit.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_internal_output_ports() = 0;
 
-        /**
-         * \return The index of the first output Internal JACK OUTPUT and Internal Port Output descriptors.
-         */
+        ///
+        /// \return The index of the first output Internal JACK OUTPUT and Internal Port Output descriptors.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_internal_output_port() = 0;
 
-        /**
-         * \return The number of controls within this Audio Unit.
-         */
+        ///
+        /// \return The number of controls within this Audio Unit.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_controls() = 0;
 
-        /**
-         * \return The index of the first Control descriptor.
-         */
+        ///
+        /// \return The index of the first Control descriptor.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_control() = 0;
 
-        /**
-         * \return The number of signal selectors within this Audio Unit.
-         */
+        ///
+        /// \return The number of signal selectors within this Audio Unit.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_signal_selectors() = 0;
 
-        /**
-         * \return The index of the first Signal Selector descriptor.
-         */
+        ///
+        /// \return The index of the first Signal Selector descriptor.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_signal_selector() = 0;
 
-        /**
-         * \return The number of mixers within this Audio Unit.
-         */
+        ///
+        /// \return The number of mixers within this Audio Unit.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_mixers() = 0;
 
-        /**
-         * \return The index of the first Mixer descriptor.
-         */
+        ///
+        /// \return The index of the first Mixer descriptor.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_mixer() = 0;
 
-        /**
-         * \return The number of matrices within this Audio Unit.
-         */
+        ///
+        /// \return The number of matrices within this Audio Unit.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_matrices() = 0;
 
-        /**
-         * \return The index of the first Matrix descriptor.
-         */
+        ///
+        /// \return The index of the first Matrix descriptor.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_matrix() = 0;
 
-        /**
-         * \return The number of splitters within this Audio Unit.
-         */
+        ///
+        /// \return The number of splitters within this Audio Unit.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_splitters() = 0;
 
-        /**
-         * \return The index of the first Signal Splitter descriptor.
-         */
+        ///
+        /// \return The index of the first Signal Splitter descriptor.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_splitter() = 0;
 
-        /**
-         * \return The number of combiners within this Audio Unit.
-         */
+        ///
+        /// \return The number of combiners within this Audio Unit.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_combiners() = 0;
 
-        /**
-         * \return index of the first Signal Combiner descriptor.
-         */
+        ///
+        /// \return index of the first Signal Combiner descriptor.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_combiner() = 0;
 
-        /**
-         * \return The number of demultiplexers within this Audio Unit.
-         */
+        ///
+        /// \return The number of demultiplexers within this Audio Unit.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_demultiplexers() = 0;
 
-        /**
-         * \return The index of the first Signal Demultiplexer descriptor.
-         */
+        ///
+        /// \return The index of the first Signal Demultiplexer descriptor.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_demultiplexer() = 0;
 
-        /**
-         * \return The number of multiplexers within this Audio Unit.
-         */
+        ///
+        /// \return The number of multiplexers within this Audio Unit.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_multiplexers() = 0;
 
-        /**
-         * \return The index of the first Multiplexer descriptor..
-         */
+        ///
+        /// \return The index of the first Multiplexer descriptor..
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_multiplexer() = 0;
 
-        /**
-         * \return The number of transcoders within this Audio Unit.
-         */
+        ///
+        /// \return The number of transcoders within this Audio Unit.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_transcoders() = 0;
 
-        /**
-         * \return The index of the first Signal Transcoder descriptor.
-         */
+        ///
+        /// \return The index of the first Signal Transcoder descriptor.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_transcoder() = 0;
 
-        /**
-         * \return The number of control blocks within this Audio Unit.
-         */
+        ///
+        /// \return The number of control blocks within this Audio Unit.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_control_blocks() = 0;
 
-        /**
-         * \return The index of the first Control Block descriptor.
-         */
+        ///
+        /// \return The index of the first Control Block descriptor.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_control_block() = 0;
 
-        /**
-         * \return The current sampling rate of this Audio Unit.
-         */
+        ///
+        /// \return The current sampling rate of this Audio Unit.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL current_sampling_rate() = 0;
 
-        /**
-         * \return The corresponding sampling rate by index of this Audio Unit.
-         */
+        ///
+        /// \return The corresponding sampling rate by index of this Audio Unit.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_sampling_rate_by_index(size_t sampling_rate_index) = 0;
 
-        /**
-         * \return The number of sample rates. The maximum value is 91 for this version of AEM.
-         */
+        ///
+        /// \return The number of sample rates. The maximum value is 91 for this version of AEM.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL sampling_rates_count() = 0;
     };
 }

--- a/controller/lib/include/audio_unit_get_sampling_rate_response.h
+++ b/controller/lib/include/audio_unit_get_sampling_rate_response.h
@@ -38,10 +38,10 @@ namespace avdecc_lib
     {
     public:
         virtual ~audio_unit_get_sampling_rate_response() {};
-        /**
-         * \return The sampling rate of a port or unit after sending a GET_SAMPLING_RATE command and
-         *	       receiving a response back for the command.
-         */
+        ///
+        /// \return The sampling rate of a port or unit after sending a GET_SAMPLING_RATE command and
+        ///	       receiving a response back for the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_sampling_rate_sampling_rate() = 0;
     };
 }

--- a/controller/lib/include/avb_counters_response.h
+++ b/controller/lib/include/avb_counters_response.h
@@ -38,18 +38,18 @@ namespace avdecc_lib
     {
     public:
         virtual ~avb_counters_response() {};
-        /**
-         * \param name avdecc_lib::counter_labels
-         *
-         * \return the avb counter valid after the GET_COUNTERS command.
-         */
+        ///
+        /// \param name avdecc_lib::counter_labels
+        ///
+        /// \return the avb counter valid after the GET_COUNTERS command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_counter_valid(int name) = 0;
 
-        /**
-         * \param name avdecc_lib::counter_labels
-         *
-         * \return the avb counter by name after the GET_COUNTERS command.
-         */
+        ///
+        /// \param name avdecc_lib::counter_labels
+        ///
+        /// \return the avb counter by name after the GET_COUNTERS command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_counter_by_name(int name) = 0;
     };
 }

--- a/controller/lib/include/avb_interface_descriptor.h
+++ b/controller/lib/include/avb_interface_descriptor.h
@@ -45,30 +45,29 @@ namespace avdecc_lib
     class avb_interface_descriptor : public virtual descriptor_base
     {
     public:
-        /**
-         * \return the avb_interface descriptor response class.
-         */
+        ///
+        /// \return the avb_interface descriptor response class.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual avb_interface_descriptor_response * STDCALL get_avb_interface_response() = 0;
 
-        /**
-         * \return the avb_interface descriptor counters response class.
-         */
+        ///
+        /// \return the avb_interface descriptor counters response class.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual avb_counters_response * STDCALL get_avb_interface_counters_response() = 0;
 
-        /**
-         * \return the avb_interface get avb info response class.
-         */
-        AVDECC_CONTROLLER_LIB32_API virtual avb_interface_get_avb_info_response *
-        STDCALL get_avb_interface_get_avb_info_response() = 0;
+        ///
+        /// \return the avb_interface get avb info response class.
+        ///
+        AVDECC_CONTROLLER_LIB32_API virtual avb_interface_get_avb_info_response * STDCALL get_avb_interface_get_avb_info_response() = 0;
 
-        /**
-         * Send a GET_COUNTERS command to get the avb_interface counters of the AVDECC Entity.
-         */
+        ///
+        /// Send a GET_COUNTERS command to get the avb_interface counters of the AVDECC Entity.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_get_counters_cmd(void *notification_id) = 0;
 
-        /**
-         * Send a GET_AVB_INFO command to get the dynamic AVB information for an AVB_INTERFACE.
-         */
+        ///
+        /// Send a GET_AVB_INFO command to get the dynamic AVB information for an AVB_INTERFACE.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_get_avb_info_cmd(void *notification_id) = 0;
     };
 }

--- a/controller/lib/include/avb_interface_descriptor_response.h
+++ b/controller/lib/include/avb_interface_descriptor_response.h
@@ -43,78 +43,78 @@ namespace avdecc_lib
     public:
         virtual ~avb_interface_descriptor_response() {};
 
-        /**
-         * \return The localized string reference pointing to the localized descriptor name.
-         */
+        ///
+        /// \return The localized string reference pointing to the localized descriptor name.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL localized_description() = 0;
 
-        /**
-         * \return The MAC address of the interface.
-         */
+        ///
+        /// \return The MAC address of the interface.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL mac_addr() = 0;
 
-        /**
-         * The flags describing the features of the interface.
-         *
-         * \return 1 (GPTP Grandmaster Supported) if the interface supports the grandmaster functionality.
-         * \return 2 (GPTP Supported) if the interface supports the functionality.
-         * \return 4 (SRP Supported) if the interface supports the "Stream Reservation Protocol (SRP)" functionality.
-         */
+        ///
+        /// The flags describing the features of the interface.
+        ///
+        /// \return 1 (GPTP Grandmaster Supported) if the interface supports the grandmaster functionality.
+        /// \return 2 (GPTP Supported) if the interface supports the functionality.
+        /// \return 4 (SRP Supported) if the interface supports the "Stream Reservation Protocol (SRP)" functionality.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL interface_flags() = 0;
 
-        /**
-         * \return The clock identity of the interface.
-         */
+        ///
+        /// \return The clock identity of the interface.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL clock_identity() = 0;
 
-        /**
-         * \return The priority1 field of the grandmaster functionality of the AVB INTERFACE if supported, 0xff otherwise.
-         */
+        ///
+        /// \return The priority1 field of the grandmaster functionality of the AVB INTERFACE if supported, 0xff otherwise.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint8_t STDCALL priority1() = 0;
 
-        /**
-         * \return The clock class field of the grandmaster functionality of the AVB INTERFACE if supported, 0xff otherwise.
-         */
+        ///
+        /// \return The clock class field of the grandmaster functionality of the AVB INTERFACE if supported, 0xff otherwise.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint8_t STDCALL clock_class() = 0;
 
-        /**
-         * \return The offset scaled log variance field of the grandmaster functionality of the AVB INTERFACE if supported, 0 otherwise.
-         */
+        ///
+        /// \return The offset scaled log variance field of the grandmaster functionality of the AVB INTERFACE if supported, 0 otherwise.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL offset_scaled_log_variance() = 0;
 
-        /**
-         * \return The clock accuracy field of the grandmaster functionality of the AVB INTERFACE if supported, 0xff otherwise.
-         */
+        ///
+        /// \return The clock accuracy field of the grandmaster functionality of the AVB INTERFACE if supported, 0xff otherwise.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint8_t STDCALL clock_accuracy() = 0;
 
-        /**
-         * \return The priority2 field of the grandmaster functionality of the AVB INTERFACE if supported, 0xff otherwise.
-         */
+        ///
+        /// \return The priority2 field of the grandmaster functionality of the AVB INTERFACE if supported, 0xff otherwise.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint8_t STDCALL priority2() = 0;
 
-        /**
-         * \return The domain number field of the grandmaster functionality of the AVB INTERFACE if supported, 0 otherwise.
-         */
+        ///
+        /// \return The domain number field of the grandmaster functionality of the AVB INTERFACE if supported, 0 otherwise.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint8_t STDCALL domain_number() = 0;
 
-        /**
-         * \return The current log sync interval field of the grandmaster functionality of the AVB INTERFACE if supported, 0 otherwise.
-         */
+        ///
+        /// \return The current log sync interval field of the grandmaster functionality of the AVB INTERFACE if supported, 0 otherwise.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint8_t STDCALL log_sync_interval() = 0;
 
-        /**
-         * \return The current log announce interval field of the grandmaster functionality of the AVB INTERFACE if supported, 0 otherwise.
-         */
+        ///
+        /// \return The current log announce interval field of the grandmaster functionality of the AVB INTERFACE if supported, 0 otherwise.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint8_t STDCALL log_announce_interval() = 0;
 
-        /**
-         * \return The current log pdelay interval field of the grandmaster functionality of the AVB INTERFACE if supported, 0 otherwise.
-         */
+        ///
+        /// \return The current log pdelay interval field of the grandmaster functionality of the AVB INTERFACE if supported, 0 otherwise.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint8_t STDCALL log_pdelay_interval() = 0;
 
-        /**
-         * \return The port number field as used by the functionality of the AVB INTERFACE if supported, 0 otherwise.
-         */
+        ///
+        /// \return The port number field as used by the functionality of the AVB INTERFACE if supported, 0 otherwise.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL port_number() = 0;
     };
 }

--- a/controller/lib/include/avb_interface_get_avb_info_response.h
+++ b/controller/lib/include/avb_interface_get_avb_info_response.h
@@ -39,40 +39,40 @@ namespace avdecc_lib
     public:
         virtual ~avb_interface_get_avb_info_response() {};
 
-        /**
-         * \return the ClockIdentity of the current IEEE Std 802.1AS-2011 grandmaster as elected on this AVB Interface.
-         */
+        ///
+        /// \return the ClockIdentity of the current IEEE Std 802.1AS-2011 grandmaster as elected on this AVB Interface.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_gptp_grandmaster_id() = 0;
 
-        /**
-         * \return the propagation delay in nanoseconds as reported by the IEEE Std 802.1AS-2011 pDelay mechanism.
-         */
+        ///
+        /// \return the propagation delay in nanoseconds as reported by the IEEE Std 802.1AS-2011 pDelay mechanism.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_propagation_delay() = 0;
 
-        /**
-         * \return the domainNumber of the current IEEE Std 802.1AS-2011 grandmaster as elected on this AVB Interface.
-         */
+        ///
+        /// \return the domainNumber of the current IEEE Std 802.1AS-2011 grandmaster as elected on this AVB Interface.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint8_t STDCALL get_gptp_domain_number() = 0;
 
-        /**
-         * \return the number of mappings present in the msrp_mappings field.
-         */
+        ///
+        /// \return the number of mappings present in the msrp_mappings field.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_msrp_mappings_count() = 0;
 
-        /**
-         * \return True if the IEEE Std 802.1AS-2011 variable asCapable is set on this interface.
-         */
+        ///
+        /// \return True if the IEEE Std 802.1AS-2011 variable asCapable is set on this interface.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL get_avb_info_flags_as_capable() = 0;
 
-        /**
-         * \return True if the interface has the IEEE Std 802.1AS- 2011 functionality enabled.
-         */
+        ///
+        /// \return True if the interface has the IEEE Std 802.1AS- 2011 functionality enabled.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL get_avb_info_flags_gptp_enabled() = 0;
 
-        /**
-         * \return True if the interface has the IEEE Std 802.1Q- 2011 Clause 35,
-         *  “Stream Reservation Protocol (SRP)” functionality enabled.
-         */
+        ///
+        /// \return True if the interface has the IEEE Std 802.1Q- 2011 Clause 35,
+        ///  “Stream Reservation Protocol (SRP)” functionality enabled.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL get_avb_info_flags_srp_enabled() = 0;
     };
 }

--- a/controller/lib/include/clock_domain_counters_response.h
+++ b/controller/lib/include/clock_domain_counters_response.h
@@ -38,18 +38,18 @@ namespace avdecc_lib
     {
     public:
         virtual ~clock_domain_counters_response() {};
-        /**
-         * \param name avdecc_lib::counter_labels
-         *
-         * \return the avb counter valid after the GET_COUNTERS command.
-         */
+        ///
+        /// \param name avdecc_lib::counter_labels
+        ///
+        /// \return the avb counter valid after the GET_COUNTERS command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_counter_valid(int name) = 0;
 
-        /**
-         * \param name avdecc_lib::counter_labels
-         *
-         * \return the avb counter by name after the GET_COUNTERS command.
-         */
+        ///
+        /// \param name avdecc_lib::counter_labels
+        ///
+        /// \return the avb counter by name after the GET_COUNTERS command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_counter_by_name(int name) = 0;
     };
 }

--- a/controller/lib/include/clock_domain_descriptor.h
+++ b/controller/lib/include/clock_domain_descriptor.h
@@ -46,49 +46,49 @@ namespace avdecc_lib
     class clock_domain_descriptor : public virtual descriptor_base
     {
     public:
-        /**
-         * \return the clock_domain descriptor response class.
-         */
+        ///
+        /// \return the clock_domain descriptor response class.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual clock_domain_descriptor_response * STDCALL get_clock_domain_response() = 0;
 
-        /**
-         * \return the clock_domain descriptor counters response class.
-         */
+        ///
+        /// \return the clock_domain descriptor counters response class.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual clock_domain_counters_response * STDCALL get_clock_domain_counters_response() = 0;
 
-        /**
-         * \return the clock_domain get clock source response class.
-         */
+        ///
+        /// \return the clock_domain get clock source response class.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual clock_domain_get_clock_source_response * STDCALL get_clock_domain_get_clock_source_response() = 0;
 
-        /**
-         * Send a SET_CLOCK_SOURCE command to change the CLOCK SOURCE of a CLOCK DOMAIN.
-         *
-         * \param notification_id A void pointer to the unique identifier associated with the command.
-         * \param new_clk_src_index The CLOCK SOURCE index field is set to the new CLOCK SOURCE index.
-         *
-         * The new CLOCK SOURCE index can be retrieved by calling the following function after successfully
-         * receiving a response back for the SET_CLOCK_SOURCE command sent.
-         *
-         * \see set_clock_source_clock_source_index()
-         */
+        ///
+        /// Send a SET_CLOCK_SOURCE command to change the CLOCK SOURCE of a CLOCK DOMAIN.
+        ///
+        /// \param notification_id A void pointer to the unique identifier associated with the command.
+        /// \param new_clk_src_index The CLOCK SOURCE index field is set to the new CLOCK SOURCE index.
+        ///
+        /// The new CLOCK SOURCE index can be retrieved by calling the following function after successfully
+        /// receiving a response back for the SET_CLOCK_SOURCE command sent.
+        ///
+        /// \see set_clock_source_clock_source_index()
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_set_clock_source_cmd(void *notification_id, uint16_t new_clk_src_index) = 0;
 
-        /**
-         * Send a GET_CLOCK_SOURCE command to get the current CLOCK SOURCE of a CLOCK DOMAIN.
-         *
-         * \param notification_id A void pointer to the unique identifier associated with the command.
-         *
-         * The CLOCK SOURCE index can be retrieved by calling the following function after successfully
-         * receiving a response back for the GET_CLOCK_SOURCE command sent.
-         *
-         * \see get_clock_source_clock_source_index()
-         */
+        ///
+        /// Send a GET_CLOCK_SOURCE command to get the current CLOCK SOURCE of a CLOCK DOMAIN.
+        ///
+        /// \param notification_id A void pointer to the unique identifier associated with the command.
+        ///
+        /// The CLOCK SOURCE index can be retrieved by calling the following function after successfully
+        /// receiving a response back for the GET_CLOCK_SOURCE command sent.
+        ///
+        /// \see get_clock_source_clock_source_index()
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_get_clock_source_cmd(void *notification_id) = 0;
 
-        /**
-         * Send a GET_COUNTERS command to get the clock_domain counters of the AVDECC Entity.
-         */
+        ///
+        /// Send a GET_COUNTERS command to get the clock_domain counters of the AVDECC Entity.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_get_counters_cmd(void *notification_id) = 0;
     };
 }

--- a/controller/lib/include/clock_domain_descriptor_response.h
+++ b/controller/lib/include/clock_domain_descriptor_response.h
@@ -45,26 +45,26 @@ namespace avdecc_lib
     public:
         virtual ~clock_domain_descriptor_response() {};
 
-        /**
-         * \return The localized string reference pointing to the localized descriptor name.
-         */
+        ///
+        /// \return The localized string reference pointing to the localized descriptor name.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL localized_description() = 0;
 
-        /**
-         * \return The descriptor index of the CLOCK SOURCE descriptor describing the current CLOCK SOURCE
-         *	       for the CLOCK DOMAIN.
-         */
+        ///
+        /// \return The descriptor index of the CLOCK SOURCE descriptor describing the current CLOCK SOURCE
+        ///	       for the CLOCK DOMAIN.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL clock_source_index() = 0;
 
-        /**
-         * \return The number of CLOCK SOURCE indexes in the clock sources field. The maximum value for this field
-         *	       is 249 for this version of AEM.
-         */
+        ///
+        /// \return The number of CLOCK SOURCE indexes in the clock sources field. The maximum value for this field
+        ///	       is 249 for this version of AEM.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL clock_sources_count() = 0;
 
-        /**
-         * \return The list of CLOCK_SOURCE descriptor indices which the clock_source index may be set to.
-         */
+        ///
+        /// \return The list of CLOCK_SOURCE descriptor indices which the clock_source index may be set to.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_clock_source_by_index(size_t clk_src_index) = 0;
     };
 }

--- a/controller/lib/include/clock_domain_get_clock_source_response.h
+++ b/controller/lib/include/clock_domain_get_clock_source_response.h
@@ -38,10 +38,10 @@ namespace avdecc_lib
     {
     public:
         virtual ~clock_domain_get_clock_source_response() {};
-        /**
-         * \return The stream format of a stream after sending a GET_clock_source command and
-         *	       receiving a response back for the command.
-         */
+        ///
+        /// \return The stream format of a stream after sending a GET_clock_source command and
+        ///	       receiving a response back for the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_clock_source_clock_source_index() = 0;
     };
 }

--- a/controller/lib/include/clock_source_descriptor.h
+++ b/controller/lib/include/clock_source_descriptor.h
@@ -42,9 +42,9 @@ namespace avdecc_lib
     class clock_source_descriptor : public virtual descriptor_base
     {
     public:
-        /**
-         * \return the clock_source descriptor response class.
-         */
+        ///
+        /// \return the clock_source descriptor response class.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual clock_source_descriptor_response * STDCALL get_clock_source_response() = 0;
     };
 }

--- a/controller/lib/include/clock_source_descriptor_response.h
+++ b/controller/lib/include/clock_source_descriptor_response.h
@@ -43,41 +43,41 @@ namespace avdecc_lib
     public:
         virtual ~clock_source_descriptor_response() {};
 
-        /**
-         * \return The localized string reference pointing to the localized descriptor name.
-         */
+        ///
+        /// \return The localized string reference pointing to the localized descriptor name.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL localized_description() = 0;
 
-        /**
-         * The flags describing the capabilities or features of the CLOCK SOURCE.
-         *
-         * \return 1 (Stream ID) if the Input Stream CLOCK SOURCE is identified by the stream ID. \n
-         *	       2 (Local ID) if the Input Stream CLOCK SOURCE is identified by it's local ID.
-         */
+        ///
+        /// The flags describing the capabilities or features of the CLOCK SOURCE.
+        ///
+        /// \return 1 (Stream ID) if the Input Stream CLOCK SOURCE is identified by the stream ID. \n
+        ///	        2 (Local ID) if the Input Stream CLOCK SOURCE is identified by it's local ID.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL clock_source_flags() = 0;
 
-        /**
-         * The type of CLOCK SOURCE.
-         *
-         * \return 0 (Internal) if the clock is sourced from within the entity such as from a crystal oscillator. \n
-         *	       1 (External) if the clock is sourced from an external connection on the entity via a Jack. \n
-         *	       2 (Input Stream) if the clock is sourced from the media clock of an Input Stream.
-         */
+        ///
+        /// The type of CLOCK SOURCE.
+        ///
+        /// \return 0 (Internal) if the clock is sourced from within the entity such as from a crystal oscillator. \n
+        ///	        1 (External) if the clock is sourced from an external connection on the entity via a Jack. \n
+        ///	        2 (Input Stream) if the clock is sourced from the media clock of an Input Stream.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL clock_source_type() = 0;
 
-        /**
-         * \return The identifier of the CLOCK SOURCE.
-         */
+        ///
+        /// \return The identifier of the CLOCK SOURCE.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL clock_source_identifier() = 0;
 
-        /**
-         * \return The descriptor type of the object that this CLOCK SOURCE is associated with.
-         */
+        ///
+        /// \return The descriptor type of the object that this CLOCK SOURCE is associated with.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL clock_source_location_type() = 0;
 
-        /**
-         * \return The descriptor index of the object that this CLOCK SOURCE is associated with.
-         */
+        ///
+        /// \return The descriptor index of the object that this CLOCK SOURCE is associated with.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL clock_source_location_index() = 0;
     };
 }

--- a/controller/lib/include/configuration_descriptor.h
+++ b/controller/lib/include/configuration_descriptor.h
@@ -62,232 +62,232 @@ namespace avdecc_lib
     class configuration_descriptor : public virtual descriptor_base
     {
     public:
-        /**
-         * \return The name of the descriptor object. This may be user set through the use of a SET_NAME command.
-         *	   The object name should be left blank (all zeros) by the manufacturer, with the manufacturer
-         *	   defined value being provided in a localized form via the localized descripton field. By leaving
-         *	   this field blank an AVDECC Controller can determine if the user has overridden the name and can
-         *	   use this name rather than the localized name.
-         */
+        ///
+        /// \return The name of the descriptor object. This may be user set through the use of a SET_NAME command.
+        ///	   The object name should be left blank (all zeros) by the manufacturer, with the manufacturer
+        ///	   defined value being provided in a localized form via the localized descripton field. By leaving
+        ///	   this field blank an AVDECC Controller can determine if the user has overridden the name and can
+        ///	   use this name rather than the localized name.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint8_t * STDCALL object_name() = 0;
-        /**
-         * \return The number of descriptor counts. The maximum value for this field is 108 for this version of AEM.
-         */
+        ///
+        /// \return The number of descriptor counts. The maximum value for this field is 108 for this version of AEM.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL descriptor_counts_count() = 0;
 
-        /**
-         * \return The top level descriptor present in the CONFIGURATION descriptor.
-         */
+        ///
+        /// \return The top level descriptor present in the CONFIGURATION descriptor.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_desc_type_from_config_by_index(int desc_index) = 0;
 
-        /**
-         * \return The count of the top level descriptor present in the CONFIGURATION descriptor.
-         */
+        ///
+        /// \return The count of the top level descriptor present in the CONFIGURATION descriptor.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_desc_count_from_config_by_index(int desc_index) = 0;
 
-        /**
-         * \return True if the descriptor type and descriptor count index are valid and present in the current configuration.
-         */
+        ///
+        /// \return True if the descriptor type and descriptor count index are valid and present in the current configuration.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL are_desc_type_and_index_in_config(int desc_type, int desc_count_index) = 0;
 
-        /**
-         * \return The number of ENTITY descriptors present in the current configuration.
-         */
+        ///
+        /// \return The number of ENTITY descriptors present in the current configuration.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual size_t STDCALL entity_desc_count() = 0;
 
-        /**
-         * \return The number of AUDIO UNIT descriptors present in the current configuration.
-         */
+        ///
+        /// \return The number of AUDIO UNIT descriptors present in the current configuration.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual size_t STDCALL audio_unit_desc_count() = 0;
 
-        /**
-         * \return The number of STREAM INPUT descriptors present in the current configuration.
-         */
+        ///
+        /// \return The number of STREAM INPUT descriptors present in the current configuration.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual size_t STDCALL stream_input_desc_count() = 0;
 
-        /**
-         * \return The number of STREAM OUTPUT descriptors present in the current configuration.
-         */
+        ///
+        /// \return The number of STREAM OUTPUT descriptors present in the current configuration.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual size_t STDCALL stream_output_desc_count() = 0;
 
-        /**
-         * \return The number of JACK INPUT descriptors present in the current configuration.
-         */
+        ///
+        /// \return The number of JACK INPUT descriptors present in the current configuration.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual size_t STDCALL jack_input_desc_count() = 0;
 
-        /**
-         * \return The number of JACK OUTPUT descriptors present in the current configuration.
-         */
+        ///
+        /// \return The number of JACK OUTPUT descriptors present in the current configuration.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual size_t STDCALL jack_output_desc_count() = 0;
 
-        /**
-         * \return The number of AVB INTERFACE descriptors present in the current configuration.
-         */
+        ///
+        /// \return The number of AVB INTERFACE descriptors present in the current configuration.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual size_t STDCALL avb_interface_desc_count() = 0;
 
-        /**
-         * \return The number of CLOCK SOURCE descriptors present in the current configuration.
-         */
+        ///
+        /// \return The number of CLOCK SOURCE descriptors present in the current configuration.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual size_t STDCALL clock_source_desc_count() = 0;
 
-        /**
-         * \return The number of MEMORY OBJECT descriptors present in the current configuration.
-         */
+        ///
+        /// \return The number of MEMORY OBJECT descriptors present in the current configuration.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual size_t STDCALL memory_object_desc_count() = 0;
 
-        /**
-         * \return The number of LOCALE descriptors present in the current configuration.
-         */
+        ///
+        /// \return The number of LOCALE descriptors present in the current configuration.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual size_t STDCALL locale_desc_count() = 0;
 
-        /**
-         * \return The strings descriptor index and the string index for the string corresponding to a particular localized description.
-         */
+        ///
+        /// \return The strings descriptor index and the string index for the string corresponding to a particular localized description.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL get_strings_desc_string_by_reference(size_t reference, size_t &string_desc_index, size_t &string_index) = 0;
 
-        /**
-         * \return The number of Strings descriptors present in the current configuration.
-         */
+        ///
+        /// \return The number of Strings descriptors present in the current configuration.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual size_t STDCALL strings_desc_count() = 0;
 
-        /**
-         * \return The number of Stream Port Input descriptors present in the current configuration.
-         */
+        ///
+        /// \return The number of Stream Port Input descriptors present in the current configuration.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual size_t STDCALL stream_port_input_desc_count() = 0;
 
-        /**
-         * \return The number of Stream Port Output descriptors present in the current configuration.
-         */
+        ///
+        /// \return The number of Stream Port Output descriptors present in the current configuration.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual size_t STDCALL stream_port_output_desc_count() = 0;
 
-        /**
-         * \return The number of Audio Cluster descriptors present in the current configuration.
-         */
+        ///
+        /// \return The number of Audio Cluster descriptors present in the current configuration.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual size_t STDCALL audio_cluster_desc_count() = 0;
 
-        /**
-         * \return The number of Audio Map descriptors present in the current configuration.
-         */
+        ///
+        /// \return The number of Audio Map descriptors present in the current configuration.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual size_t STDCALL audio_map_desc_count() = 0;
 
-        /**
-         * \return The number of CLOCK DOMAIN descriptors present in the current configuration.
-         */
+        ///
+        /// \return The number of CLOCK DOMAIN descriptors present in the current configuration.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual size_t STDCALL clock_domain_desc_count() = 0;
 
-        /**
-         * \return The number of CONTROL descriptors present in the current configuration.
-         */
+        ///
+        /// \return The number of CONTROL descriptors present in the current configuration.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual size_t STDCALL control_desc_count() = 0;
 
-        /**
-        * \return The number of EXTERNAL_PORT_INPUT descriptors present in the current configuration.
-        */
+        ///
+        /// \return The number of EXTERNAL_PORT_INPUT descriptors present in the current configuration.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual size_t STDCALL external_port_input_desc_count() = 0;
 
-        /**
-        * \return The number of EXTERNAL_PORT_OUTPUT descriptors present in the current configuration.
-        */
+        ///
+        /// \return The number of EXTERNAL_PORT_OUTPUT descriptors present in the current configuration.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual size_t STDCALL external_port_output_desc_count() = 0;
 
-        /**
-         * \return A descriptor by type and index.
-         */
+        ///
+        /// \return A descriptor by type and index.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual descriptor_base * STDCALL lookup_desc(uint16_t desc_type, size_t index) = 0;
 
-        /**
-         * \return The corresponding ENTITY descriptor by index.
-         */
+        ///
+        /// \return The corresponding ENTITY descriptor by index.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual entity_descriptor * STDCALL get_entity_descriptor_by_index(size_t audio_unit_desc_index) = 0;
 
-        /**
-         * \return The corresponding AUDIO UNIT descriptor by index.
-         */
+        ///
+        /// \return The corresponding AUDIO UNIT descriptor by index.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual audio_unit_descriptor * STDCALL get_audio_unit_desc_by_index(size_t audio_unit_desc_index) = 0;
 
-        /**
-         * \return The corresponding STREAM INPUT descriptor by index.
-         */
+        ///
+        /// \return The corresponding STREAM INPUT descriptor by index.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual stream_input_descriptor * STDCALL get_stream_input_desc_by_index(size_t stream_input_desc_index) = 0;
 
-        /**
-         * \return The corresponding STREAM OUTPUT descriptor by index.
-         */
+        ///
+        /// \return The corresponding STREAM OUTPUT descriptor by index.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual stream_output_descriptor * STDCALL get_stream_output_desc_by_index(size_t stream_output_desc_index) = 0;
 
-        /**
-         * \return The corresponding JACK INPUT descriptor by index.
-         */
+        ///
+        /// \return The corresponding JACK INPUT descriptor by index.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual jack_input_descriptor * STDCALL get_jack_input_desc_by_index(size_t jack_input_desc_index) = 0;
 
-        /**
-         * \return The corresponding JACK OUTPUT descriptor by index.
-         */
+        ///
+        /// \return The corresponding JACK OUTPUT descriptor by index.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual jack_output_descriptor * STDCALL get_jack_output_desc_by_index(size_t jack_output_desc_index) = 0;
 
-        /**
-         * \return The corresponding AVB INTERFACE descriptor by index.
-         */
+        ///
+        /// \return The corresponding AVB INTERFACE descriptor by index.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual avb_interface_descriptor * STDCALL get_avb_interface_desc_by_index(size_t avb_interface_desc_index) = 0;
 
-        /**
-         * \return The corresponding CLOCK SOURCE descriptor by index.
-         */
+        ///
+        /// \return The corresponding CLOCK SOURCE descriptor by index.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual clock_source_descriptor * STDCALL get_clock_source_desc_by_index(size_t clock_source_desc_index) = 0;
 
-        /**
-         * \return The corresponding MEMORY OBJECT descriptor by index.
-         */
+        ///
+        /// \return The corresponding MEMORY OBJECT descriptor by index.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual memory_object_descriptor * STDCALL get_memory_object_desc_by_index(size_t memory_object_desc_index) = 0;
 
-        /**
-         * \return The corresponding LOCALE descriptor by index.
-         */
+        ///
+        /// \return The corresponding LOCALE descriptor by index.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual locale_descriptor * STDCALL get_locale_desc_by_index(size_t locale_desc_index) = 0;
 
-        /**
-         * \return The corresponding STRINGS descriptor by index.
-         */
+        ///
+        /// \return The corresponding STRINGS descriptor by index.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual strings_descriptor * STDCALL get_strings_desc_by_index(size_t strings_desc_index) = 0;
 
-        /**
-         * \return The corresponding STREAM PORT INPUT descriptor by index.
-         */
+        ///
+        /// \return The corresponding STREAM PORT INPUT descriptor by index.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual stream_port_input_descriptor * STDCALL get_stream_port_input_desc_by_index(size_t stream_port_input_desc_index) = 0;
 
-        /**
-         * \return The corresponding STREAM PORT OUTPUT descriptor by index.
-         */
+        ///
+        /// \return The corresponding STREAM PORT OUTPUT descriptor by index.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual stream_port_output_descriptor * STDCALL get_stream_port_output_desc_by_index(size_t stream_port_output_desc_index) = 0;
 
-        /**
-         * \return The corresponding AUDIO CLUSTER descriptor by index.
-         */
+        ///
+        /// \return The corresponding AUDIO CLUSTER descriptor by index.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual audio_cluster_descriptor * STDCALL get_audio_cluster_desc_by_index(size_t audio_cluster_desc_index) = 0;
 
-        /**
-         * \return The corresponding AUDIO MAP descriptor by index.
-         */
+        ///
+        /// \return The corresponding AUDIO MAP descriptor by index.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual audio_map_descriptor * STDCALL get_audio_map_desc_by_index(size_t audio_map_desc_index) = 0;
 
-        /**
-         * \return The corresponding CLOCK DOMAIN descriptor by index.
-         */
+        ///
+        /// \return The corresponding CLOCK DOMAIN descriptor by index.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual clock_domain_descriptor * STDCALL get_clock_domain_desc_by_index(size_t clock_domain_desc_index) = 0;
 
-        /**
-         * \return The corresponding CONTROL descriptor by index.
-         */
+        ///
+        /// \return The corresponding CONTROL descriptor by index.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual control_descriptor * STDCALL get_control_desc_by_index(size_t control_desc_index) = 0;
 
-        /**
-        * \return The corresponding INTERNAL_PORT_INPUT descriptor by index.
-        */
+        ///
+        /// \return The corresponding INTERNAL_PORT_INPUT descriptor by index.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual external_port_input_descriptor * STDCALL get_external_port_input_desc_by_index(size_t index) = 0;
 
-        /**
-        * \return The corresponding INTERNAL_PORT_OUTPUT descriptor by index.
-        */
+        ///
+        /// \return The corresponding INTERNAL_PORT_OUTPUT descriptor by index.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual external_port_output_descriptor * STDCALL get_external_port_output_desc_by_index(size_t index) = 0;
     };
 }

--- a/controller/lib/include/control_descriptor_response.h
+++ b/controller/lib/include/control_descriptor_response.h
@@ -41,72 +41,72 @@ namespace avdecc_lib
     public:
         virtual ~control_descriptor_response() {};
 
-        /**
-         * \return The localized string reference pointing to the localized descriptor name.
-         */
+        ///
+        /// \return The localized string reference pointing to the localized descriptor name.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL localized_description() = 0;
 
-        /**
-         * \return This is the latency in nanoseconds between the output of the previous
-         *		   block and its output. The previous block is the object identified by the
-         *		   signal_type and signal_index fields. For a DELAY Control, the value
-         *		   of the delay is not included in this value.
-         */
+        ///
+        /// \return This is the latency in nanoseconds between the output of the previous
+        ///		   block and its output. The previous block is the object identified by the
+        ///		   signal_type and signal_index fields. For a DELAY Control, the value
+        ///		   of the delay is not included in this value.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL block_latency() = 0;
 
-        /**
-         * \return The worst-case time in microseconds from when a Control value
-         *		change is received and when the Control has completely switched to
-         *		the new value.
-         */
+        ///
+        /// \return The worst-case time in microseconds from when a Control value
+        ///		change is received and when the Control has completely switched to
+        ///		the new value.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL control_latency() = 0;
 
-        /**
-         * \return The domain that this Control belongs to.
-         */
+        ///
+        /// \return The domain that this Control belongs to.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL control_domain() = 0;
 
-        /**
-         * \return The type of the value contained in the Control as defined in 7.3.5.1
-         */
+        ///
+        /// \return The type of the value contained in the Control as defined in 7.3.5.1
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL control_value_type() = 0;
 
-        /**
-         * \return The type of the Control.
-         */
+        ///
+        /// \return The type of the Control.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL control_type() = 0;
 
-        /**
-         * \return The time period in milliseconds from when a Control is set with the
-         *  SET_CONTROL command until it automatically resets to its default values.
-         *  When this is zero (0), automatic resets do not happen.
-         */
+        ///
+        /// \return The time period in milliseconds from when a Control is set with the
+        ///     SET_CONTROL command until it automatically resets to its default values.
+        ///     When this is zero (0), automatic resets do not happen.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL reset_time() = 0;
 
-        /**
-         * \return The offset from the start of the descriptor for the first octet
-         *  of the value_details. The field is 104 for this version of AEM.
-         */
+        ///
+        /// \return The offset from the start of the descriptor for the first octet
+        ///     of the value_details. The field is 104 for this version of AEM.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL values_offset() = 0;
 
-        /**
-         * \return The number of value settings this Control has.
-         */
+        ///
+        /// \return The number of value settings this Control has.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_values() = 0;
 
-        /**
-         * \return The descriptor_type for the signal source of the Control.
-         */
+        ///
+        /// \return The descriptor_type for the signal source of the Control.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL signal_type() = 0;
 
-        /**
-         * \return The descriptor_index for the signal source of the Control.
-         */
+        ///
+        /// \return The descriptor_index for the signal source of the Control.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL signal_index() = 0;
 
-        /**
-         * \return The index of the output of the signal source of the Control.
-         */
+        ///
+        /// \return The index of the output of the signal source of the Control.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL signal_output() = 0;
     };
 }

--- a/controller/lib/include/controller.h
+++ b/controller/lib/include/controller.h
@@ -44,98 +44,98 @@ namespace avdecc_lib
     class controller
     {
     public:
-        /**
-         * Call destructor for Controller used for destroying objects
-         */
+        ///
+        /// Call destructor for Controller used for destroying objects
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual void STDCALL destroy() = 0;
 
-        /**
-         * \return The current AVDECC Controller build release version.
-         */
+        ///
+        /// \return The current AVDECC Controller build release version.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual const char * STDCALL get_version() const = 0;
 
-        /**
-         * \return The total number of End Stations connected.
-         */
+        ///
+        /// \return The total number of End Stations connected.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual size_t STDCALL get_end_station_count() = 0;
 
-        /**
-         * \return The corresponding End Station by index.
-         */
+        ///
+        /// \return The corresponding End Station by index.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual end_station * STDCALL get_end_station_by_index(size_t end_station_index) = 0;
 
-        /**
-         * \return Find an endstation's index by Entity ID.
-         */
+        ///
+        /// \return Find an endstation's index by Entity ID.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL is_end_station_found_by_entity_id(uint64_t entity_entity_id, uint32_t &end_station_index) = 0;
 
-        /**
-         * \return Find an endstation's index by MAC Address.
-         */
+        ///
+        /// \return Find an endstation's index by MAC Address.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL is_end_station_found_by_mac_addr(uint64_t mac_addr, uint32_t &end_station_index) = 0;
 
-        /**
-         * \return The corresponding CONFIGURATION descriptor by index.
-         */
+        ///
+        /// \return The corresponding CONFIGURATION descriptor by index.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual configuration_descriptor * STDCALL get_current_config_desc(size_t end_station_index, bool report_error=true) = 0;
 
-        /**
-         * \return The corresponding CONFIGURATION descriptor by Entity ID.
-         */
+        ///
+        /// \return The corresponding CONFIGURATION descriptor by Entity ID.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual configuration_descriptor * STDCALL get_config_desc_by_entity_id(uint64_t end_station_entity_id, uint16_t entity_index, uint16_t config_index) = 0;
 
-        /**
-         * Update the base log level for messages to be logged by the post_log_msg callback.
-         */
+        ///
+        /// Update the base log level for messages to be logged by the post_log_msg callback.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual void STDCALL set_logging_level(int32_t new_log_level) = 0;
 
-        /**
-         * Apply filters required to be true for an end station to be enumerated.
-         *
-         * The required filters are passed in.  If any of the required entity, talker,
-         * or listener flags are not true for an end station, the end station is not enumerated.
-         *
-         * \param entity_capabilities_flags avdecc_lib::end_station_entity_capabilities_flags
-         * \param talker_capabilities_flags avdecc_lib::end_station_talker_capabilities_flags
-         * \param listener_capabilities_flags avdecc_lib::end_station_listener_capabilities_flags
-         */
+        ///
+        /// Apply filters required to be true for an end station to be enumerated.
+        ///
+        /// The required filters are passed in.  If any of the required entity, talker,
+        /// or listener flags are not true for an end station, the end station is not enumerated.
+        ///
+        /// \param entity_capabilities_flags avdecc_lib::end_station_entity_capabilities_flags
+        /// \param talker_capabilities_flags avdecc_lib::end_station_talker_capabilities_flags
+        /// \param listener_capabilities_flags avdecc_lib::end_station_listener_capabilities_flags
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual void STDCALL apply_end_station_capabilities_filters(uint32_t entity_capabilities_flags,
                                                                                                 uint32_t talker_capabilities_flags,
                                                                                                 uint32_t listener_capabilities_flags) = 0;
 
-        /**
-         * \return The number of missed notifications that exceeds the notification buffer count.
-         */
+        ///
+        /// \return The number of missed notifications that exceeds the notification buffer count.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL missed_notification_count() = 0;
 
-        /**
-         * \return The number of missed logs that exceeds the log buffer count.
-         */
+        ///
+        /// \return The number of missed logs that exceeds the log buffer count.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL missed_log_count() = 0;
 
-        /**
-         * Send a CONTROLLER_AVAILABLE command to verify that the AVDECC Controller is still there.
-         */
+        ///
+        /// Send a CONTROLLER_AVAILABLE command to verify that the AVDECC Controller is still there.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_controller_avail_cmd(void *notification_id, uint32_t end_station_index) = 0;
     };
 
-    /**
-     * Create a public AVDECC Controller object with a network interface object, notification and post_log_msg callback functions used for accessing from outside the library.
-     *
-     * \param netif A network interface object created in the application level using the public network interface API provided.
-     * \param notification_user_obj A void pointer used to store any helpful C++ class object.
-     * \param notification_type The type of notification that the callback function is called with. (Refer to notifications enumeration included in the library for a list of notification types supported.)
-     * \param entity_id An unique identifier of the End Station the command is targeted to.
-     * \param cmd_type The type of the AEM command used in the command data to be sent.
-     * \param desc_type The type of the AEM descriptor used in the command data to be sent.
-     * \param desc_index The index associated with the corresponding descriptor type used in the command data to be sent.
-     * \param notification_id A void pointer to the unique identifier for each notification message.
-     *
-     * \param log_user_obj A void pointer used to store any helpful class object.
-     * \param log_level The log level that the callback function is called with. (Refer to logging levels enumeration included in the library for a list of log levels supported.)
-     * \param log_msg A message containing additional information to be logged.
-     * \param time_stamp_ms The time in milliseconds indicating when the message is logged.
-     */
+    ///
+    /// Create a public AVDECC Controller object with a network interface object, notification and post_log_msg callback functions used for accessing from outside the library.
+    ///
+    /// \param netif A network interface object created in the application level using the public network interface API provided.
+    /// \param notification_user_obj A void pointer used to store any helpful C++ class object.
+    /// \param notification_type The type of notification that the callback function is called with. (Refer to notifications enumeration included in the library for a list of notification types supported.)
+    /// \param entity_id An unique identifier of the End Station the command is targeted to.
+    /// \param cmd_type The type of the AEM command used in the command data to be sent.
+    /// \param desc_type The type of the AEM descriptor used in the command data to be sent.
+    /// \param desc_index The index associated with the corresponding descriptor type used in the command data to be sent.
+    /// \param notification_id A void pointer to the unique identifier for each notification message.
+    ///
+    /// \param log_user_obj A void pointer used to store any helpful class object.
+    /// \param log_level The log level that the callback function is called with. (Refer to logging levels enumeration included in the library for a list of log levels supported.)
+    /// \param log_msg A message containing additional information to be logged.
+    /// \param time_stamp_ms The time in milliseconds indicating when the message is logged.
+    ///
     extern "C" AVDECC_CONTROLLER_LIB32_API controller * STDCALL create_controller(net_interface *netif,
                                                                                   void (*notification_callback) (void *notification_user_obj, int32_t notification_type, uint64_t entity_id, uint16_t cmd_type,
                                                                                                                  uint16_t desc_type, uint16_t desc_index, uint32_t cmd_status, void *notification_id),

--- a/controller/lib/include/descriptor_base.h
+++ b/controller/lib/include/descriptor_base.h
@@ -43,119 +43,119 @@ namespace avdecc_lib
     {
     public:
         virtual ~descriptor_base() {}
-        /**
-         * \return The type of the descriptor.
-         */
+        ///
+        /// \return The type of the descriptor.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL descriptor_type() const = 0;
 
-        /**
-         * \return The index of the descriptor.
-         */
+        ///
+        /// \return The index of the descriptor.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL descriptor_index() const = 0;
 
-        /**
-        * \return The number of fields in the descriptor.
-        */
+        ///
+        /// \return The number of fields in the descriptor.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual size_t STDCALL field_count() const = 0;
 
-        /**
-        * \return The indicated field in the descriptor.
-        */
+        ///
+        /// \return The indicated field in the descriptor.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual descriptor_field * STDCALL field(size_t index) const = 0;
 
-        /**
-         * \return The localized string reference pointing to the localized descriptor name.
-         */
+        ///
+        /// \return The localized string reference pointing to the localized descriptor name.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL localized_description() = 0;
 
-        /**
-         * \return The flags after sending a ACQUIRE_ENTITY command and receiving a response back for the command.
-         */
+        ///
+        /// \return The flags after sending a ACQUIRE_ENTITY command and receiving a response back for the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL acquire_entity_flags() = 0;
 
-        /**
-         * \return The owner id after sending a ACQUIRE_ENTITY command and receiving a response back for the command.
-         */
+        ///
+        /// \return The owner id after sending a ACQUIRE_ENTITY command and receiving a response back for the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL acquire_entity_owner_entity_id() = 0;
 
-        /**
-         * \return The flags after sending a LOCK_ENTITY command and receiving a response back for the command.
-         */
+        ///
+        /// \return The flags after sending a LOCK_ENTITY command and receiving a response back for the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL lock_entity_flags() = 0;
 
-        /**
-         * \return The locked entity id after sending a LOCK_ENTITY command and receiving a response back for the command.
-         */
+        ///
+        /// \return The locked entity id after sending a LOCK_ENTITY command and receiving a response back for the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL lock_entity_locked_entity_id() = 0;
 
-        /**
-         * Send a ACQURE_ENTITY command to obtain exclusive access to an entire Entity or a sub-tree of objects.
-         *
-         * \param notification_id A void pointer to the unique identifier associated with the command.
-         * \param acquire_entity_flag The flag to be set for the command. Valid flags are 0, 1 (PERSISTENT), and 0x80000000 (RELEASE).
-         *
-         * The flags and owner id can be retrieved by calling the following function after successfully
-         * receiving a response back for the ACQURE_ENTITY command sent.
-         *
-         * \see acquire_entity_flags(), acquire_entity_owner_entity_id()
-         *
-         */
+        ///
+        /// Send a ACQURE_ENTITY command to obtain exclusive access to an entire Entity or a sub-tree of objects.
+        ///
+        /// \param notification_id A void pointer to the unique identifier associated with the command.
+        /// \param acquire_entity_flag The flag to be set for the command. Valid flags are 0, 1 (PERSISTENT), and 0x80000000 (RELEASE).
+        ///
+        /// The flags and owner id can be retrieved by calling the following function after successfully
+        /// receiving a response back for the ACQURE_ENTITY command sent.
+        ///
+        /// \see acquire_entity_flags(), acquire_entity_owner_entity_id()
+        ///
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_acquire_entity_cmd(void *notification_id, uint32_t acquire_entity_flag) = 0;
 
-        /**
-         * Send a LOCK_ENTITY command to provide short term exclusive access to the AVDECC Entity to perform atomic operations.
-         *
-         * \param notification_id A void pointer to the unique identifier associated with the command.
-         * \param lock_entity_flag The flag to be set for the command. Valid flags are 0 and 1 (UNLOCK).
-         *
-         * The flags and locked entity id can be retrieved by calling the following function after successfully
-         * receiving a response back for the LOCK_ENTITY command sent.
-         *
-         * \see lock_entity_flags(), lock_entity_locked_entity_id()
-         */
+        ///
+        /// Send a LOCK_ENTITY command to provide short term exclusive access to the AVDECC Entity to perform atomic operations.
+        ///
+        /// \param notification_id A void pointer to the unique identifier associated with the command.
+        /// \param lock_entity_flag The flag to be set for the command. Valid flags are 0 and 1 (UNLOCK).
+        ///
+        /// The flags and locked entity id can be retrieved by calling the following function after successfully
+        /// receiving a response back for the LOCK_ENTITY command sent.
+        ///
+        /// \see lock_entity_flags(), lock_entity_locked_entity_id()
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_lock_entity_cmd(void *notification_id, uint32_t lock_entity_flag) = 0;
 
-        /**
-         * Send a REBOOT command to the AVDECC Entity
-         *
-         * \param notification_id A void pointer to the unique identifier associated with the command.
-         * \param lock_entity_flag The flag to be set for the command. Valid flags are 0 and 1 (UNLOCK).
-         *
-         */
+        ///
+        /// Send a REBOOT command to the AVDECC Entity
+        ///
+        /// \param notification_id A void pointer to the unique identifier associated with the command.
+        /// \param lock_entity_flag The flag to be set for the command. Valid flags are 0 and 1 (UNLOCK).
+        ///
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_reboot_cmd(void *notification_id) = 0;
 
-        /**
-         * Send a SET_NAME command to change the value of a name field within a descriptor. For descriptors with multiple names, this
-         * sets only one specified name per command.
-         *
-         * \param notification_id A void pointer to the unique identifier associated with the command.
-         * \param name_index The index of the name within the descriptor, with the first name being index 0 and so on.
-         * \param config_index The descriptor index of the configuration, which contains the descriptor whose name is being set.
-         *		       If the descriptor type field is either ENTITY or CONFIGURATION, then this field is set to 0.
-         * \param new_name The new name to be set. The name does not contain a trailing NULL, but if the name is less than 64 bytes
-         *		   in length, then it is zero padded.
-         */
+        ///
+        /// Send a SET_NAME command to change the value of a name field within a descriptor. For descriptors with multiple names, this
+        /// sets only one specified name per command.
+        ///
+        /// \param notification_id A void pointer to the unique identifier associated with the command.
+        /// \param name_index The index of the name within the descriptor, with the first name being index 0 and so on.
+        /// \param config_index The descriptor index of the configuration, which contains the descriptor whose name is being set.
+        ///		       If the descriptor type field is either ENTITY or CONFIGURATION, then this field is set to 0.
+        /// \param new_name The new name to be set. The name does not contain a trailing NULL, but if the name is less than 64 bytes
+        ///		   in length, then it is zero padded.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_set_name_cmd(void *notification_id, uint16_t name_index, uint16_t config_index, const struct avdecc_lib_name_string64 * new_name) = 0;
 
-        /**
-         * Send a GET_NAME command to get the value of a name field within a descriptor. For descriptors with multiple names, this
-         * sets only one specified name.
-         *
-         * \param notification_id A void pointer to the unique identifier associated with the command.
-         * \param name_index The index of the name within the descriptor, with the first name being index 0 and so on.
-         * \param config_index The descriptor index of the configuration, which contains the descriptor whose name is being set.
-         *		       If the descriptor type field is either ENTITY or CONFIGURATION, then this field is set to 0.
-         */
+        ///
+        /// Send a GET_NAME command to get the value of a name field within a descriptor. For descriptors with multiple names, this
+        /// sets only one specified name.
+        ///
+        /// \param notification_id A void pointer to the unique identifier associated with the command.
+        /// \param name_index The index of the name within the descriptor, with the first name being index 0 and so on.
+        /// \param config_index The descriptor index of the configuration, which contains the descriptor whose name is being set.
+        ///		       If the descriptor type field is either ENTITY or CONFIGURATION, then this field is set to 0.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_get_name_cmd(void *notification_id, uint16_t name_index, uint16_t config_index) = 0;
 
-        /**
-         * \return the descriptor base response class.
-         */
+        ///
+        /// \return the descriptor base response class.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual descriptor_response_base * STDCALL get_descriptor_response() = 0;
 
-        /**
-         * \return the GET_NAME response class.
-         */
+        ///
+        /// \return the GET_NAME response class.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual descriptor_base_get_name_response * STDCALL get_name_response() = 0;
     };
 }

--- a/controller/lib/include/descriptor_base_get_name_response.h
+++ b/controller/lib/include/descriptor_base_get_name_response.h
@@ -39,9 +39,9 @@ namespace avdecc_lib
     {
     public:
         virtual ~descriptor_base_get_name_response() {};
-        /**
-         * Get the descriptor object name at index name_index.
-         */
+        ///
+        /// Get the descriptor object name at index name_index.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint8_t * STDCALL get_name() = 0;
     };
 }

--- a/controller/lib/include/descriptor_field.h
+++ b/controller/lib/include/descriptor_field.h
@@ -48,44 +48,44 @@ namespace avdecc_lib
             TYPE_FLAGS32
         };
 
-        /**
-         * \return The name of the descriptor field.
-         */
+        ///
+        /// \return The name of the descriptor field.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual const char * STDCALL get_name() const = 0;
 
-        /**
-        * \return The type of the descriptor field.
-        */
+        ///
+        /// \return The type of the descriptor field.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual enum aem_desc_field_types STDCALL get_type() const = 0;
 
-        /**
-         * \return The value of the descriptor as a char pointer.
-         */
+        ///
+        /// \return The value of the descriptor as a char pointer.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual char * STDCALL get_char() const = 0;
 
-        /**
-        * \return The value of the descriptor as a uint16_t type.
-        */
+        ///
+        /// \return The value of the descriptor as a uint16_t type.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_uint16() const = 0;
 
-        /**
-        * \return The value of the descriptor as a uint32_t type.
-        */
+        ///
+        /// \return The value of the descriptor as a uint32_t type.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_uint32() const = 0;
 
-        /**
-        * \return The value of the descriptor field of type flags.
-        */
+        ///
+        /// \return The value of the descriptor field of type flags.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_flags() const = 0;
 
-        /**
-        * \return The number flags for descriptor field of type flags.
-        */
+        ///
+        /// \return The number flags for descriptor field of type flags.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_flags_count() const = 0;
 
-        /**
-        * \return Get flag details.
-        */
+        ///
+        /// \return Get flag details.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual descriptor_field_flags * STDCALL get_flag_by_index(uint32_t index) const = 0;
     };
 }

--- a/controller/lib/include/descriptor_field_flags.h
+++ b/controller/lib/include/descriptor_field_flags.h
@@ -37,14 +37,14 @@ namespace avdecc_lib
     class descriptor_field_flags
     {
     public:
-        /**
-         * \return The name of the flag.
-         */
+        ///
+        /// \return The name of the flag.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual const char * STDCALL get_flag_name(void) const = 0;
 
-        /**
-         * \return The mask for the flag.
-         */
+        ///
+        /// \return The mask for the flag.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_flag_mask(void) const = 0;
     };
 }

--- a/controller/lib/include/descriptor_response_base.h
+++ b/controller/lib/include/descriptor_response_base.h
@@ -43,13 +43,13 @@ namespace avdecc_lib
     {
     public:
         virtual ~descriptor_response_base() {};
-        /**
-         * \return The name of the descriptor object. This may be user set through the use of a SET_NAME command.
-         *	   The object name should be left blank (all zeros) by the manufacturer, with the manufacturer
-         *	   defined value being provided in a localized form via the localized descripton field. By leaving
-         *	   this field blank an AVDECC Controller can determine if the user has overridden the name and can
-         *	   use this name rather than the localized name.
-         */
+        ///
+        /// \return The name of the descriptor object. This may be user set through the use of a SET_NAME command.
+        ///	   The object name should be left blank (all zeros) by the manufacturer, with the manufacturer
+        ///	   defined value being provided in a localized form via the localized descripton field. By leaving
+        ///	   this field blank an AVDECC Controller can determine if the user has overridden the name and can
+        ///	   use this name rather than the localized name.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint8_t * STDCALL object_name() = 0;
     };
 }

--- a/controller/lib/include/end_station.h
+++ b/controller/lib/include/end_station.h
@@ -40,49 +40,49 @@ namespace avdecc_lib
     class end_station
     {
     public:
-        /**
-         * \return The status of the End Station connection.
-         *	       'C' if connected. An End Station is connected after capturing an ADP packet with a different and unique Entity ID.
-         *         'D' if disconnected. An End Station is disconnected after it fails to advertise through ADP for 62,000 milliseconds.
-         */
+        ///
+        /// \return The status of the End Station connection.
+        ///	       'C' if connected. An End Station is connected after capturing an ADP packet with a different and unique Entity ID.
+        ///         'D' if disconnected. An End Station is disconnected after it fails to advertise through ADP for 62,000 milliseconds.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual const char STDCALL get_connection_status() const = 0;
 
-        /**
-         * \return The Entity ID of the End Station.
-         */
+        ///
+        /// \return The Entity ID of the End Station.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL entity_id() = 0;
 
-        /**
-         * \return The source MAC address of the End Station.
-         */
+        ///
+        /// \return The source MAC address of the End Station.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL mac() = 0;
 
-        /**
-         * \return The number of Entity descriptors for this End Station.
-         */
+        ///
+        /// \return The number of Entity descriptors for this End Station.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual size_t STDCALL entity_desc_count() = 0;
 
-        /**
-         * \return The corresponding ENTITY descriptor by index.
-         */
+        ///
+        /// \return The corresponding ENTITY descriptor by index.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual entity_descriptor * STDCALL get_entity_desc_by_index(size_t entity_desc_index) = 0;
 
-        /**
-         * Send a READ_DESCRIPTOR command to read a descriptor from an AVDECC Entity. Reading a descriptor can be performed
-         * by any AVDECC Controller even when the AVDECC Entitys locked or acquired as the act of reading the descriptor
-         * does not affect the AVDECC Entity state.
-         *
-         * \param notification_id A void pointer to the unique identifier associated with the command.
-         * \param desc_type The type of the descriptor to be read by the command.
-         * \param desc_index The index of the descriptor to be read by the command.
-         */
+        ///
+        /// Send a READ_DESCRIPTOR command to read a descriptor from an AVDECC Entity. Reading a descriptor can be performed
+        /// by any AVDECC Controller even when the AVDECC Entitys locked or acquired as the act of reading the descriptor
+        /// does not affect the AVDECC Entity state.
+        ///
+        /// \param notification_id A void pointer to the unique identifier associated with the command.
+        /// \param desc_type The type of the descriptor to be read by the command.
+        /// \param desc_index The index of the descriptor to be read by the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_read_desc_cmd(void *notification_id, uint16_t desc_type, uint16_t desc_index) = 0;
 
-        /**
-         * Send a ENTITY_AVAILABLE command to verify that an AVDECC Entity is still available and responding to commands.
-         *
-         * \param notification_id A void pointer to the unique identifier associated with the command.
-         */
+        ///
+        /// Send a ENTITY_AVAILABLE command to verify that an AVDECC Entity is still available and responding to commands.
+        ///
+        /// \param notification_id A void pointer to the unique identifier associated with the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_entity_avail_cmd(void *notification_id) = 0;
 
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_aecp_address_access_cmd(void *notification_id,
@@ -90,50 +90,50 @@ namespace avdecc_lib
                                                                                      unsigned length,
                                                                                      uint64_t address,
                                                                                      uint8_t memory_data[]) = 0;
-
-        /**
-         * Send a IDENTIFY command
-         *
-         * \param notification_id A void pointer to the unique identifier associated with the command.
-         * \param turn_on When true the end station will be told to enable identification.
-         */
+        
+        ///
+        /// Send a IDENTIFY command
+        ///
+        /// \param notification_id A void pointer to the unique identifier associated with the command.
+        /// \param turn_on When true the end station will be told to enable identification.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_identify(void *notification_id, bool turn_on) = 0;
 
-        /**
-         * \param entity_index The index of the entity to set as current selected.
-         */
+        ///
+        /// \param entity_index The index of the entity to set as current selected.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual void STDCALL set_current_entity_index(uint16_t entity_index) = 0;
 
 
-        /**
-         * \return The index of the currently selected entity.
-         */
+        ///
+        /// \return The index of the currently selected entity.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_current_entity_index() const = 0;
 
-        /**
-         * \param config_index The index of the config to set as current selected.
-         */
+        ///
+        /// \param config_index The index of the config to set as current selected.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual void STDCALL set_current_config_index(uint16_t entity_index) = 0;
 
-        /**
-         * \return The index of the currently selected config.
-         */
+        ///
+        /// \return The index of the currently selected config.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_current_config_index() const = 0;
 
-        /**
-         * Send a REGISTER_UNSOLICITED_NOTIFICATION command to add the controller as being interested
-         * in receiving unsolicited response notifications
-         *
-         * \param notification_id A void pointer to the unique identifier associated with the command.
-         */
+        ///
+        /// Send a REGISTER_UNSOLICITED_NOTIFICATION command to add the controller as being interested
+        /// in receiving unsolicited response notifications
+        ///
+        /// \param notification_id A void pointer to the unique identifier associated with the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_register_unsolicited_cmd(void *notification_id) = 0;
 
-        /**
-         * Send a DEREGISTER_UNSOLICITED_NOTIFICATION command to remove the controller as being interested
-         * in receiving unsolicited response notifications
-         *
-         * \param notification_id A void pointer to the unique identifier associated with the command.
-         */
+        ///
+        /// Send a DEREGISTER_UNSOLICITED_NOTIFICATION command to remove the controller as being interested
+        /// in receiving unsolicited response notifications
+        ///
+        /// \param notification_id A void pointer to the unique identifier associated with the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_deregister_unsolicited_cmd(void *notification_id) = 0;
     };
 }

--- a/controller/lib/include/entity_descriptor.h
+++ b/controller/lib/include/entity_descriptor.h
@@ -44,30 +44,30 @@ namespace avdecc_lib
     class entity_descriptor : public virtual descriptor_base
     {
     public:
-
-        /**
-         * \return the entity descriptor response class.
-         */
+        ///
+        /// \return the entity descriptor response class.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual entity_descriptor_response * STDCALL get_entity_response() = 0;
-        /**
-         * \return The number of Configuration descriptors.
-         * \see configurations_count()
-         */
+
+        ///
+        /// \return The number of Configuration descriptors.
+        /// \see configurations_count()
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual size_t STDCALL config_desc_count() = 0;
 
-        /**
-         * \return The corresponding Configuration descriptor by index.
-         */
+        ///
+        /// \return The corresponding Configuration descriptor by index.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual configuration_descriptor * STDCALL get_config_desc_by_index(uint16_t config_desc_index) = 0;
 
-        /**
-         * Send a SET_CONFIFURATION command to change the current configuration of the AVDECC Entity.
-         */
+        ///
+        /// Send a SET_CONFIFURATION command to change the current configuration of the AVDECC Entity.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_set_config_cmd() = 0;
 
-        /**
-         * Send a GET_CONFIGURATION command to get the current configuration of the AVDECC Entity.
-         */
+        ///
+        /// Send a GET_CONFIGURATION command to get the current configuration of the AVDECC Entity.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_get_config_cmd() = 0;
     };
 }

--- a/controller/lib/include/entity_descriptor_response.h
+++ b/controller/lib/include/entity_descriptor_response.h
@@ -42,96 +42,96 @@ namespace avdecc_lib
     {
     public:
         virtual ~entity_descriptor_response() {};
-        /**
-         * \return The Entity ID of the AVDECC Entity.
-         */
+        ///
+        /// \return The Entity ID of the AVDECC Entity.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL entity_id() = 0;
 
-        /**
-         * \return The AVDECC Entity model id for the AVDECC Entity.
-         */
+        ///
+        /// \return The AVDECC Entity model id for the AVDECC Entity.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL entity_model_id() = 0;
 
-        /**
-         * \return The capabilities of the AVDECC Entity.
-         */
+        ///
+        /// \return The capabilities of the AVDECC Entity.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL entity_capabilities() = 0;
 
-        /**
-         * \return The number of Output Streams the AVDECC Entity has. This is also the number
-         *	       of STREAM_OUTPUT descriptors the AVDECC Entity has for Output Streams.
-         */
+        ///
+        /// \return The number of Output Streams the AVDECC Entity has. This is also the number
+        ///	       of STREAM_OUTPUT descriptors the AVDECC Entity has for Output Streams.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL talker_stream_sources() = 0;
 
-        /**
-         * \return The AVDECC Talker capabilities of the AVDECC Entity.
-         */
+        ///
+        /// \return The AVDECC Talker capabilities of the AVDECC Entity.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL talker_capabilities() = 0;
 
-        /**
-         * \return The number of Input Streams the AVDECC Entity has. This is also the number
-         *         of STREAM_INPUT descriptors the AVDECC Entity has for Input Streams.
-         */
+        ///
+        /// \return The number of Input Streams the AVDECC Entity has. This is also the number
+        ///         of STREAM_INPUT descriptors the AVDECC Entity has for Input Streams.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL listener_stream_sinks() = 0;
 
-        /**
-         * \return The AVDECC Listener capabilities of the AVDECC Entity.
-         */
+        ///
+        /// \return The AVDECC Listener capabilities of the AVDECC Entity.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL listener_capabilities() = 0;
 
-        /**
-         * \return The AVDECC Controller capabilities of the AVDECC Entity.
-         */
+        ///
+        /// \return The AVDECC Controller capabilities of the AVDECC Entity.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL controller_capabilities() = 0;
 
-        /**
-         * \return The available index of the AVDECC Entity.
-         */
+        ///
+        /// \return The available index of the AVDECC Entity.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL available_index() = 0;
 
-        /**
-         * \return The association ID for the AVDECC Entity.
-         */
+        ///
+        /// \return The association ID for the AVDECC Entity.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL association_id() = 0;
 
-        /**
-         * \return The name of the AVDECC Entity. This may be user set through the use of a SET_NAME command.
-         */
+        ///
+        /// \return The name of the AVDECC Entity. This may be user set through the use of a SET_NAME command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint8_t * STDCALL entity_name() = 0;
 
-        /**
-         * \return The localized string reference pointing to the localized vendor name.
-         */
+        ///
+        /// \return The localized string reference pointing to the localized vendor name.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL vendor_name_string() = 0;
 
-        /**
-         * \return The localized string reference pointing to the localized model name.
-         */
+        ///
+        /// \return The localized string reference pointing to the localized model name.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL model_name_string() = 0;
 
-        /**
-         * \return The firmware version of the AVDECC Entity.
-         */
+        ///
+        /// \return The firmware version of the AVDECC Entity.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint8_t * STDCALL firmware_version() = 0;
 
-        /**
-         * \return The group name of the AVDECC Entity. This may be user set through the use of a SET_NAME command.
-         */
+        ///
+        /// \return The group name of the AVDECC Entity. This may be user set through the use of a SET_NAME command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint8_t * STDCALL group_name() = 0;
 
-        /**
-         * \return The serial number of the AVDECC Entity.
-         */
+        ///
+        /// \return The serial number of the AVDECC Entity.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint8_t * STDCALL serial_number() = 0;
 
-        /**
-         * \return The number of Configurations the device has. A device is required to have at least 1 Configuration.
-         */
+        ///
+        /// \return The number of Configurations the device has. A device is required to have at least 1 Configuration.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL configurations_count() = 0;
 
-        /**
-         * \return The index of the currently set Configuration.
-         */
+        ///
+        /// \return The index of the currently set Configuration.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL current_configuration() = 0;
     };
 }

--- a/controller/lib/include/external_port_input_descriptor.h
+++ b/controller/lib/include/external_port_input_descriptor.h
@@ -39,9 +39,9 @@ namespace avdecc_lib
     class external_port_input_descriptor : public virtual descriptor_base
     {
     public:
-        /**
-         * \return the external port input descriptor response class.
-         */
+        ///
+        /// \return the external port input descriptor response class.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual external_port_input_descriptor_response * STDCALL get_external_port_input_response() = 0;
     };
 }

--- a/controller/lib/include/external_port_input_descriptor_response.h
+++ b/controller/lib/include/external_port_input_descriptor_response.h
@@ -40,49 +40,49 @@ namespace avdecc_lib
     {
     public:
         virtual ~external_port_input_descriptor_response() {};
-        /**
-         * \return The flags describing the capabilities or features of the port.
-         */
+        ///
+        /// \return The flags describing the capabilities or features of the port.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL port_flags() = 0;
 
-        /**
-         * The index of the CLOCK_DOMAIN descriptor that describes the clock domain for the port.
-         */
+        ///
+        /// The index of the CLOCK_DOMAIN descriptor that describes the clock domain for the port.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL clock_domain_index() = 0;
 
-        /**
-         * \return The number of controls within this jack.
-         */
+        ///
+        /// \return The number of controls within this jack.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_controls() = 0;
 
-        /**
-         * \return The index of the first Control descriptor.
-         */
+        ///
+        /// \return The index of the first Control descriptor.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_control() = 0;
 
-        /**
-         * \return The signal type.
-         */
+        ///
+        /// \return The signal type.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL signal_type() = 0;
 
-        /**
-         * \return The signal index.
-         */
+        ///
+        /// \return The signal index.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL signal_index() = 0;
 
-        /**
-         * \return The signal output.
-         */
+        ///
+        /// \return The signal output.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL signal_output() = 0;
 
-        /**
-         * \return Latency in nanoseconds.
-         */
+        ///
+        /// \return Latency in nanoseconds.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL block_latency() = 0;
 
-        /**
-         * \return The index of the jack connected to the port.
-         */
+        ///
+        /// \return The index of the jack connected to the port.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL jack_index() = 0;
     };
 }

--- a/controller/lib/include/external_port_output_descriptor.h
+++ b/controller/lib/include/external_port_output_descriptor.h
@@ -39,9 +39,9 @@ namespace avdecc_lib
     class external_port_output_descriptor : public virtual descriptor_base
     {
     public:
-        /**
-         * \return the external port output descriptor response class.
-         */
+        ///
+        /// \return the external port output descriptor response class.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual external_port_output_descriptor_response * STDCALL get_external_port_output_response() = 0;
     };
 }

--- a/controller/lib/include/external_port_output_descriptor_response.h
+++ b/controller/lib/include/external_port_output_descriptor_response.h
@@ -39,49 +39,49 @@ namespace avdecc_lib
     {
     public:
         virtual ~external_port_output_descriptor_response() {};
-        /**
-         * \return The flags describing the capabilities or features of the port.
-         */
+        ///
+        /// \return The flags describing the capabilities or features of the port.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL port_flags() = 0;
 
-        /**
-         * The index of the CLOCK_DOMAIN descriptor that describes the clock domain for the port.
-         */
+        ///
+        /// The index of the CLOCK_DOMAIN descriptor that describes the clock domain for the port.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL clock_domain_index() = 0;
 
-        /**
-         * \return The number of controls within this jack.
-         */
+        ///
+        /// \return The number of controls within this jack.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_controls() = 0;
 
-        /**
-         * \return The index of the first Control descriptor.
-         */
+        ///
+        /// \return The index of the first Control descriptor.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_control() = 0;
 
-        /**
-         * \return The signal type.
-         */
+        ///
+        /// \return The signal type.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL signal_type() = 0;
 
-        /**
-         * \return The signal index.
-         */
+        ///
+        /// \return The signal index.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL signal_index() = 0;
 
-        /**
-         * \return The signal output.
-         */
+        ///
+        /// \return The signal output.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL signal_output() = 0;
 
-        /**
-         * \return Latency in nanoseconds.
-         */
+        ///
+        /// \return Latency in nanoseconds.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL block_latency() = 0;
 
-        /**
-         * \return The index of the jack connected to the port.
-         */
+        ///
+        /// \return The index of the jack connected to the port.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL jack_index() = 0;
     };
 }

--- a/controller/lib/include/jack_input_descriptor.h
+++ b/controller/lib/include/jack_input_descriptor.h
@@ -40,9 +40,9 @@ namespace avdecc_lib
     class jack_input_descriptor : public virtual descriptor_base
     {
     public:
-        /**
-         * \return the jack input descriptor response class.
-         */
+        ///
+        /// \return the jack input descriptor response class.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual jack_input_descriptor_response * STDCALL get_jack_input_response() = 0;
     };
 }

--- a/controller/lib/include/jack_input_descriptor_response.h
+++ b/controller/lib/include/jack_input_descriptor_response.h
@@ -40,41 +40,40 @@ namespace avdecc_lib
     {
     public:
         virtual ~jack_input_descriptor_response() {};
-
-        /**
-         * \return The localized string reference pointing to the localized descriptor name.
-         */
+        ///
+        /// \return The localized string reference pointing to the localized descriptor name.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL localized_description() = 0;
 
-        /**
-         * \return The flags describing the capabilities or features of the Jack.
-         */
+        ///
+        /// \return The flags describing the capabilities or features of the Jack.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL jack_flags() = 0;
 
-        /**
-         * Check if the jack can be used as a clock synchronization source.
-         */
+        ///
+        /// Check if the jack can be used as a clock synchronization source.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL jack_flag_clock_sync_source() = 0;
 
-        /**
-         * Check if the jack connection is hardwired, cannot be disconnected and
-         * may be physically within the device's structure.
-         */
+        ///
+        /// Check if the jack connection is hardwired, cannot be disconnected and
+        /// may be physically within the device's structure.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL jack_flag_captive() = 0;
 
-        /**
-         * \return The type of the jack.
-         */
+        ///
+        /// \return The type of the jack.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL jack_type() = 0;
 
-        /**
-         * \return The number of controls within this jack.
-         */
+        ///
+        /// \return The number of controls within this jack.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_controls() = 0;
 
-        /**
-         * \return The index of the first Control descriptor.
-         */
+        ///
+        /// \return The index of the first Control descriptor.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_control() = 0;
     };
 }

--- a/controller/lib/include/jack_output_descriptor.h
+++ b/controller/lib/include/jack_output_descriptor.h
@@ -40,9 +40,9 @@ namespace avdecc_lib
     class jack_output_descriptor : public virtual descriptor_base
     {
     public:
-        /**
-         * \return the jack output descriptor response class.
-         */
+        ///
+        /// \return the jack output descriptor response class.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual jack_output_descriptor_response * STDCALL get_jack_output_response() = 0;
     };
 }

--- a/controller/lib/include/jack_output_descriptor_response.h
+++ b/controller/lib/include/jack_output_descriptor_response.h
@@ -40,41 +40,40 @@ namespace avdecc_lib
     {
     public:
         virtual ~jack_output_descriptor_response() {};
-
-        /**
-         * \return The localized string reference pointing to the localized descriptor name.
-         */
+        ///
+        /// \return The localized string reference pointing to the localized descriptor name.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL localized_description() = 0;
 
-        /**
-         * \return The flags describing the capabilities or features of the Jack.
-         */
+        ///
+        /// \return The flags describing the capabilities or features of the Jack.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL jack_flags() = 0;
 
-        /**
-         * Check if the jack can be used as a clock synchronization source.
-         */
+        ///
+        /// Check if the jack can be used as a clock synchronization source.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL jack_flag_clock_sync_source() = 0;
 
-        /**
-         * Check if the jack connection is hardwired, cannot be disconnected and
-         * may be physically within the device's structure.
-         */
+        ///
+        /// Check if the jack connection is hardwired, cannot be disconnected and
+        /// may be physically within the device's structure.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL jack_flag_captive() = 0;
 
-        /**
-         * \return The type of the jack.
-         */
+        ///
+        /// \return The type of the jack.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL jack_type() = 0;
 
-        /**
-         * \return The number of controls within this jack.
-         */
+        ///
+        /// \return The number of controls within this jack.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_controls() = 0;
 
-        /**
-         * \return The index of the first Control descriptor.
-         */
+        ///
+        /// \return The index of the first Control descriptor.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_control() = 0;
     };
 }

--- a/controller/lib/include/locale_descriptor.h
+++ b/controller/lib/include/locale_descriptor.h
@@ -41,9 +41,9 @@ namespace avdecc_lib
     class locale_descriptor : public virtual descriptor_base
     {
     public:
-        /**
-         *  \return the locale descriptor response class.
-         */
+        ///
+        ///  \return the locale descriptor response class.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual locale_descriptor_response * STDCALL get_locale_response() = 0;
     };
 }

--- a/controller/lib/include/locale_descriptor_response.h
+++ b/controller/lib/include/locale_descriptor_response.h
@@ -41,25 +41,25 @@ namespace avdecc_lib
     {
     public:
         virtual ~locale_descriptor_response() {};
-        /**
-        * The identifier is a UTF-8 string that contains one to three components such as a
-        * language code, a region code, or a variant code, separated by the dash character.
-        * Examples of valid locale identifiers are en-US for English in the US, en-AU for
-        * English in Australia, haw-US for Hawaiian in the US, and fr-CA for French in Canada.
-        *
-        * \return The identifier of the LOCALE.
-        */
+        ///
+        /// The identifier is a UTF-8 string that contains one to three components such as a
+        /// language code, a region code, or a variant code, separated by the dash character.
+        /// Examples of valid locale identifiers are en-US for English in the US, en-AU for
+        /// English in Australia, haw-US for Hawaiian in the US, and fr-CA for French in Canada.
+        ///
+        /// \return The identifier of the LOCALE.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint8_t * STDCALL locale_identifier() = 0;
 
-        /**
-         * \return The number of Strings descriptor in this locale. This is the same value for
-         *	       all locales in an AVDECC Entity.
-         */
+        ///
+        /// \return The number of Strings descriptor in this locale. This is the same value for
+        ///	       all locales in an AVDECC Entity.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_strings() = 0;
 
-        /**
-         * \return The descriptor index of the first Strings descriptor for this LOCALE.
-         */
+        ///
+        /// \return The descriptor index of the first Strings descriptor for this LOCALE.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_strings() = 0;
     };
 }

--- a/controller/lib/include/memory_object_descriptor.h
+++ b/controller/lib/include/memory_object_descriptor.h
@@ -40,17 +40,17 @@ namespace avdecc_lib
     class memory_object_descriptor : public virtual descriptor_base
     {
     public:
-        /**
-         * \return the memory object descriptor response class.
-         */
+        ///
+        /// \return the memory object descriptor response class.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual memory_object_descriptor_response * STDCALL get_memory_object_response() = 0;
 
-        /**
-         * Send a START_OPERATION command with a notification id to begin an operation on the memory object
-         *
-         * \param notification_id   A void pointer to the unique identifier associated with the command.
-         * \param operation_tyoe    An integer representation the operation type to perform on the object
-         */
+        ///
+        /// Send a START_OPERATION command with a notification id to begin an operation on the memory object
+        ///
+        /// \param notification_id   A void pointer to the unique identifier associated with the command.
+        /// \param operation_tyoe    An integer representation the operation type to perform on the object
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL start_operation_cmd(void *notification_id, uint16_t operation_type) = 0;
     };
 }

--- a/controller/lib/include/memory_object_descriptor_response.h
+++ b/controller/lib/include/memory_object_descriptor_response.h
@@ -41,48 +41,48 @@ namespace avdecc_lib
     public:
         virtual ~memory_object_descriptor_response() {};
 
-        /**
-         * \return The localized string reference pointing to the localized descriptor name.
-         */
+        ///
+        /// \return The localized string reference pointing to the localized descriptor name.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL localized_description() = 0;
 
-        /**
-         * \return The type of the Memory Object
-         */
+        ///
+        /// \return The type of the Memory Object
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL memory_object_type() = 0;
 
-        /**
-         * \return The descriptor_type of the object that is the target of the memory region.
-         *         This is the object to which the settings, log file, or firmware applies.
-         */
+        ///
+        /// \return The descriptor_type of the object that is the target of the memory region.
+        ///         This is the object to which the settings, log file, or firmware applies.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL target_descriptor_type() = 0;
 
-        /**
-         * \return The descriptor_index of the object that is the target of the memory region.
-         *         This is the object to which the settings, log file, or firmware applies.
-         */
+        ///
+        /// \return The descriptor_index of the object that is the target of the memory region.
+        ///         This is the object to which the settings, log file, or firmware applies.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL target_descriptor_index() = 0;
 
-        /**
-         * \return The 64-bit start address used for reading or writing the object’s data
-         */
+        ///
+        /// \return The 64-bit start address used for reading or writing the object’s data
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL start_address() = 0;
 
-        /**
-         * \return The 64-bit maximum length of the Memory Object.
-         */
+        ///
+        /// \return The 64-bit maximum length of the Memory Object.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL maximum_length() = 0;
 
-        /**
-         * \return The 64-bit actual length of the Memory Object.
-         *         This value will change and will reflect the actual size of the data contained
-         *         in the memory region described by this Memory Object.
-         */
+        ///
+        /// \return The 64-bit actual length of the Memory Object.
+        ///         This value will change and will reflect the actual size of the data contained
+        ///         in the memory region described by this Memory Object.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL length() = 0;
 
-        /**
-         * \return String representation of the memory_object_type
-         */
+        ///
+        /// \return String representation of the memory_object_type
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual const char * STDCALL memory_object_type_to_str() = 0;
     };
 }

--- a/controller/lib/include/net_interface.h
+++ b/controller/lib/include/net_interface.h
@@ -37,35 +37,35 @@ namespace avdecc_lib
     class net_interface
     {
     public:
-        /**
-         * Call destructor for Network Interface used for destroying objects
-         */
+        ///
+        /// Call destructor for Network Interface used for destroying objects
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual void STDCALL destroy() = 0;
 
-        /**
-         * \return The number of devices.
-         */
+        ///
+        /// \return The number of devices.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL devs_count() = 0;
 
-        /**
-         * \return The corresponding network interface description by index.
-         */
+        ///
+        /// \return The corresponding network interface description by index.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual char * STDCALL get_dev_desc_by_index(size_t dev_index) = 0;
 
-        /** This function is OS dependant. In linux and OSX the return is the same as for a call to
-         * get_dev_desc_by_index(). In Windows this function returns a GUID as a string.
-         * \return The corresponding network interface name by index.
-         */
+        /// This function is OS dependant. In linux and OSX the return is the same as for a call to
+        /// get_dev_desc_by_index(). In Windows this function returns a GUID as a string.
+        /// \return The corresponding network interface name by index.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual char * STDCALL get_dev_name_by_index(size_t dev_index) = 0;
 
-        /**
-         * Select the corresponding interface by number.
-         */
+        ///
+        /// Select the corresponding interface by number.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL select_interface_by_num(uint32_t interface_num) = 0;
 
-        /**
-         * Capture a network packet.
-         */
+        ///
+        /// Capture a network packet.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL capture_frame(const uint8_t **frame, uint16_t *frame_len) = 0;
     };
 

--- a/controller/lib/include/response_frame.h
+++ b/controller/lib/include/response_frame.h
@@ -42,15 +42,15 @@ namespace avdecc_lib
         response_frame(const uint8_t *frame, size_t size, size_t pos);
         virtual ~response_frame();
 
-        /*
-         * Buffer to store counters and command response frames.  Will be updated
-         * by command response processing methods.
-         */
+        //
+        // Buffer to store counters and command response frames.  Will be updated
+        // by command response processing methods.
+        //
         uint8_t * buffer;
-        /*
-         * Buffer to store descriptor response frames.  Will be updated by
-         * update_desc_database() method in configuration descriptor.
-         */
+        //
+        // Buffer to store descriptor response frames.  Will be updated by
+        // update_desc_database() method in configuration descriptor.
+        //
         uint8_t * desc_buffer;
         size_t frame_size;
         size_t desc_frame_size;

--- a/controller/lib/include/stream_input_counters_response.h
+++ b/controller/lib/include/stream_input_counters_response.h
@@ -38,18 +38,18 @@ namespace avdecc_lib
     {
     public:
         virtual ~stream_input_counters_response() {};
-        /**
-         * \param name avdecc_lib::counter_labels
-         *
-         * \return the stream input counter valid after the GET_COUNTERS command.
-         */
+        ///
+        /// \param name avdecc_lib::counter_labels
+        ///
+        /// \return the stream input counter valid after the GET_COUNTERS command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_counter_valid(int name) = 0;
 
-        /**
-         * \param name avdecc_lib::counter_labels
-         *
-         * \return the stream input counter by name after the GET_COUNTERS command.
-         */
+        ///
+        /// \param name avdecc_lib::counter_labels
+        ///
+        /// \return the stream input counter by name after the GET_COUNTERS command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_counter_by_name(int name) = 0;
     };
 }

--- a/controller/lib/include/stream_input_descriptor.h
+++ b/controller/lib/include/stream_input_descriptor.h
@@ -44,142 +44,142 @@ namespace avdecc_lib
     class stream_input_descriptor : public virtual descriptor_base
     {
     public:
-        /**
-         * \return the stream_input descriptor response class.
-         */
+        ///
+        /// \return the stream_input descriptor response class.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual stream_input_descriptor_response * STDCALL get_stream_input_response() = 0;
 
-        /**
-         * \return the stream_input descriptor counters response class.
-         */
+        ///
+        /// \return the stream_input descriptor counters response class.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual stream_input_counters_response * STDCALL get_stream_input_counters_response() = 0;
 
-        /**
-         * \return the stream_input get_stream_format response class.
-         */
+        ///
+        /// \return the stream_input get_stream_format response class.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual stream_input_get_stream_format_response * STDCALL get_stream_input_get_stream_format_response() = 0;
 
-        /**
-         * \return the stream_input get_stream_format response class.
-         */
+        ///
+        /// \return the stream_input get_stream_format response class.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual stream_input_get_stream_info_response * STDCALL get_stream_input_get_stream_info_response() = 0;
 
-        /**
-         * \return the stream_input get_rx_state response class.
-         */
+        ///
+        /// \return the stream_input get_rx_state response class.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual stream_input_get_rx_state_response * STDCALL get_stream_input_get_rx_state_response() = 0;
 
-        /**
-         * Send a SET_STREAM_FORMAT command with a notification id to change the format of a stream.
-         *
-         * \param notification_id A void pointer to the unique identifier associated with the command.
-         * \param new_stream_format The stream format field is set to the new stream format.
-         *
-         * The new stream format can be retrieved by calling the set_stream_format_stream_format function after successfully
-         * receiving a response back for the SET_STREAM_FORMAT command sent.
-         *
-         * \see set_stream_format_stream_format()
-         */
+        ///
+        /// Send a SET_STREAM_FORMAT command with a notification id to change the format of a stream.
+        ///
+        /// \param notification_id A void pointer to the unique identifier associated with the command.
+        /// \param new_stream_format The stream format field is set to the new stream format.
+        ///
+        /// The new stream format can be retrieved by calling the set_stream_format_stream_format function after successfully
+        /// receiving a response back for the SET_STREAM_FORMAT command sent.
+        ///
+        /// \see set_stream_format_stream_format()
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_set_stream_format_cmd(void *notification_id, uint64_t new_stream_format) = 0;
 
-        /**
-         * Send a GET_STREAM_FORMAT command with a notification id to fetch the current format of a stream.
-         *
-         * \param notification_id A void pointer to the unique identifier associated with the command.
-         *
-         * The stream format can be retrieved by calling the get_stream_format_stream_format function after successfully
-         * receiving a response back for the GET_STREAM_FORMAT command sent.
-         *
-         * \see get_stream_format_stream_format()
-         */
+        ///
+        /// Send a GET_STREAM_FORMAT command with a notification id to fetch the current format of a stream.
+        ///
+        /// \param notification_id A void pointer to the unique identifier associated with the command.
+        ///
+        /// The stream format can be retrieved by calling the get_stream_format_stream_format function after successfully
+        /// receiving a response back for the GET_STREAM_FORMAT command sent.
+        ///
+        /// \see get_stream_format_stream_format()
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_get_stream_format_cmd(void *notification_id) = 0;
 
-        /**
-         * Send a SET_STREAM_INFO command with a notification id to change the current values of the dynamic information of
-         * the stream, such as the msrp_accumulated_latency, stream ID, and destination MAC.
-         *
-         * \param notification_id A void pointer to the unique identifier associated with the command.
-         * \param new_stream_info_field The new field information to be set to for a stream.
-         */
+        ///
+        /// Send a SET_STREAM_INFO command with a notification id to change the current values of the dynamic information of
+        /// the stream, such as the msrp_accumulated_latency, stream ID, and destination MAC.
+        ///
+        /// \param notification_id A void pointer to the unique identifier associated with the command.
+        /// \param new_stream_info_field The new field information to be set to for a stream.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_set_stream_info_cmd(void *notification_id, void *new_stream_info_field) = 0;
 
-        /**
-         * Send a GET_STREAM_INFO command with a notification id to fetch the current information for a stream.
-         *
-         * \param notification_id A void pointer to the unique identifier associated with the command.
-         *
-         * The stream information can be retrieved by calling the following functions after successfully
-         * receiving a response back for the GET_STREAM_INFO command sent.
-         *
-         * \see get_stream_info_flags(), get_stream_info_stream_format(), get_stream_info_stream_id(),
-         *      get_stream_info_msrp_accumulated_latency(), get_stream_info_stream_dest_mac(),
-         *      get_stream_info_msrp_failure_code(), get_stream_info_msrp_failure_bridge_id()
-         */
+        ///
+        /// Send a GET_STREAM_INFO command with a notification id to fetch the current information for a stream.
+        ///
+        /// \param notification_id A void pointer to the unique identifier associated with the command.
+        ///
+        /// The stream information can be retrieved by calling the following functions after successfully
+        /// receiving a response back for the GET_STREAM_INFO command sent.
+        ///
+        /// \see get_stream_info_flags(), get_stream_info_stream_format(), get_stream_info_stream_id(),
+        ///      get_stream_info_msrp_accumulated_latency(), get_stream_info_stream_dest_mac(),
+        ///      get_stream_info_msrp_failure_code(), get_stream_info_msrp_failure_bridge_id()
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_get_stream_info_cmd(void *notification_id) = 0;
 
-        /**
-         * Send a START_STREAMING command with a notification id to start streaming on a previously connected stream that was connected
-         * via ACMP or has previously been stopped with the STOP_STREAMING command.
-         *
-         * \param notification_id A void pointer to the unique identifier associated with the command.
-         */
+        ///
+        /// Send a START_STREAMING command with a notification id to start streaming on a previously connected stream that was connected
+        /// via ACMP or has previously been stopped with the STOP_STREAMING command.
+        ///
+        /// \param notification_id A void pointer to the unique identifier associated with the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_start_streaming_cmd(void *notification_id) = 0;
 
-        /**
-         * Send a STOP_STREAMING command with a notification id to stop a connected stream for streaming media.
-         *
-         * \param notification_id A void pointer to the unique identifier associated with the command.
-         */
+        ///
+        /// Send a STOP_STREAMING command with a notification id to stop a connected stream for streaming media.
+        ///
+        /// \param notification_id A void pointer to the unique identifier associated with the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_stop_streaming_cmd(void *notification_id) = 0;
 
-        /**
-         * Send a CONNECT_RX command with a notification id to connect Listener sink stream.
-         *
-         * \param notification_id A void pointer to the unique identifier associated with the command.
-         * \param talker_entity_id The Talker Entity ID used to identify the AVDECC Talker being targed by
-         *                    the command. In the case of Talker commands, this is the AVDECC Entity
-         *                    receiving the command. In the case of Listener commands, this is the
-         *                    AVDECC Entity that any Talker command is to be sent to. This field is
-         *                    either the Entity ID of the AVDECC Entity being targets to or 0.
-         * \param talker_unique_id The Talker Unique ID is used to uniquely identify the stream source
-         *                         of the AVDECC Talker. For entities using the AVDECC Entity Mondel,
-         *                         this corresponds to the id of the STREAM OUTPUT descriptor.
-         */
+        ///
+        /// Send a CONNECT_RX command with a notification id to connect Listener sink stream.
+        ///
+        /// \param notification_id A void pointer to the unique identifier associated with the command.
+        /// \param talker_entity_id The Talker Entity ID used to identify the AVDECC Talker being targed by
+        ///                    the command. In the case of Talker commands, this is the AVDECC Entity
+        ///                    receiving the command. In the case of Listener commands, this is the
+        ///                    AVDECC Entity that any Talker command is to be sent to. This field is
+        ///                    either the Entity ID of the AVDECC Entity being targets to or 0.
+        /// \param talker_unique_id The Talker Unique ID is used to uniquely identify the stream source
+        ///                         of the AVDECC Talker. For entities using the AVDECC Entity Model,
+        ///                         this corresponds to the id of the STREAM OUTPUT descriptor.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_connect_rx_cmd(void *notification_id, uint64_t talker_entity_id, uint16_t talker_unique_id, uint16_t flags) = 0;
 
-        /**
-         * Send a DISCONNECT_RX command with a notification id to disconnect Listener sink stream.
-         *
-         * \param notification_id A void pointer to the unique identifier associated with the command.
-         * \param talker_entity_id The Talker Entity ID used to identify the AVDECC Talker being targed by
-         *                    the command. In the case of Talker commands, this is the AVDECC Entity
-         *                    receiving the command. In the case of Listener commands, this is the
-         *                    AVDECC Entity that any Talker command is to be sent to. This field is
-         *                    either the Entity ID of the AVDECC Entity being targets to or 0.
-         * \param talker_unique_id The Talker Unique ID is used to uniquely identify the stream source
-         *                         of the AVDECC Talker. For entities using the AVDECC Entity Mondel,
-         *                         this corresponds to the id of the STREAM OUTPUT descriptor.
-         */
+        ///
+        /// Send a DISCONNECT_RX command with a notification id to disconnect Listener sink stream.
+        ///
+        /// \param notification_id A void pointer to the unique identifier associated with the command.
+        /// \param talker_entity_id The Talker Entity ID used to identify the AVDECC Talker being targed by
+        ///                    the command. In the case of Talker commands, this is the AVDECC Entity
+        ///                    receiving the command. In the case of Listener commands, this is the
+        ///                    AVDECC Entity that any Talker command is to be sent to. This field is
+        ///                    either the Entity ID of the AVDECC Entity being targets to or 0.
+        /// \param talker_unique_id The Talker Unique ID is used to uniquely identify the stream source
+        ///                         of the AVDECC Talker. For entities using the AVDECC Entity Model,
+        ///                          this corresponds to the id of the STREAM OUTPUT descriptor.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_disconnect_rx_cmd(void *notification_id, uint64_t talker_entity_id, uint16_t talker_unique_id) = 0;
 
-        /**
-         * Send a GET_RX_STATE command with a notification id to get Listener sink stream connection state.
-         *
-         * \param notification_id A void pointer to the unique identifier associated with the command.
-         * \param talker_entity_id The Talker Entity ID used to identify the AVDECC Talker being targed by
-         *                    the command. In the case of Talker commands, this is the AVDECC Entity
-         *                    receiving the command. In the case of Listener commands, this is the
-         *                    AVDECC Entity that any Talker command is to be sent to. This field is
-         *                    either the Entity ID of the AVDECC Entity being targets to or 0.
-         * \param talker_unique_id The Talker Unique ID is used to uniquely identify the stream source
-         *                         of the AVDECC Talker. For entities using the AVDECC Entity Mondel,
-         *                         this corresponds to the id of the STREAM OUTPUT descriptor.
-         */
+        ///
+        /// Send a GET_RX_STATE command with a notification id to get Listener sink stream connection state.
+        ///
+        /// \param notification_id A void pointer to the unique identifier associated with the command.
+        /// \param talker_entity_id The Talker Entity ID used to identify the AVDECC Talker being targed by
+        ///                     the command. In the case of Talker commands, this is the AVDECC Entity
+        ///                     receiving the command. In the case of Listener commands, this is the
+        ///                     AVDECC Entity that any Talker command is to be sent to. This field is
+        ///                     either the Entity ID of the AVDECC Entity being targets to or 0.
+        /// \param talker_unique_id The Talker Unique ID is used to uniquely identify the stream source
+        ///                         of the AVDECC Talker. For entities using the AVDECC Entity Model,
+        ///                         this corresponds to the id of the STREAM OUTPUT descriptor.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_get_rx_state_cmd(void *notification_id) = 0;
 
-        /**
-         * Send a GET_COUNTERS command to get the stream_input counters of the AVDECC Entity.
-         */
+        ///
+        /// Send a GET_COUNTERS command to get the stream_input counters of the AVDECC Entity.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_get_counters_cmd(void *notification_id) = 0;
     };
 }

--- a/controller/lib/include/stream_input_descriptor_response.h
+++ b/controller/lib/include/stream_input_descriptor_response.h
@@ -41,141 +41,141 @@ namespace avdecc_lib
     public:
         virtual ~stream_input_descriptor_response() {};
 
-        /**
-         * \return The localized string reference pointing to the localized descriptor name.
-         */
+        ///
+        /// \return The localized string reference pointing to the localized descriptor name.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL localized_description() = 0;
 
-        /**
-         * \return The descriptor index of the CLOCK DOMAIN descriptor providing the media clock for the stream.
-         */
+        ///
+        /// \return The descriptor index of the CLOCK DOMAIN descriptor providing the media clock for the stream.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL clock_domain_index() = 0;
 
-        /**
-         * \return The flags describing the capabilities or features of the stream.
-         */
+        ///
+        /// \return The flags describing the capabilities or features of the stream.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL stream_flags() = 0;
 
-        /**
-         * \return True if the stream can be used as a clock synchronization source.
-         */
+        ///
+        /// \return True if the stream can be used as a clock synchronization source.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_clock_sync_source() = 0;
 
-        /**
-         * \return True if the stream supports streaming at Class A.
-         */
+        ///
+        /// \return True if the stream supports streaming at Class A.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_class_a() = 0;
 
-        /**
-         * \return True if the stream supports streaming at Class B.
-         */
+        ///
+        /// \return True if the stream supports streaming at Class B.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_class_b() = 0;
 
-        /**
-         * \return True if the stream supports streaming with encrypted PDUs.
-         */
+        ///
+        /// \return True if the stream supports streaming with encrypted PDUs.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_supports_encrypted() = 0;
 
-        /**
-         * \return True if the primary backup AVDECC Talker's Entity ID and primary backup AVDECC Talker's Unique ID are supported.
-         */
+        ///
+        /// \return True if the primary backup AVDECC Talker's Entity ID and primary backup AVDECC Talker's Unique ID are supported.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_primary_backup_supported() = 0;
 
-        /**
-         * \return True if the primary backup AVDECC Talker's Entity ID and primary backup AVDECC Talker's Unique ID are valid.
-         */
+        ///
+        /// \return True if the primary backup AVDECC Talker's Entity ID and primary backup AVDECC Talker's Unique ID are valid.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_primary_backup_valid() = 0;
 
-        /**
-         * \return True if the secondary backup AVDECC Talker's Entity ID and secondary backup AVDECC Talker's Unique ID are supported.
-         */
+        ///
+        /// \return True if the secondary backup AVDECC Talker's Entity ID and secondary backup AVDECC Talker's Unique ID are supported.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_secondary_backup_supported() = 0;
 
-        /**
-         * \return True if the secondary backup AVDECC Talker's Entity ID and secondary backup AVDECC Talker's Unique ID are valid.
-         */
+        ///
+        /// \return True if the secondary backup AVDECC Talker's Entity ID and secondary backup AVDECC Talker's Unique ID are valid.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_secondary_backup_valid() = 0;
 
-        /**
-         * \return True if the tertiary backup AVDECC Talker's Entity ID and tertiary backup AVDECC Talker's Unique ID are supported.
-         */
+        ///
+        /// \return True if the tertiary backup AVDECC Talker's Entity ID and tertiary backup AVDECC Talker's Unique ID are supported.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_tertiary_backup_supported() = 0;
 
-        /**
-         * \return True if the tertiary backup AVDECC Talker's Entity ID and tertiary backup AVDECC Talker's Unique ID are valid.
-         */
+        ///
+        /// \return True if the tertiary backup AVDECC Talker's Entity ID and tertiary backup AVDECC Talker's Unique ID are valid.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_tertiary_backup_valid() = 0;
 
-        /**
-         * \return The current format name of the stream.
-         */
+        ///
+        /// \return The current format name of the stream.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual const char * STDCALL current_format_name() = 0;
 
-        /**
-         * \return The current format value of the stream.
-         */
+        ///
+        /// \return The current format value of the stream.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL current_format_value() = 0;
 
-        /**
-         * \return The number of formats supported by this audio stream. The maximum value
-         *	       for this field is 47 for this version of AEM.
-         */
+        ///
+        /// \return The number of formats supported by this audio stream. The maximum value
+        ///	       for this field is 47 for this version of AEM.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_formats() = 0;
 
-        /**
-         * \return The primary backup AVDECC Talker's Entity ID.
-         */
+        ///
+        /// \return The primary backup AVDECC Talker's Entity ID.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL backup_talker_entity_id_0() = 0;
 
-        /**
-         * \return The primary backup AVDECC Talker's Unique ID.
-         */
+        ///
+        /// \return The primary backup AVDECC Talker's Unique ID.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL backup_talker_unique_0() = 0;
 
-        /**
-         * \return The secondary backup AVDECC Talker's Entity ID.
-         */
+        ///
+        /// \return The secondary backup AVDECC Talker's Entity ID.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL backup_talker_entity_id_1() = 0;
 
-        /**
-         * \return The secondary backup AVDECC Talker's Unique ID.
-         */
+        ///
+        /// \return The secondary backup AVDECC Talker's Unique ID.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL backup_talker_unique_1() = 0;
 
-        /**
-         * \return The tertiary backup AVDECC Talker's Entity ID.
-         */
+        ///
+        /// \return The tertiary backup AVDECC Talker's Entity ID.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL backup_talker_entity_id_2() = 0;
 
-        /**
-         * \return The tertiary backup AVDECC Talker's Unique ID.
-         */
+        ///
+        /// \return The tertiary backup AVDECC Talker's Unique ID.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL backup_talker_unique_2() = 0;
 
-        /**
-         * \return The Entity ID of the AVDECC Talker that this stream is backing up.
-         */
+        ///
+        /// \return The Entity ID of the AVDECC Talker that this stream is backing up.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL backedup_talker_entity_id() = 0;
 
-        /**
-         * \return The Unique ID of the AVDECC Talker that this stream is backing up.
-         */
+        ///
+        /// \return The Unique ID of the AVDECC Talker that this stream is backing up.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL backedup_talker_unique() = 0;
 
-        /**
-         * \return The descriptor index of the AVB INTERFACE descriptor from which this stream
-         *	       is sourced or to which it is sinked.
-         */
+        ///
+        /// \return The descriptor index of the AVB INTERFACE descriptor from which this stream
+        ///	       is sourced or to which it is sinked.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL avb_interface_index() = 0;
 
-        /**
-         * \return The length in nanoseconds of the MAC's ingress buffer size.
-         */
+        ///
+        /// \return The length in nanoseconds of the MAC's ingress buffer size.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL buffer_length() = 0;
 
-        /**
-         * \return The supported stream format by index.
-         */
+        ///
+        /// \return The supported stream format by index.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_supported_stream_fmt_by_index(size_t stream_fmt_index) = 0;
     };
 }

--- a/controller/lib/include/stream_input_get_rx_state_response.h
+++ b/controller/lib/include/stream_input_get_rx_state_response.h
@@ -38,49 +38,49 @@ namespace avdecc_lib
     {
     public:
         virtual ~stream_input_get_rx_state_response() {};
-        /**
-         * \return The stream id field used to identify and transfer the associated stream ID where suitable
-         *         after sending a GET_RX_STATE command and receiving a response back for the command.
-         */
+        ///
+        /// \return The stream id field used to identify and transfer the associated stream ID where suitable
+        ///         after sending a GET_RX_STATE command and receiving a response back for the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_rx_state_stream_id() = 0;
 
-        /**
-         * \return The Talker unique ID used to uniquely identify the stream source of the AVDECC Talker
-         *         after sending a GET_RX_STATE command and receiving a response back for the command.
-         */
+        ///
+        /// \return The Talker unique ID used to uniquely identify the stream source of the AVDECC Talker
+        ///         after sending a GET_RX_STATE command and receiving a response back for the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_rx_state_talker_unique_id() = 0;
 
-        /**
-         * \return The Listener unique ID used to uniquely identify the stream sink of the AVDECC Listener
-         *         after sending a GET_RX_STATE command and receiving a response back for the command.
-         */
+        ///
+        /// \return The Listener unique ID used to uniquely identify the stream sink of the AVDECC Listener
+        ///         after sending a GET_RX_STATE command and receiving a response back for the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_rx_state_listener_unique_id() = 0;
 
-        /**
-         * \return The stream destination MAC address used to convey the destination MAC address for a stream
-         *         from the AVDECC Talker to the AVDECC Listener, or from either to the AVDECC Controller after
-         *         sending a GET_RX_STATE command and receiving a response back for the command.
-         */
+        ///
+        /// \return The stream destination MAC address used to convey the destination MAC address for a stream
+        ///         from the AVDECC Talker to the AVDECC Listener, or from either to the AVDECC Controller after
+        ///         sending a GET_RX_STATE command and receiving a response back for the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_rx_state_stream_dest_mac() = 0;
 
-        /**
-         * \return The connection count used by the state commands to return the number of connections an AVDECC Talker
-         *         thinks it has on its stream source after sending a GET_RX_STATE command and receiving a response
-         *         back for the command.
-         */
+        ///
+        /// \return The connection count used by the state commands to return the number of connections an AVDECC Talker
+        ///         thinks it has on its stream source after sending a GET_RX_STATE command and receiving a response
+        ///         back for the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_rx_state_connection_count() = 0;
 
-        /**
-         * \return The flags used to indicate attributes of the connection or saved state after sending a GET_RX_STATE
-         *         command and receiving a response back for the command.
-         */
+        ///
+        /// \return The flags used to indicate attributes of the connection or saved state after sending a GET_RX_STATE
+        ///         command and receiving a response back for the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_rx_state_flags() = 0;
 
-        /**
-         * \return The stream vlan id used to convey the VLAN ID for a stream from the AVDECC Talker to the AVDECC Listener,
-         *         or from either to the AVDECC Controller after sending a GET_RX_STATE command and receiving a response
-         *         back for the command.
-         */
+        ///
+        /// \return The stream vlan id used to convey the VLAN ID for a stream from the AVDECC Talker to the AVDECC Listener,
+        ///         or from either to the AVDECC Controller after sending a GET_RX_STATE command and receiving a response
+        ///         back for the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_rx_state_stream_vlan_id() = 0;
     };
 }

--- a/controller/lib/include/stream_input_get_stream_format_response.h
+++ b/controller/lib/include/stream_input_get_stream_format_response.h
@@ -38,10 +38,10 @@ namespace avdecc_lib
     {
     public:
         virtual ~stream_input_get_stream_format_response() {};
-        /**
-         * \return The stream format of a stream after sending a GET_STREAM_FORMAT command and
-         *	       receiving a response back for the command.
-         */
+        ///
+        /// \return The stream format of a stream after sending a GET_STREAM_FORMAT command and
+        ///	       receiving a response back for the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_stream_format() = 0;
     };
 }

--- a/controller/lib/include/stream_input_get_stream_info_response.h
+++ b/controller/lib/include/stream_input_get_stream_info_response.h
@@ -38,70 +38,70 @@ namespace avdecc_lib
     {
     public:
         virtual ~stream_input_get_stream_info_response() {};
-        /**
-         * \return The stream info flags of a stream after sending a GET_STREAM_INFO command and
-         *	       receiving a response back for the command.
-         */
+        ///
+        /// \return The stream info flags of a stream after sending a GET_STREAM_INFO command and
+        ///	       receiving a response back for the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_stream_info_flags() = 0;
 
-        /**
-         * \return True if the stream's msrp_failure_code and msrp_failure_id fields are valid.
-         */
+        ///
+        /// \return True if the stream's msrp_failure_code and msrp_failure_id fields are valid.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL get_stream_info_flags_msrp_failure_valid() = 0;
 
-        /**
-         * \return True if the stream's stream_dest_mac field is valid.
-         */
+        ///
+        /// \return True if the stream's stream_dest_mac field is valid.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL get_stream_info_flags_stream_dest_mac_valid() = 0;
 
-        /**
-         * \return True if the stream's msrp_accumulated_latency field is valid.
-         */
+        ///
+        /// \return True if the stream's msrp_accumulated_latency field is valid.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL get_stream_info_flags_msrp_acc_lat_valid() = 0;
 
-        /**
-         * \return True if the stream's stream_id field is valid.
-         */
+        ///
+        /// \return True if the stream's stream_id field is valid.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL get_stream_info_flags_stream_id_valid() = 0;
 
-        /**
-         * \return True if the stream's stream_format field is valid.
-         */
+        ///
+        /// \return True if the stream's stream_format field is valid.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL get_stream_info_flags_stream_format_valid() = 0;
-        /**
-         * \return The stream info stream format of a stream after sending a GET_STREAM_INFO command and
-         *	       receiving a response back for the command.
-         */
+        ///
+        /// \return The stream info stream format of a stream after sending a GET_STREAM_INFO command and
+        ///	       receiving a response back for the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_stream_info_stream_format() = 0;
 
-        /**
-         * \return The stream info stream id of a stream after sending a GET_STREAM_INFO command and
-         *	       receiving a response back for the command.
-         */
+        ///
+        /// \return The stream info stream id of a stream after sending a GET_STREAM_INFO command and
+        ///	       receiving a response back for the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_stream_info_stream_id() = 0;
 
-        /**
-         * \return The stream info MSRP accumulated latency of a stream after sending a GET_STREAM_INFO command and
-         *	       receiving a response back for the command.
-         */
+        ///
+        /// \return The stream info MSRP accumulated latency of a stream after sending a GET_STREAM_INFO command and
+        ///	       receiving a response back for the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_stream_info_msrp_accumulated_latency() = 0;
 
-        /**
-         * \return The stream info stream destination MAC of a stream after sending a GET_STREAM_INFO command and
-         *	       receiving a response back for the command.
-         */
+        ///
+        /// \return The stream info stream destination MAC of a stream after sending a GET_STREAM_INFO command and
+        ///	       receiving a response back for the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_stream_info_stream_dest_mac() = 0;
 
-        /**
-         * \return The stream info MSRP failure code of a stream after sending a GET_STREAM_INFO command and
-         *	       receiving a response back for the command.
-         */
+        ///
+        /// \return The stream info MSRP failure code of a stream after sending a GET_STREAM_INFO command and
+        ///	       receiving a response back for the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint8_t STDCALL get_stream_info_msrp_failure_code() = 0;
 
-        /**
-         * \return The stream info MSRP failure bridge id of a stream after sending a GET_STREAM_INFO command and
-         *	       receiving a response back for the command.
-         */
+        ///
+        /// \return The stream info MSRP failure bridge id of a stream after sending a GET_STREAM_INFO command and
+        ///	       receiving a response back for the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_stream_info_msrp_failure_bridge_id() = 0;
     };
 }

--- a/controller/lib/include/stream_output_descriptor.h
+++ b/controller/lib/include/stream_output_descriptor.h
@@ -44,122 +44,122 @@ namespace avdecc_lib
     class stream_output_descriptor : public virtual descriptor_base
     {
     public:
-        /**
-         * \return the stream_output descriptor response class.
-         */
+        ///
+        /// \return the stream_output descriptor response class.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual stream_output_descriptor_response * STDCALL get_stream_output_response() = 0;
 
-        /**
-         * \return the stream_output get_stream_format response class.
-         */
+        ///
+        /// \return the stream_output get_stream_format response class.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual stream_output_get_stream_format_response * STDCALL get_stream_output_get_stream_format_response() = 0;
 
-        /**
-         * \return the stream_output get_stream_info response class.
-         */
+        ///
+        /// \return the stream_output get_stream_info response class.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual stream_output_get_stream_info_response * STDCALL get_stream_output_get_stream_info_response() = 0;
 
-        /**
-         * \return the stream_output get_tx_state response class.
-         */
+        ///
+        /// \return the stream_output get_tx_state response class.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual stream_output_get_tx_state_response * STDCALL get_stream_output_get_tx_state_response() = 0;
 
-        /**
-         * \return the stream_output get_tx_connection response class.
-         */
+        ///
+        /// \return the stream_output get_tx_connection response class.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual stream_output_get_tx_connection_response * STDCALL get_stream_output_get_tx_connection_response() = 0;
 
-        /**
-         * Send a SET_STREAM_FORMAT command with a notification id to change the format of a stream.
-         *
-         * \param notification_id A void pointer to the unique identifier associated with the command.
-         * \param new_stream_format The stream format field is set to the new stream format.
-         *
-         * The new stream format can be retrieved by calling the set_stream_format_stream_format function after successfully
-         * receiving a response back for the SET_STREAM_FORMAT command sent.
-         *
-         * \see set_stream_format_stream_format()
-         */
+        ///
+        /// Send a SET_STREAM_FORMAT command with a notification id to change the format of a stream.
+        ///
+        /// \param notification_id A void pointer to the unique identifier associated with the command.
+        /// \param new_stream_format The stream format field is set to the new stream format.
+        ///
+        /// The new stream format can be retrieved by calling the set_stream_format_stream_format function after successfully
+        /// receiving a response back for the SET_STREAM_FORMAT command sent.
+        ///
+        /// \see set_stream_format_stream_format()
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_set_stream_format_cmd(void *notification_id, uint64_t new_stream_format) = 0;
 
-        /**
-         * Send a GET_STREAM_FORMAT command with a notification id to fetch the current format of a stream.
-         *
-         * \param notification_id A void pointer to the unique identifier associated with the command.
-         *
-         * The stream format can be retrieved by calling the get_stream_format_stream_format function after successfully
-         * receiving a response back for the GET_STREAM_FORMAT command sent.
-         *
-         * \see get_stream_format_stream_format()
-         */
+        ///
+        /// Send a GET_STREAM_FORMAT command with a notification id to fetch the current format of a stream.
+        ///
+        /// \param notification_id A void pointer to the unique identifier associated with the command.
+        ///
+        /// The stream format can be retrieved by calling the get_stream_format_stream_format function after successfully
+        /// receiving a response back for the GET_STREAM_FORMAT command sent.
+        ///
+        /// \see get_stream_format_stream_format()
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_get_stream_format_cmd(void *notification_id) = 0;
 
-        /**
-         * Send a SET_STREAM_INFO command with a notification id to set the vlan ID of the stream.
-         *
-         * \param notification_id A void pointer to the unique identifier associated with the command.
-         * \param new_stream_info_field The new field information to be set to for a stream.
-         */
+        ///
+        /// Send a SET_STREAM_INFO command with a notification id to set the vlan ID of the stream.
+        ///
+        /// \param notification_id A void pointer to the unique identifier associated with the command.
+        /// \param new_stream_info_field The new field information to be set to for a stream.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_set_stream_info_vlan_id_cmd(void *notification_id, uint16_t vlan_id) = 0;
 
-        /**
-         * Send a GET_STREAM_INFO command with a notification id to fetch the current information for a stream.
-         *
-         * \param notification_id A void pointer to the unique identifier associated with the command.
-         *
-         * The stream information can be retrieved by calling the following functions after successfully
-         * receiving a response back for the GET_STREAM_INFO command sent.
-         *
-         * \see get_stream_info_flags(), get_stream_info_stream_format(), get_stream_info_stream_id(),
-         *      get_stream_info_msrp_accumulated_latency(), get_stream_info_stream_dest_mac(),
-         *      get_stream_info_msrp_failure_code(), get_stream_info_msrp_failure_bridge_id()
-         */
+        ///
+        /// Send a GET_STREAM_INFO command with a notification id to fetch the current information for a stream.
+        ///
+        /// \param notification_id A void pointer to the unique identifier associated with the command.
+        ///
+        /// The stream information can be retrieved by calling the following functions after successfully
+        /// receiving a response back for the GET_STREAM_INFO command sent.
+        ///
+        /// \see get_stream_info_flags(), get_stream_info_stream_format(), get_stream_info_stream_id(),
+        ///      get_stream_info_msrp_accumulated_latency(), get_stream_info_stream_dest_mac(),
+        ///      get_stream_info_msrp_failure_code(), get_stream_info_msrp_failure_bridge_id()
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_get_stream_info_cmd(void *notification_id) = 0;
 
-        /**
-         * Send a START_STREAMING command with a notification id to start streaming on a previously connected stream that was connected
-         * via ACMP or has previously been stopped with the STOP_STREAMING command.
-         *
-         * \param notification_id A void pointer to the unique identifier associated with the command.
-         */
+        ///
+        /// Send a START_STREAMING command with a notification id to start streaming on a previously connected stream that was connected
+        /// via ACMP or has previously been stopped with the STOP_STREAMING command.
+        ///
+        /// \param notification_id A void pointer to the unique identifier associated with the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_start_streaming_cmd(void *notification_id) = 0;
 
-        /**
-         * Send a STOP_STREAMING command with a notification id to stop a connected stream for streaming media.
-         *
-         * \param notification_id A void pointer to the unique identifier associated with the command.
-         */
+        ///
+        /// Send a STOP_STREAMING command with a notification id to stop a connected stream for streaming media.
+        ///
+        /// \param notification_id A void pointer to the unique identifier associated with the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_stop_streaming_cmd(void *notification_id) = 0;
 
-        /**
-        * Send a GET_TX_STATE command with a notification id to connect Listener sink stream.
-        *
-        * \param notification_id A void pointer to the unique identifier associated with the command.
-        * \param talker_entity_id The Talker Entity ID used to identify the AVDECC Talker being targed by
-        *                    the command. In the case of Talker commands, this is the AVDECC Entity
-        *                    receiving the command. In the case of Listener commands, this is the
-        *                    AVDECC Entity that any Talker command is to be sent to. This field is
-        *                    either the Entity ID of the AVDECC Entity being targets to or 0.
-        * \param talker_unique_id The Talker Unique ID is used to uniquely identify the stream source
-        *                         of the AVDECC Talker. For entities using the AVDECC Entity Mondel,
-        *                         this corresponds to the id of the STREAM OUTPUT descriptor.
-        */
+        ///
+        /// Send a GET_TX_STATE command with a notification id to connect Listener sink stream.
+        ///
+        /// \param notification_id A void pointer to the unique identifier associated with the command.
+        /// \param talker_entity_id The Talker Entity ID used to identify the AVDECC Talker being targed by
+        ///                    the command. In the case of Talker commands, this is the AVDECC Entity
+        ///                    receiving the command. In the case of Listener commands, this is the
+        ///                    AVDECC Entity that any Talker command is to be sent to. This field is
+        ///                    either the Entity ID of the AVDECC Entity being targets to or 0.
+        /// \param talker_unique_id The Talker Unique ID is used to uniquely identify the stream source
+        ///                         of the AVDECC Talker. For entities using the AVDECC Entity Model,
+        ///                         this corresponds to the id of the STREAM OUTPUT descriptor.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_get_tx_state_cmd(void *notification_id) = 0;
 
-        /**
-         * Send a GET_TX_CONNECTION command with a notification id to get a specific Talker connection information.
-         *
-         * \param notification_id A void pointer to the unique identifier associated with the command.
-         * \param talker_entity_id The Talker Entity ID used to identify the AVDECC Talker being targed by
-         *                    the command. In the case of Talker commands, this is the AVDECC Entity
-         *                    receiving the command. In the case of Listener commands, this is the
-         *                    AVDECC Entity that any Talker command is to be sent to. This field is
-         *                    either the Entity ID of the AVDECC Entity being targets to or 0.
-         * \param talker_unique_id The Talker Unique ID is used to uniquely identify the stream source
-         *                         of the AVDECC Talker. For entities using the AVDECC Entity Mondel,
-         *                         this corresponds to the id of the STREAM OUTPUT descriptor.
-         * \return Returns 0 on success.
-         */
+        ///
+        /// Send a GET_TX_CONNECTION command with a notification id to get a specific Talker connection information.
+        ///
+        /// \param notification_id A void pointer to the unique identifier associated with the command.
+        /// \param talker_entity_id The Talker Entity ID used to identify the AVDECC Talker being targed by
+        ///                    the command. In the case of Talker commands, this is the AVDECC Entity
+        ///                    receiving the command. In the case of Listener commands, this is the
+        ///                    AVDECC Entity that any Talker command is to be sent to. This field is
+        ///                    either the Entity ID of the AVDECC Entity being targets to or 0.
+        /// \param talker_unique_id The Talker Unique ID is used to uniquely identify the stream source
+        ///                         of the AVDECC Talker. For entities using the AVDECC Entity Model,
+        ///                         this corresponds to the id of the STREAM OUTPUT descriptor.
+        /// \return Returns 0 on success.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_get_tx_connection_cmd(void *notification_id, uint64_t listener_entity_id, uint16_t listener_unique_id) = 0;
     };
 }

--- a/controller/lib/include/stream_output_descriptor_response.h
+++ b/controller/lib/include/stream_output_descriptor_response.h
@@ -41,156 +41,156 @@ namespace avdecc_lib
     public:
         virtual ~stream_output_descriptor_response() {};
 
-        /**
-         * \return The localized string reference pointing to the localized descriptor name.
-         */
+        ///
+        /// \return The localized string reference pointing to the localized descriptor name.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL localized_description() = 0;
 
-        /**
-         * \return The descriptor index of the CLOCK DOMAIN descriptor providing the media clock for the stream.
-         */
+        ///
+        /// \return The descriptor index of the CLOCK DOMAIN descriptor providing the media clock for the stream.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL clock_domain_index() = 0;
 
-        /**
-         * \return The flags describing the capabilities or features of the stream.
-         */
+        ///
+        /// \return The flags describing the capabilities or features of the stream.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL stream_flags() = 0;
 
-        /**
-         * \return True if the stream can be used as a clock synchronization source.
-         */
+        ///
+        /// \return True if the stream can be used as a clock synchronization source.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_clock_sync_source() = 0;
 
-        /**
-         * \return True if the stream supports streaming at Class A.
-         */
+        ///
+        /// \return True if the stream supports streaming at Class A.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_class_a() = 0;
 
-        /**
-         * \return True if the stream supports streaming at Class B.
-         */
+        ///
+        /// \return True if the stream supports streaming at Class B.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_class_b() = 0;
 
-        /**
-         * \return True if the stream supports streaming with encrypted PDUs.
-         */
+        ///
+        /// \return True if the stream supports streaming with encrypted PDUs.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_supports_encrypted() = 0;
 
-        /**
-         * \return True if the primary backup AVDECC Talker's Entity ID and primary backup AVDECC Talker's Unique ID are supported.
-         */
+        ///
+        /// \return True if the primary backup AVDECC Talker's Entity ID and primary backup AVDECC Talker's Unique ID are supported.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_primary_backup_supported() = 0;
 
-        /**
-         * \return True if the primary backup AVDECC Talker's Entity ID and primary backup AVDECC Talker's Unique ID are valid.
-         */
+        ///
+        /// \return True if the primary backup AVDECC Talker's Entity ID and primary backup AVDECC Talker's Unique ID are valid.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_primary_backup_valid() = 0;
 
-        /**
-         * \return True if the secondary backup AVDECC Talker's Entity ID and secondary backup AVDECC Talker's Unique ID are supported.
-         */
+        ///
+        /// \return True if the secondary backup AVDECC Talker's Entity ID and secondary backup AVDECC Talker's Unique ID are supported.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_secondary_backup_supported() = 0;
 
-        /**
-         * \return True if the secondary backup AVDECC Talker's Entity ID and secondary backup AVDECC Talker's Unique ID are valid.
-         */
+        ///
+        /// \return True if the secondary backup AVDECC Talker's Entity ID and secondary backup AVDECC Talker's Unique ID are valid.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_secondary_backup_valid() = 0;
 
-        /**
-         * \return True if the tertiary backup AVDECC Talker's Entity ID and tertiary backup AVDECC Talker's Unique ID are supported.
-         */
+        ///
+        /// \return True if the tertiary backup AVDECC Talker's Entity ID and tertiary backup AVDECC Talker's Unique ID are supported.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_tertiary_backup_supported() = 0;
 
-        /**
-         * \return True if the tertiary backup AVDECC Talker's Entity ID and tertiary backup AVDECC Talker's Unique ID are valid.
-         */
+        ///
+        /// \return True if the tertiary backup AVDECC Talker's Entity ID and tertiary backup AVDECC Talker's Unique ID are valid.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL stream_flags_tertiary_backup_valid() = 0;
 
-        /**
-         * \return The current format name of the stream.
-         */
+        ///
+        /// \return The current format name of the stream.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual const char * STDCALL current_format_name() = 0;
 
-        /**
-         * \return The current format value of the stream.
-         */
+        ///
+        /// \return The current format value of the stream.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL current_format_value() = 0;
 
-        /**
-         * \return The number of formats supported by this audio stream. The maximum value
-         *	       for this field is 47 for this version of AEM.
-         */
+        ///
+        /// \return The number of formats supported by this audio stream. The maximum value
+        ///	       for this field is 47 for this version of AEM.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_formats() = 0;
 
-        /**
-         * \return The primary backup AVDECC Talker's Entity ID.
-         */
+        ///
+        /// \return The primary backup AVDECC Talker's Entity ID.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL backup_talker_entity_id_0() = 0;
 
-        /**
-         * \return The primary backup AVDECC Talker's Unique ID.
-         */
+        ///
+        /// \return The primary backup AVDECC Talker's Unique ID.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL backup_talker_unique_0() = 0;
 
-        /**
-         * \return The secondary backup AVDECC Talker's Entity ID.
-         */
+        ///
+        /// \return The secondary backup AVDECC Talker's Entity ID.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL backup_talker_entity_id_1() = 0;
 
-        /**
-         * \return The secondary backup AVDECC Talker's Unique ID.
-         */
+        ///
+        /// \return The secondary backup AVDECC Talker's Unique ID.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL backup_talker_unique_1() = 0;
 
-        /**
-         * \return The tertiary backup AVDECC Talker's Entity ID.
-         */
+        ///
+        /// \return The tertiary backup AVDECC Talker's Entity ID.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL backup_talker_entity_id_2() = 0;
 
-        /**
-         * \return The tertiary backup AVDECC Talker's Unique ID.
-         */
+        ///
+        /// \return The tertiary backup AVDECC Talker's Unique ID.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL backup_talker_unique_2() = 0;
 
-        /**
-         * \return The Entity ID of the AVDECC Talker that this stream is backing up.
-         */
+        ///
+        /// \return The Entity ID of the AVDECC Talker that this stream is backing up.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL backedup_talker_entity_id() = 0;
 
-        /**
-         * \return The Unique ID of the AVDECC Talker that this stream is backing up.
-         */
+        ///
+        /// \return The Unique ID of the AVDECC Talker that this stream is backing up.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL backedup_talker_unique() = 0;
 
-        /**
-         * \return The descriptor index of the AVB INTERFACE descriptor from which this stream
-         *	       is sourced or to which it is sinked.
-         */
+        ///
+        /// \return The descriptor index of the AVB INTERFACE descriptor from which this stream
+        ///	       is sourced or to which it is sinked.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL avb_interface_index() = 0;
 
-        /**
-         * \return The length in nanoseconds of the MAC's ingress buffer size.
-         */
+        ///
+        /// \return The length in nanoseconds of the MAC's ingress buffer size.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL buffer_length() = 0;
 
-        /**
-         * Tests state of a flag returned by last GET_STREAM_INFO command.
-         *
-         * \param flag The flag to check. Valid values are:
-         * CLASS_B, FAST_CONNECT, SAVED_STATE, STREAMING_WAIT, ENCRYPTED_PDU, STREAM_VLAN_ID_VALID
-         * CONNECTED, MSRP_FAILURE_VALID, STREAM_DEST_MAC_VALID, MSRP_ACC_LAT_VALID, STREAM_ID_VALID,
-         * STREAM_FORMAT_VALID.
-         *
-         * \see get_stream_info_flags(), get_stream_info_stream_format(), get_stream_info_stream_id(),
-         *      get_stream_info_msrp_accumulated_latency(), get_stream_info_stream_dest_mac(),
-         *      get_stream_info_msrp_failure_code(), get_stream_info_msrp_failure_bridge_id()
-         */
+        ///
+        /// Tests state of a flag returned by last GET_STREAM_INFO command.
+        ///
+        /// \param flag The flag to check. Valid values are:
+        /// CLASS_B, FAST_CONNECT, SAVED_STATE, STREAMING_WAIT, ENCRYPTED_PDU, STREAM_VLAN_ID_VALID
+        /// CONNECTED, MSRP_FAILURE_VALID, STREAM_DEST_MAC_VALID, MSRP_ACC_LAT_VALID, STREAM_ID_VALID,
+        /// STREAM_FORMAT_VALID.
+        ///
+        /// \see get_stream_info_flags(), get_stream_info_stream_format(), get_stream_info_stream_id(),
+        ///      get_stream_info_msrp_accumulated_latency(), get_stream_info_stream_dest_mac(),
+        ///      get_stream_info_msrp_failure_code(), get_stream_info_msrp_failure_bridge_id()
+        ///
 
         AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL get_stream_info_flag(const char *flag) = 0;
 
-        /**
-         * \return The supported stream format by index.
-         */
+        ///
+        /// \return The supported stream format by index.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_supported_stream_fmt_by_index(size_t stream_fmt_index) = 0;
     };
 }

--- a/controller/lib/include/stream_output_get_stream_format_response.h
+++ b/controller/lib/include/stream_output_get_stream_format_response.h
@@ -38,10 +38,10 @@ namespace avdecc_lib
     {
     public:
         virtual ~stream_output_get_stream_format_response() {};
-        /**
-         * \return The stream format of a stream after sending a GET_STREAM_FORMAT command and
-         *	       receiving a response back for the command.
-         */
+        ///
+        /// \return The stream format of a stream after sending a GET_STREAM_FORMAT command and
+        ///	       receiving a response back for the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_stream_format() = 0;
     };
 }

--- a/controller/lib/include/stream_output_get_stream_info_response.h
+++ b/controller/lib/include/stream_output_get_stream_info_response.h
@@ -38,82 +38,82 @@ namespace avdecc_lib
     {
     public:
         virtual ~stream_output_get_stream_info_response() {};
-        /**
-         * \return The stream info flags of a stream after sending a GET_STREAM_INFO command and
-         *	       receiving a response back for the command.
-         */
+        ///
+        /// \return The stream info flags of a stream after sending a GET_STREAM_INFO command and
+        ///	       receiving a response back for the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_stream_info_flags() = 0;
 
-        /**
-         * \return True if the stream's stream_vlan_id field is valid.
-         */
+        ///
+        /// \return True if the stream's stream_vlan_id field is valid.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL get_stream_info_flags_stream_vlan_id_valid() = 0;
 
-        /**
-         * \return True if the stream's msrp_failure_code and msrp_failure_id fields are valid.
-         */
+        ///
+        /// \return True if the stream's msrp_failure_code and msrp_failure_id fields are valid.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL get_stream_info_flags_msrp_failure_valid() = 0;
 
-        /**
-         * \return True if the stream's stream_dest_mac field is valid.
-         */
+        ///
+        /// \return True if the stream's stream_dest_mac field is valid.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL get_stream_info_flags_stream_dest_mac_valid() = 0;
 
-        /**
-         * \return True if the stream's msrp_accumulated_latency field is valid.
-         */
+        ///
+        /// \return True if the stream's msrp_accumulated_latency field is valid.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL get_stream_info_flags_msrp_acc_lat_valid() = 0;
 
-        /**
-         * \return True if the stream's stream_id field is valid.
-         */
+        ///
+        /// \return True if the stream's stream_id field is valid.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL get_stream_info_flags_stream_id_valid() = 0;
 
-        /**
-         * \return True if the stream's stream_format field is valid.
-         */
+        ///
+        /// \return True if the stream's stream_format field is valid.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL get_stream_info_flags_stream_format_valid() = 0;
 
-        /**
-         * \return The stream info stream format of a stream after sending a GET_STREAM_INFO command and
-         *	       receiving a response back for the command.
-         */
+        ///
+        /// \return The stream info stream format of a stream after sending a GET_STREAM_INFO command and
+        ///	       receiving a response back for the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_stream_info_stream_format() = 0;
 
-        /**
-         * \return The stream info stream id of a stream after sending a GET_STREAM_INFO command and
-         *	       receiving a response back for the command.
-         */
+        ///
+        /// \return The stream info stream id of a stream after sending a GET_STREAM_INFO command and
+        ///	       receiving a response back for the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_stream_info_stream_id() = 0;
 
-        /**
-         * \return The stream info MSRP accumulated latency of a stream after sending a GET_STREAM_INFO command and
-         *	       receiving a response back for the command.
-         */
+        ///
+        /// \return The stream info MSRP accumulated latency of a stream after sending a GET_STREAM_INFO command and
+        ///	       receiving a response back for the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL get_stream_info_msrp_accumulated_latency() = 0;
 
-        /**
-         * \return The stream info stream destination MAC of a stream after sending a GET_STREAM_INFO command and
-         *	       receiving a response back for the command.
-         */
+        ///
+        /// \return The stream info stream destination MAC of a stream after sending a GET_STREAM_INFO command and
+        ///	       receiving a response back for the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_stream_info_stream_dest_mac() = 0;
 
-        /**
-         * \return The stream info MSRP failure code of a stream after sending a GET_STREAM_INFO command and
-         *	       receiving a response back for the command.
-         */
+        ///
+        /// \return The stream info MSRP failure code of a stream after sending a GET_STREAM_INFO command and
+        ///	       receiving a response back for the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint8_t STDCALL get_stream_info_msrp_failure_code() = 0;
 
-        /**
-         * \return The stream info MSRP failure bridge id of a stream after sending a GET_STREAM_INFO command and
-         *	       receiving a response back for the command.
-         */
+        ///
+        /// \return The stream info MSRP failure bridge id of a stream after sending a GET_STREAM_INFO command and
+        ///	       receiving a response back for the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_stream_info_msrp_failure_bridge_id() = 0;
 
-        /**
-         * \return The stream info vlan id of a stream after sending a GET_STREAM_INFO command and
-         *	       receiving a response back for the command.
-         */
+        ///
+        /// \return The stream info vlan id of a stream after sending a GET_STREAM_INFO command and
+        ///	       receiving a response back for the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_stream_info_stream_vlan_id() = 0;
     };
 }

--- a/controller/lib/include/stream_output_get_tx_connection_response.h
+++ b/controller/lib/include/stream_output_get_tx_connection_response.h
@@ -38,49 +38,49 @@ namespace avdecc_lib
     {
     public:
         virtual ~stream_output_get_tx_connection_response() {};
-        /**
-         * \return The stream id field used to identify and transfer the associated stream ID where suitable
-         *         after sending a GET_TX_CONNECTION command and receiving a response back for the command.
-         */
+        ///
+        /// \return The stream id field used to identify and transfer the associated stream ID where suitable
+        ///         after sending a GET_TX_CONNECTION command and receiving a response back for the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_tx_connection_stream_id() = 0;
 
-        /**
-         * \return The Talker unique ID used to uniquely identify the stream source of the AVDECC Talker
-         *         after sending a GET_TX_CONNECTION command and receiving a response back for the command.
-         */
+        ///
+        /// \return The Talker unique ID used to uniquely identify the stream source of the AVDECC Talker
+        ///         after sending a GET_TX_CONNECTION command and receiving a response back for the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_tx_connection_talker_unique_id() = 0;
 
-        /**
-         * \return The Listener unique ID used to uniquely identify the stream sink of the AVDECC Listener
-         *         after sending a GET_TX_CONNECTION command and receiving a response back for the command.
-         */
+        ///
+        /// \return The Listener unique ID used to uniquely identify the stream sink of the AVDECC Listener
+        ///         after sending a GET_TX_CONNECTION command and receiving a response back for the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_tx_connection_listener_unique_id() = 0;
 
-        /**
-         * \return The Listener entity ID of the stream sink of the AVDECC Talker
-         *         after sending a GET_TX_CONNECTION command and receiving a response back for the command.
-         */
+        ///
+        /// \return The Listener entity ID of the stream sink of the AVDECC Talker
+        ///         after sending a GET_TX_CONNECTION command and receiving a response back for the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_tx_connection_listener_entity_id() = 0;
 
-        /**
-         * \return The stream destination MAC address used to convey the destination MAC address for a stream
-         *         from the AVDECC Talker to the AVDECC Listener, or from either to the AVDECC Controller after
-         *         sending a GET_TX_CONNECTION command and receiving a response back for the command.
-         */
+        ///
+        /// \return The stream destination MAC address used to convey the destination MAC address for a stream
+        ///         from the AVDECC Talker to the AVDECC Listener, or from either to the AVDECC Controller after
+        ///         sending a GET_TX_CONNECTION command and receiving a response back for the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_tx_connection_stream_dest_mac() = 0;
 
-        /**
-         * \return The connection count used by the state commands to return the number of connections an AVDECC Talker
-         *         thinks it has on its stream source after sending a GET_TX_CONNECTION command and receiving a response
-         *         back for the command.
-         */
+        ///
+        /// \return The connection count used by the state commands to return the number of connections an AVDECC Talker
+        ///         thinks it has on its stream source after sending a GET_TX_CONNECTION command and receiving a response
+        ///         back for the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_tx_connection_connection_count() = 0;
 
-        /**
-         * \return The stream vlan id used to convey the VLAN ID for a stream from the AVDECC Talker to the AVDECC Listener,
-         *         or from either to the AVDECC Controller after sending a GET_TX_CONNECTION command and receiving a response
-         *         back for the command.
-         */
+        ///
+        /// \return The stream vlan id used to convey the VLAN ID for a stream from the AVDECC Talker to the AVDECC Listener,
+        ///         or from either to the AVDECC Controller after sending a GET_TX_CONNECTION command and receiving a response
+        ///         back for the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_tx_connection_stream_vlan_id() = 0;
     };
 }

--- a/controller/lib/include/stream_output_get_tx_state_response.h
+++ b/controller/lib/include/stream_output_get_tx_state_response.h
@@ -38,31 +38,31 @@ namespace avdecc_lib
     {
     public:
         virtual ~stream_output_get_tx_state_response() {};
-        /**
-         * \return The stream id field used to identify and transfer the associated stream ID where suitable
-         * after sending a GET_TX_STATE command and receiving a response back for the command.
-         */
+        ///
+        /// \return The stream id field used to identify and transfer the associated stream ID where suitable
+        ///         after sending a GET_TX_STATE command and receiving a response back for the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_tx_state_stream_id() = 0;
 
-        /**
-         * \return The stream destination MAC address used to convey the destination MAC address for a stream
-         *         from the AVDECC Talker to the AVDECC Listener, or from either to the AVDECC Controller after
-         *         sending a GET_TX_STATE command and receiving a response back for the command.
-         */
+        ///
+        /// \return The stream destination MAC address used to convey the destination MAC address for a stream
+        ///         from the AVDECC Talker to the AVDECC Listener, or from either to the AVDECC Controller after
+        ///         sending a GET_TX_STATE command and receiving a response back for the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_tx_state_stream_dest_mac() = 0;
 
-        /**
-         * \return The connection count used by the state commands to return the number of connections an AVDECC Talker
-         *         thinks it has on its stream source after sending a GET_TX_STATE command and receiving a response
-         *         back for the command.
-         */
+        ///
+        /// \return The connection count used by the state commands to return the number of connections an AVDECC Talker
+        ///         thinks it has on its stream source after sending a GET_TX_STATE command and receiving a response
+        ///         back for the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_tx_state_connection_count() = 0;
 
-        /**
-         * \return The stream vlan id used to convey the VLAN ID for a stream from the AVDECC Talker to the AVDECC Listener,
-         *         or from either to the AVDECC Controller after sending a GET_TX_STATE command and receiving a response
-         *         back for the command.
-         */
+        ///
+        /// \return The stream vlan id used to convey the VLAN ID for a stream from the AVDECC Talker to the AVDECC Listener,
+        ///         or from either to the AVDECC Controller after sending a GET_TX_STATE command and receiving a response
+        ///         back for the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_tx_state_stream_vlan_id() = 0;
     };
 }

--- a/controller/lib/include/stream_port_input_descriptor.h
+++ b/controller/lib/include/stream_port_input_descriptor.h
@@ -41,75 +41,75 @@ namespace avdecc_lib
     class stream_port_input_descriptor : public virtual descriptor_base
     {
     public:
-        /**
-         * \return the stream port input descriptor response class.
-         */
+        ///
+        /// \return the stream port input descriptor response class.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual stream_port_input_descriptor_response * STDCALL get_stream_port_input_response() = 0;
 
-        /**
-         * \return the audio_map get_audio_map response class.
-         */
+        ///
+        /// \return the audio_map get_audio_map response class.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual stream_port_input_get_audio_map_response * STDCALL get_stream_port_input_audio_map_response() = 0;
 
-        /**
-         * \param map The audio_map pending for adding/removal.
-         */
+        ///
+        /// \param map The audio_map pending for adding/removal.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int store_pending_map(struct audio_map_mapping &map) = 0;
 
-        /**
-         *  Get pending audio mappings.
-         *
-         * \param index The index of the queued audio mapping.
-         */
+        ///
+        ///  Get pending audio mappings.
+        ///
+        /// \param index The index of the queued audio mapping.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int get_pending_maps(size_t index, struct audio_map_mapping &map) = 0;
 
-        /**
-         * \return the number of pending audio mappings.
-         */
+        ///
+        /// \return the number of pending audio mappings.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual size_t get_number_of_pending_maps() = 0;
 
-        /**
-         *  Clear pending audio mappings.
-         */
+        ///
+        ///  Clear pending audio mappings.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int clear_pending_maps() = 0;
 
-        /**
-         * Send a GET_AUDIO_MAP command to fetch the dynamic mapping between the Audio Clusters and
-         * the input or output streams.
-         *
-         * \param notification_id A void pointer to the unique identifier associated with the command.
-         */
+        ///
+        /// Send a GET_AUDIO_MAP command to fetch the dynamic mapping between the Audio Clusters and
+        /// the input or output streams.
+        ///
+        /// \param notification_id A void pointer to the unique identifier associated with the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_get_audio_map_cmd(void *notification_id, uint16_t mapping_index) = 0;
 
-        /**
-         * Send an ADD_AUDIO_MAPPINGS command to add mapping entries to the dynamic mappings between the Audio
-         * Clusters and the input or output Streams.  This command sends up to the maximum number of mappings
-         * specified by 1722.1.  If more mappings are pending, this command should be called multiple times.
-         *
-         * The mappings to be added are stored in a local queue.
-         * \see store_pending_map().
-         *
-         * \param notification_id A void pointer to the unique identifier associated with the command.
-         *
-         * \return 0 if there are no pending mappings after sending the command. \n
-         *	       1 if there are more pending mappings after sending the command.
-         */
+        ///
+        /// Send an ADD_AUDIO_MAPPINGS command to add mapping entries to the dynamic mappings between the Audio
+        /// Clusters and the input or output Streams.  This command sends up to the maximum number of mappings
+        /// specified by 1722.1.  If more mappings are pending, this command should be called multiple times.
+        ///
+        /// The mappings to be added are stored in a local queue.
+        /// \see store_pending_map().
+        ///
+        /// \param notification_id A void pointer to the unique identifier associated with the command.
+        ///
+        /// \return 0 if there are no pending mappings after sending the command. \n
+        ///	       1 if there are more pending mappings after sending the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_add_audio_mappings_cmd(void *notification_id) = 0;
 
-        /**
-         * Send a REMOVE_AUDIO_MAPPINGS command to remove mapping entries from the dynamic mappings
-         * between the Audio Clusters and the input or output Streams.  This command sends up to the maximum
-         * number of mappings specified by 1722.1.  If more mappings are pending, this command should be called
-         * multiple times.
-         *
-         * The mappings to be removed are stored in a local queue.
-         * \see store_pending_map().
-         *
-         * \param notification_id A void pointer to the unique identifier associated with the command.
-         *
-         * \return 0 if there are no pending mappings after sending the command. \n
-         *	       1 if there are more pending mappings after sending the command.
-         */
+        ///
+        /// Send a REMOVE_AUDIO_MAPPINGS command to remove mapping entries from the dynamic mappings
+        /// between the Audio Clusters and the input or output Streams.  This command sends up to the maximum
+        /// number of mappings specified by 1722.1.  If more mappings are pending, this command should be called
+        /// multiple times.
+        ///
+        /// The mappings to be removed are stored in a local queue.
+        /// \see store_pending_map().
+        ///
+        /// \param notification_id A void pointer to the unique identifier associated with the command.
+        ///
+        /// \return 0 if there are no pending mappings after sending the command. \n
+        ///	       1 if there are more pending mappings after sending the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_remove_audio_mappings_cmd(void *notification_id) = 0;
     };
 }

--- a/controller/lib/include/stream_port_input_descriptor_response.h
+++ b/controller/lib/include/stream_port_input_descriptor_response.h
@@ -40,53 +40,53 @@ namespace avdecc_lib
     {
     public:
         virtual ~stream_port_input_descriptor_response() {};
-        /**
-         * \return The descriptor index of the CLOCK DOMAIN descriptor describing the CLOCK DOMAIN for the port.
-         */
+        ///
+        /// \return The descriptor index of the CLOCK DOMAIN descriptor describing the CLOCK DOMAIN for the port.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL clock_domain_index() = 0;
 
-        /**
-         * The flags describing the capabilities or features of the port.
-         *
-         * \return 1 (Clock Sync Source) if the port can be used as a clock synchronization source. \n
-         *	       2 (Async Sample Rate Conv) if the port has an asynchronous sample rate converter
-         *	         to convert sample rates between another CLOCK DOMAIN and the Unit's. \n
-         *	       3 (Sync Sample Rate Conv) if the port has a synchronous sample rate converter
-         *	         to convert between sample rates in the same CLOCK DOMAIN.
-         */
+        ///
+        /// The flags describing the capabilities or features of the port.
+        ///
+        /// \return 1 (Clock Sync Source) if the port can be used as a clock synchronization source. \n
+        ///	        2 (Async Sample Rate Conv) if the port has an asynchronous sample rate converter
+        ///	          to convert sample rates between another CLOCK DOMAIN and the Unit's. \n
+        ///	        3 (Sync Sample Rate Conv) if the port has a synchronous sample rate converter
+        ///	          to convert between sample rates in the same CLOCK DOMAIN.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL port_flags() = 0;
 
-        /**
-         * \return The number of controls within the port.
-         */
+        ///
+        /// \return The number of controls within the port.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_controls() = 0;
 
-        /**
-         * \return The index of the first Control descriptor.
-         */
+        ///
+        /// \return The index of the first Control descriptor.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_control() = 0;
 
-        /**
-         * \return The number of clusters within the port. This corresponds to the number of Audio Cluster,
-         *	       Video Cluster, and Sensor Cluster descriptors which represent these clusters.
-         */
+        ///
+        /// \return The number of clusters within the port. This corresponds to the number of Audio Cluster,
+        ///	       Video Cluster, and Sensor Cluster descriptors which represent these clusters.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_clusters() = 0;
 
-        /**
-         * \return The index of the first Audio Cluster, Video Cluster, or Sensor Cluster descriptor
-         *	       describing the clusters within the port.
-         */
+        ///
+        /// \return The index of the first Audio Cluster, Video Cluster, or Sensor Cluster descriptor
+        ///	       describing the clusters within the port.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_cluster() = 0;
 
-        /**
-         * \return The number of map descriptors used to define the mapping between the stream and the port.
-         */
+        ///
+        /// \return The number of map descriptors used to define the mapping between the stream and the port.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_maps() = 0;
 
-        /**
-         * \return The index of the first Audio Map, Video Map, or Sensor Map, descriptor which defines
-         *	       the mappling between the stream and the port.
-         */
+        ///
+        /// \return The index of the first Audio Map, Video Map, or Sensor Map, descriptor which defines
+        ///	       the mappling between the stream and the port.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_map() = 0;
     };
 }

--- a/controller/lib/include/stream_port_input_get_audio_map_response.h
+++ b/controller/lib/include/stream_port_input_get_audio_map_response.h
@@ -47,18 +47,18 @@ namespace avdecc_lib
     public:
         virtual ~stream_port_input_get_audio_map_response() {};
 
-        /**
-         * \return The GET_AUDIO_MAP response map_index.
-         */
+        ///
+        /// \return The GET_AUDIO_MAP response map_index.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t map_index() = 0;
 
-        /**
-         * \return The number of mappings contained in a GET_AUDIO_MAP response.
-         */
+        ///
+        /// \return The number of mappings contained in a GET_AUDIO_MAP response.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t number_of_mappings() = 0;
-        /**
-         * \return The audio mapping by index after sending a GET_AUDIO_MAP command.
-         */
+        ///
+        /// \return The audio mapping by index after sending a GET_AUDIO_MAP command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL mapping(size_t index, struct stream_port_input_audio_mapping &map) = 0;
     };
 }

--- a/controller/lib/include/stream_port_output_descriptor.h
+++ b/controller/lib/include/stream_port_output_descriptor.h
@@ -41,75 +41,75 @@ namespace avdecc_lib
     class stream_port_output_descriptor : public virtual descriptor_base
     {
     public:
-        /**
-         * \return the stream port output descriptor response class.
-         */
+        ///
+        /// \return the stream port output descriptor response class.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual stream_port_output_descriptor_response * STDCALL get_stream_port_output_response() = 0;
 
-        /**
-         * \return the audio_map get_audio_map response class.
-         */
+        ///
+        /// \return the audio_map get_audio_map response class.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual stream_port_output_get_audio_map_response * STDCALL get_stream_port_output_audio_map_response() = 0;
 
-        /**
-         * \param map The added audio_map pending for adding/removal.
-         */
+        ///
+        /// \param map The added audio_map pending for adding/removal.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int store_pending_map(struct audio_map_mapping &map) = 0;
 
-        /**
-         *  Get pending audio mappings.
-         *
-         * \param index The index of the queued audio mapping.
-         */
+        ///
+        /// Get pending audio mappings.
+        ///
+        /// \param index The index of the queued audio mapping.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int get_pending_maps(size_t index, struct audio_map_mapping &map) = 0;
 
-        /**
-         *  Clear pending audio mappings.
-         */
+        ///
+        ///  Clear pending audio mappings.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int clear_pending_maps() = 0;
 
-        /**
-         * \return the number of pending audio mappings.
-         */
+        ///
+        /// \return the number of pending audio mappings.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual size_t get_number_of_pending_maps() = 0;
 
-        /**
-         * Send a GET_AUDIO_MAP command to fetch the dynamic mapping between the Audio Clusters and
-         * the input or output streams.
-         *
-         * \param notification_id A void pointer to the unique identifier associated with the command.
-         */
+        ///
+        /// Send a GET_AUDIO_MAP command to fetch the dynamic mapping between the Audio Clusters and
+        /// the input or output streams.
+        ///
+        /// \param notification_id A void pointer to the unique identifier associated with the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_get_audio_map_cmd(void *notification_id, uint16_t mapping_index) = 0;
 
-        /**
-         * Send an ADD_AUDIO_MAPPINGS command to add mapping entries to the dynamic mappings between the Audio
-         * Clusters and the input or output Streams.  This command sends up to the maximum number of mappings
-         * specified by 1722.1.  If more mappings are pending, this command should be called multiple times.
-         *
-         * The mappings to be added are stored in a local queue.
-         * \see store_pending_map().
-         *
-         * \param notification_id A void pointer to the unique identifier associated with the command.
-         *
-         * \return 0 if there are no pending mappings after sending the command. \n
-         *	       1 if there are more pending mappings after sending the command.
-         */
+        ///
+        /// Send an ADD_AUDIO_MAPPINGS command to add mapping entries to the dynamic mappings between the Audio
+        /// Clusters and the input or output Streams.  This command sends up to the maximum number of mappings
+        /// specified by 1722.1.  If more mappings are pending, this command should be called multiple times.
+        ///
+        /// The mappings to be added are stored in a local queue.
+        /// \see store_pending_map().
+        ///
+        /// \param notification_id A void pointer to the unique identifier associated with the command.
+        ///
+        /// \return 0 if there are no pending mappings after sending the command. \n
+        ///	        1 if there are more pending mappings after sending the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_add_audio_mappings_cmd(void *notification_id) = 0;
 
-        /**
-         * Send a REMOVE_AUDIO_MAPPINGS command to remove mapping entries from the dynamic mappings
-         * between the Audio Clusters and the input or output Streams.  This command sends up to the maximum
-         * number of mappings specified by 1722.1.  If more mappings are pending, this command should be called
-         * multiple times.
-         *
-         * The mappings to be removed are stored in a local queue.
-         * \see store_pending_map().
-         *
-         * \param notification_id A void pointer to the unique identifier associated with the command.
-         *
-         * \return 0 if there are no pending mappings after sending the command. \n
-         *	       1 if there are more pending mappings after sending the command.
-         */
+        ///
+        /// Send a REMOVE_AUDIO_MAPPINGS command to remove mapping entries from the dynamic mappings
+        /// between the Audio Clusters and the input or output Streams.  This command sends up to the maximum
+        /// number of mappings specified by 1722.1.  If more mappings are pending, this command should be called
+        /// multiple times.
+        ///
+        /// The mappings to be removed are stored in a local queue.
+        /// \see store_pending_map().
+        ///
+        /// \param notification_id A void pointer to the unique identifier associated with the command.
+        ///
+        /// \return 0 if there are no pending mappings after sending the command. \n
+        ///	        1 if there are more pending mappings after sending the command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_remove_audio_mappings_cmd(void *notification_id) = 0;
     };
 }

--- a/controller/lib/include/stream_port_output_descriptor_response.h
+++ b/controller/lib/include/stream_port_output_descriptor_response.h
@@ -40,53 +40,53 @@ namespace avdecc_lib
     {
     public:
         virtual ~stream_port_output_descriptor_response() {};
-        /**
-         * \return The descriptor index of the CLOCK DOMAIN descriptor describing the CLOCK DOMAIN for the port.
-         */
+        ///
+        /// \return The descriptor index of the CLOCK DOMAIN descriptor describing the CLOCK DOMAIN for the port.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL clock_domain_index() = 0;
 
-        /**
-         * The flags describing the capabilities or features of the port.
-         *
-         * \return 1 (Clock Sync Source) if the port can be used as a clock synchronization source. \n
-         *	       2 (Async Sample Rate Conv) if the port has an asynchronous sample rate converter
-         *	         to convert sample rates between another CLOCK DOMAIN and the Unit's. \n
-         *	       3 (Sync Sample Rate Conv) if the port has a synchronous sample rate converter
-         *	         to convert between sample rates in the same CLOCK DOMAIN.
-         */
+        ///
+        /// The flags describing the capabilities or features of the port.
+        ///
+        /// \return 1 (Clock Sync Source) if the port can be used as a clock synchronization source. \n
+        ///	        2 (Async Sample Rate Conv) if the port has an asynchronous sample rate converter
+        ///	          to convert sample rates between another CLOCK DOMAIN and the Unit's. \n
+        ///	        3 (Sync Sample Rate Conv) if the port has a synchronous sample rate converter
+        ///	          to convert between sample rates in the same CLOCK DOMAIN.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL port_flags() = 0;
 
-        /**
-         * \return The number of controls within the port.
-         */
+        ///
+        /// \return The number of controls within the port.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_controls() = 0;
 
-        /**
-         * \return The index of the first Control descriptor.
-         */
+        ///
+        /// \return The index of the first Control descriptor.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_control() = 0;
 
-        /**
-         * \return The number of clusters within the port. This corresponds to the number of Audio Cluster,
-         *	       Video Cluster, and Sensor Cluster descriptors which represent these clusters.
-         */
+        ///
+        /// \return The number of clusters within the port. This corresponds to the number of Audio Cluster,
+        ///	       Video Cluster, and Sensor Cluster descriptors which represent these clusters.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_clusters() = 0;
 
-        /**
-         * \return The index of the first Audio Cluster, Video Cluster, or Sensor Cluster descriptor
-         *	       describing the clusters within the port.
-         */
+        ///
+        /// \return The index of the first Audio Cluster, Video Cluster, or Sensor Cluster descriptor
+        ///	       describing the clusters within the port.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_cluster() = 0;
 
-        /**
-         * \return The number of map descriptors used to define the mapping between the stream and the port.
-         */
+        ///
+        /// \return The number of map descriptors used to define the mapping between the stream and the port.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL number_of_maps() = 0;
 
-        /**
-         * \return The index of the first Audio Map, Video Map, or Sensor Map, descriptor which defines
-         *	       the mappling between the stream and the port.
-         */
+        ///
+        /// \return The index of the first Audio Map, Video Map, or Sensor Map, descriptor which defines
+        ///	       the mappling between the stream and the port.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL base_map() = 0;
     };
 }

--- a/controller/lib/include/stream_port_output_get_audio_map_response.h
+++ b/controller/lib/include/stream_port_output_get_audio_map_response.h
@@ -46,18 +46,18 @@ namespace avdecc_lib
     {
     public:
         virtual ~stream_port_output_get_audio_map_response() {};
-        /**
-         * \return The GET_AUDIO_MAP response map_index.
-         */
+        ///
+        /// \return The GET_AUDIO_MAP response map_index.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t map_index() = 0;
 
-        /**
-         * \return The number of mappings contained in a GET_AUDIO_MAP response.
-         */
+        ///
+        /// \return The number of mappings contained in a GET_AUDIO_MAP response.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint16_t number_of_mappings() = 0;
-        /**
-         * \return The audio mapping by index after sending a GET_AUDIO_MAP command.
-         */
+        ///
+        /// \return The audio mapping by index after sending a GET_AUDIO_MAP command.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL mapping(size_t index, struct stream_port_output_audio_mapping &map) = 0;
     };
 }

--- a/controller/lib/include/strings_descriptor.h
+++ b/controller/lib/include/strings_descriptor.h
@@ -40,9 +40,9 @@ namespace avdecc_lib
     class strings_descriptor : public virtual descriptor_base
     {
     public:
-        /**
-         * \return the strings descriptor response class.
-         */
+        ///
+        /// \return the strings descriptor response class.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual strings_descriptor_response * STDCALL get_strings_response() = 0;
     };
 }

--- a/controller/lib/include/strings_descriptor_response.h
+++ b/controller/lib/include/strings_descriptor_response.h
@@ -41,9 +41,9 @@ namespace avdecc_lib
     {
     public:
         virtual ~strings_descriptor_response() {};
-        /**
-         * \return The corresponding localized string of the Strings descriptor.
-         */
+        ///
+        /// \return The corresponding localized string of the Strings descriptor.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual uint8_t * STDCALL get_string_by_index(size_t string_index) = 0;
     };
 }

--- a/controller/lib/include/system.h
+++ b/controller/lib/include/system.h
@@ -46,39 +46,39 @@ namespace avdecc_lib
             // Add system types
         };
 
-        /**
-         * Call destructor for System used for destroying objects
-         */
+        ///
+        /// Call destructor for System used for destroying objects
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual void STDCALL destroy() = 0;
 
-        /**
-         * Set a waiting flag for the command to be sent.
-         */
+        ///
+        /// Set a waiting flag for the command to be sent.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL set_wait_for_next_cmd(void *) = 0;
 
-        /**
-         * Wait for the response packet with the corrsponding notification id to be received.
-         */
+        ///
+        /// Wait for the response packet with the corrsponding notification id to be received.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL get_last_resp_status() = 0;
 
-        /**
-         * Start point of the system process, which calls the thread initialization function.
-         */
+        ///
+        /// Start point of the system process, which calls the thread initialization function.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL process_start() = 0;
 
-        /**
-         * End point of the system process, which terminates the threads.
-         */
+        ///
+        /// End point of the system process, which terminates the threads.
+        ///
         AVDECC_CONTROLLER_LIB32_API virtual int STDCALL process_close() = 0;
     };
 
-    /**
-     * Create a public AVDECC System object with a certain System type, network interface and controller objects used for accessing from outside the library.
-     *
-     * \param type The type of the system to be created.
-     * \param netif A network interface object created in the application level using the public network interface API provided.
-     * \param controller_obj An AVDECC Controller object created in the application level using the public Controller API provided.
-     */
+    //
+    // Create a public AVDECC System object with a certain System type, network interface and controller objects used for accessing from outside the library.
+    //
+    // \param type The type of the system to be created.
+    // \param netif A network interface object created in the application level using the public network interface API provided.
+    // \param controller_obj An AVDECC Controller object created in the application level using the public Controller API provided.
+    //
     extern "C" AVDECC_CONTROLLER_LIB32_API system * STDCALL create_system(system::system_type type, net_interface *netif, controller *controller_obj);
 }
 

--- a/controller/lib/include/util.h
+++ b/controller/lib/include/util.h
@@ -36,109 +36,109 @@ namespace avdecc_lib
 {
     namespace utility
     {
-        /**
-         * Convert command value to its corresponding AEM command name.
-         */
+        ///
+        /// Convert command value to its corresponding AEM command name.
+        ///
         AVDECC_CONTROLLER_LIB32_API const char * STDCALL aem_cmd_value_to_name(uint16_t cmd_value);
 
-        /**
-         * Convert AEM command name to its corresponding command value.
-         */
+        ///
+        /// Convert AEM command name to its corresponding command value.
+        ///
         AVDECC_CONTROLLER_LIB32_API uint16_t STDCALL aem_cmd_name_to_value(const char *cmd_name);
 
-        /**
-         * Convert descriptor value to its corresponding descriptor name.
-         */
+        ///
+        /// Convert descriptor value to its corresponding descriptor name.
+        ///
         AVDECC_CONTROLLER_LIB32_API const char * STDCALL aem_desc_value_to_name(uint16_t desc_value);
 
-        /**
-         * Convert descriptor name to its corresponding descriptor value.
-         */
+        ///
+        /// Convert descriptor name to its corresponding descriptor value.
+        ///
         AVDECC_CONTROLLER_LIB32_API uint16_t STDCALL aem_desc_name_to_value(const char *desc_name);
 
-        /**
-         * Convert AEM command status value to its corresponding command status name.
-         */
+        ///
+        /// Convert AEM command status value to its corresponding command status name.
+        ///
         AVDECC_CONTROLLER_LIB32_API const char * STDCALL aem_cmd_status_value_to_name(uint32_t aem_cmd_status_value);
 
-        /**
-         * Convert command value to its corresponding ACMP command name.
-         */
+        ///
+        /// Convert command value to its corresponding ACMP command name.
+        ///
         AVDECC_CONTROLLER_LIB32_API const char * STDCALL acmp_cmd_value_to_name(uint32_t cmd_value);
 
-        /**
-         * Convert ACMP command name to its corresponding command value.
-         */
+        ///
+        /// Convert ACMP command name to its corresponding command value.
+        ///
         AVDECC_CONTROLLER_LIB32_API uint16_t STDCALL acmp_cmd_name_to_value(const char *cmd_name);
 
-        /**
-         * Convert ACMP command status value to its corresponding command status name.
-         */
+        ///
+        /// Convert ACMP command status value to its corresponding command status name.
+        ///
         AVDECC_CONTROLLER_LIB32_API const char * STDCALL acmp_cmd_status_value_to_name(uint32_t acmp_cmd_status_value);
 
-        /**
-         * Convert notification value to its corresponding notification name.
-         */
+        ///
+        /// Convert notification value to its corresponding notification name.
+        ///
         AVDECC_CONTROLLER_LIB32_API const char * STDCALL notification_value_to_name(uint16_t notification_value);
 
-        /**
-         * Convert post_log_msg value to its corresponding post_log_msg name.
-         */
+        ///
+        /// Convert post_log_msg value to its corresponding post_log_msg name.
+        ///
         AVDECC_CONTROLLER_LIB32_API const char * STDCALL logging_level_value_to_name(uint16_t logging_level_value);
 
-        /**
-         * Get the timeout for the corresponding ACMP command.
-         */
+        ///
+        /// Get the timeout for the corresponding ACMP command.
+        ///
         AVDECC_CONTROLLER_LIB32_API uint32_t STDCALL acmp_cmd_to_timeout(const uint32_t acmp_cmd);
 
-        /**
-          * Convert IEEE1722 format name to value.
-          */
+        ///
+        /// Convert IEEE1722 format name to value.
+        ///
         AVDECC_CONTROLLER_LIB32_API uint64_t STDCALL ieee1722_format_name_to_value(const char *format_name);
 
-        /**
-         * Convert IEEE1722 format name to description.
-         */
+        ///
+        /// Convert IEEE1722 format name to description.
+        ///
         AVDECC_CONTROLLER_LIB32_API const char * STDCALL ieee1722_format_name_to_description(const char *format_name);
 
-        /**
-         *  Return IEEE1722 format value by index
-         */
+        ///
+        ///  Return IEEE1722 format value by index
+        ///
         AVDECC_CONTROLLER_LIB32_API uint64_t STDCALL ieee1722_format_index_to_value(unsigned int index);
 
-        /**
-         *  Return IEEE1722 format name by index
-         */
+        ///
+        ///  Return IEEE1722 format name by index
+        ///
         AVDECC_CONTROLLER_LIB32_API const char * STDCALL ieee1722_format_index_to_name(unsigned int index);
 
-        /**
-         *  Return IEEE1722 format description by index
-         */
+        ///
+        ///  Return IEEE1722 format description by index
+        ///
         AVDECC_CONTROLLER_LIB32_API const char * STDCALL ieee1722_format_index_to_description(unsigned int index);
 
-        /**
-         * Convert IEEE1722 format value to name.
-         */
+        ///
+        /// Convert IEEE1722 format value to name.
+        ///
         AVDECC_CONTROLLER_LIB32_API const char * STDCALL ieee1722_format_value_to_name(uint64_t format_value);
 
-        /**
-         * Get IEEE1722 format table size
-         */
+        ///
+        /// Get IEEE1722 format table size
+        ///
         AVDECC_CONTROLLER_LIB32_API unsigned int STDCALL get_ieee1722_format_table_size();
 
-        /**
-         * Convert End Station MAC address to a short string.
-         */
+        ///
+        /// Convert End Station MAC address to a short string.
+        ///
         AVDECC_CONTROLLER_LIB32_API const char * STDCALL end_station_mac_to_string(uint64_t end_station_mac);
 
-        /**
-         * Convert an uint64_t value to eui48.
-         */
+        ///
+        /// Convert an uint64_t value to eui48.
+        ///
         AVDECC_CONTROLLER_LIB32_API void convert_uint64_to_eui48(const uint64_t value, uint8_t new_value[6]);
 
-        /**
-         * Convert an eui48 value to uint64_t.
-         */
+        ///
+        /// Convert an eui48 value to uint64_t.
+        ///
         AVDECC_CONTROLLER_LIB32_API void convert_eui48_to_uint64(const uint8_t value[6], uint64_t &new_value);
     }
 }

--- a/controller/lib/src/acmp_controller_state_machine.h
+++ b/controller/lib/src/acmp_controller_state_machine.h
@@ -43,56 +43,55 @@ public:
     acmp_controller_state_machine();
 
     ~acmp_controller_state_machine();
-
-    /**
-     * Initialize and fill Ethernet frame payload with Ethernet frame information for AEM commands.
-     */
+    ///
+    /// Initialize and fill Ethernet frame payload with Ethernet frame information for AEM commands.
+    ///
     int ether_frame_init(struct jdksavdecc_frame *cmd_frame);
 
-    /**
-     * Initialize and fill Ethernet frame payload with 1722 ACMP Header information.
-     */
+    ///
+    /// Initialize and fill Ethernet frame payload with 1722 ACMP Header information.
+    ///
     void common_hdr_init(uint32_t msg_type, struct jdksavdecc_frame *cmd_frame);
 
-    /**
-     * Process the Command state of the ACMP Controller State Machine.
-     */
+    ///
+    /// Process the Command state of the ACMP Controller State Machine.
+    ///
     int state_command(void *notification_id, uint32_t notification_flag, struct jdksavdecc_frame *cmd_frame);
 
-    /**
-     * Process the Response state of the ACMP Controller State Machine.
-     */
+    ///
+    /// Process the Response state of the ACMP Controller State Machine.
+    ///
     int state_resp(void *&notification_id, struct jdksavdecc_frame *cmd_frame);
 
-    /**
-     * Check timeout for the inflight commands.
-     */
+    ///
+    /// Check timeout for the inflight commands.
+    ///
     void tick();
 
-    /**
-     * Check if the command with the corresponding notification id is already in the inflight command vector.
-     */
+    ///
+    /// Check if the command with the corresponding notification id is already in the inflight command vector.
+    ///
     bool is_inflight_cmd_with_notification_id(void *notification_id);
 
 private:
-    /**
-     * Process the Timeout state of the ACMP Controller State Machine.
-     */
+    ///
+    /// Process the Timeout state of the ACMP Controller State Machine.
+    ///
     void state_timeout(uint32_t inflight_cmd_index);
 
-    /**
-     * Transmit an ACMP Command.
-     */
+    ///
+    /// Transmit an ACMP Command.
+    ///
     int tx_cmd(void *notification_id, uint32_t notification_flag, struct jdksavdecc_frame *cmd_frame, bool resend);
 
-    /**
-     * Handle the receipt and processing of a received response for a command sent.
-     */
+    ///
+    /// Handle the receipt and processing of a received response for a command sent.
+    ///
     int proc_resp(void *&notification_id, struct jdksavdecc_frame *cmd_frame);
 
-    /**
-     * Call notification or post_log_msg callback function for the command sent or response received.
-     */
+    ///
+    /// Call notification or post_log_msg callback function for the command sent or response received.
+    ///
     int callback(void *notification_id, uint32_t notification_flag, uint8_t *frame);
 };
 

--- a/controller/lib/src/adp.h
+++ b/controller/lib/src/adp.h
@@ -44,178 +44,177 @@ private:
     int proc_adpdu_returned; //result of ADP update
 
 public:
-    /**
-     * Constructor for ADP used for constructing an object with a base pointer and memory buffer length.
-     */
+    ///
+    /// Constructor for ADP used for constructing an object with a base pointer and memory buffer length.
+    ///
     adp(const uint8_t *frame, size_t frame_len);
 
     ~adp();
-
-    /**
-     * Update the stored ADP contents with the latest ADPDU fields
-     */
+    ///
+    /// Update the stored ADP contents with the latest ADPDU fields
+    ///
     int proc_adpdu(const uint8_t *frame, size_t frame_len);
 
-    /**
-     * Get the Ethernet type of the ADP packet.
-     */
+    ///
+    /// Get the Ethernet type of the ADP packet.
+    ///
     inline uint16_t get_ethernet_type()
     {
         return cmd_frame.ethertype;
     }
 
-    /**
-     * Get the source address of the ADP packet.
-     */
+    ///
+    /// Get the source address of the ADP packet.
+    ///
     inline struct jdksavdecc_eui48 get_src_addr()
     {
         return cmd_frame.src_address;
     }
 
-    /**
-     * Get the destination address of the ADP packet.
-     */
+    ///
+    /// Get the destination address of the ADP packet.
+    ///
     inline struct jdksavdecc_eui48 get_dest_addr()
     {
         return cmd_frame.dest_address;
     }
 
-    /**
-     * Get the Controller Entity ID of the AVDECC Entity sending the command.
-     */
+    ///
+    /// Get the Controller Entity ID of the AVDECC Entity sending the command.
+    ///
     static struct jdksavdecc_eui64 get_controller_entity_id();
 
-    /**
-     * Get the header field of the ADP object.
-     */
+    ///
+    /// Get the header field of the ADP object.
+    ///
     inline struct jdksavdecc_adpdu_common_control_header get_hdr()
     {
         return adpdu.header;
     }
 
-    /**
-     * Get the Entity ID field of the ADP object.
-     */
+    ///
+    /// Get the Entity ID field of the ADP object.
+    ///
     inline struct jdksavdecc_eui64 get_entity_entity_id()
     {
         return adpdu.header.entity_id;
     }
 
-    /**
-     * Get the Entity model id field of the ADP object.
-     */
+    ///
+    /// Get the Entity model id field of the ADP object.
+    ///
     inline uint64_t get_entity_model_id()
     {
         return jdksavdecc_uint64_get(&adpdu.entity_model_id, 0);
     }
 
-    /**
-     * Get the Entity capabilities field of the ADP object.
-     */
+    ///
+    /// Get the Entity capabilities field of the ADP object.
+    ///
     inline uint32_t get_entity_capabilities()
     {
         return adpdu.entity_capabilities;
     }
 
-    /**
-     * Get the Talker stream sources field of the ADP object.
-     */
+    ///
+    /// Get the Talker stream sources field of the ADP object.
+    ///
     inline uint16_t get_talker_stream_sources()
     {
         return adpdu.talker_stream_sources;
     }
 
-    /**
-     * Get the Talker capabilities field of the ADP object.
-     */
+    ///
+    /// Get the Talker capabilities field of the ADP object.
+    ///
     inline uint16_t get_talker_capabilities()
     {
         return adpdu.talker_capabilities;
     }
 
-    /**
-     * Get the Listener stream sinks field of the ADP object.
-     */
+    ///
+    /// Get the Listener stream sinks field of the ADP object.
+    ///
     inline uint16_t get_listener_stream_sinks()
     {
         return adpdu.listener_stream_sinks;
     }
 
-    /**
-     * Get the Listener capabilities field of the ADP object.
-     */
+    ///
+    /// Get the Listener capabilities field of the ADP object.
+    ///
     inline uint16_t get_listener_capabilities()
     {
         return adpdu.listener_capabilities;
     }
 
-    /**
-     * Get the Controller capabilities field of the ADP object.
-     */
+    ///
+    /// Get the Controller capabilities field of the ADP object.
+    ///
     inline uint32_t get_controller_capabilities()
     {
         return adpdu.controller_capabilities;
     }
 
-    /**
-     * Get the available index field of the ADP object.
-     */
+    ///
+    /// Get the available index field of the ADP object.
+    ///
     inline uint32_t get_available_index()
     {
         return adpdu.available_index;
     }
 
-    /**
-     * Get the GPTP grandmaster id field of the ADP object.
-     */
+    ///
+    /// Get the GPTP grandmaster id field of the ADP object.
+    ///
     inline uint64_t get_gptp_grandmaster_id()
     {
         return jdksavdecc_uint64_get(&adpdu.gptp_grandmaster_id, 0);
     }
 
-    /**
-     * Get the GPTP domain number field of the ADP object.
-     */
+    ///
+    /// Get the GPTP domain number field of the ADP object.
+    ///
     inline uint8_t get_gptp_domain_number()
     {
         return adpdu.gptp_domain_number;
     }
 
-    /**
-     * Get the reserved0 field of the ADP object.
-     */
+    ///
+    /// Get the reserved0 field of the ADP object.
+    ///
     inline uint32_t get_reserved0()
     {
         return adpdu.reserved0;
     }
 
-    /**
-     * Get the identify control index field of the ADP object.
-     */
+    ///
+    /// Get the identify control index field of the ADP object.
+    ///
     inline uint16_t get_identify_control_index()
     {
         return adpdu.identify_control_index;
     }
 
-    /**
-     * Get the interface index field of the ADP object.
-     */
+    ///
+    /// Get the interface index field of the ADP object.
+    ///
     inline uint16_t get_interface_index()
     {
         return adpdu.interface_index;
     }
 
-    /**
-     * Get the association id field of the ADP object.
-     */
+    ///
+    /// Get the association id field of the ADP object.
+    ///
     inline uint64_t get_association_id()
     {
         return jdksavdecc_uint64_get(&adpdu.association_id, 0);
     }
 
-    /**
-     * Get the reserved1 field of the ADPDU object.
-     */
+    ///
+    /// Get the reserved1 field of the ADPDU object.
+    ///
     inline uint32_t get_reserved1()
     {
         return adpdu.reserved1;

--- a/controller/lib/src/adp_discovery_state_machine.h
+++ b/controller/lib/src/adp_discovery_state_machine.h
@@ -49,72 +49,71 @@ public:
     adp_discovery_state_machine();
 
     ~adp_discovery_state_machine();
-
-    /**
-     * Initialize and fill Ethernet frame payload with Ethernet frame information for ADP messages.
-     */
+    ///
+    /// Initialize and fill Ethernet frame payload with Ethernet frame information for ADP messages.
+    ///
     int ether_frame_init(struct jdksavdecc_frame *cmd_frame);
 
-    /**
-     * Initialize and fill Ethernet frame payload with 1722 ADP Header information.
-     */
+    ///
+    /// Initialize and fill Ethernet frame payload with 1722 ADP Header information.
+    ///
     void common_hdr_init(struct jdksavdecc_frame *cmd_frame, uint64_t target_entity_id);
 
-    /**
-     * Process the Discover state of the ADP Discovery State Machine.
-     */
+    ///
+    /// Process the Discover state of the ADP Discovery State Machine.
+    ///
     int state_discover(uint64_t discover_id);
 
-    /**
-     * Process the Available state of the ADP Discovery State Machine.
-     */
+    ///
+    /// Process the Available state of the ADP Discovery State Machine.
+    ///
     int state_avail(const uint8_t *frame, size_t frame_len);
 
-    /**
-     * Process the Departing state of the ADP Discovery State Machine.
-     */
+    ///
+    /// Process the Departing state of the ADP Discovery State Machine.
+    ///
     int state_departing();
 
-    /**
-     * Check timeout for the end stations.
-     */
+    ///
+    /// Check timeout for the end stations.
+    ///
     bool tick(uint64_t &end_station_entity_id);
 
 private:
-    /**
-     * The perform discover event is used to trigger an AVDECC Entity discovery search to search
-     * for all AVDECC Entities or to the Entity ID of an AVDECC Entity to search for.
-     */
+    ///
+    /// The perform discover event is used to trigger an AVDECC Entity discovery search to search
+    /// for all AVDECC Entities or to the Entity ID of an AVDECC Entity to search for.
+    ///
     int perform_discover(uint64_t entity_id);
 
-    /**
-     * Transmit an ENTITY_DISCOVER message.
-     */
+    ///
+    /// Transmit an ENTITY_DISCOVER message.
+    ///
     int tx_discover(struct jdksavdecc_frame *cmd_frame);
 
-    /**
-     * Check if an AVDECC Entity is present in the entities variable.
-     */
+    ///
+    /// Check if an AVDECC Entity is present in the entities variable.
+    ///
     bool have_entity(uint64_t entity_id, uint32_t *entity_index);
 
-    /**
-     * Update the AVDECC Entity record timeout information.
-     */
+    ///
+    /// Update the AVDECC Entity record timeout information.
+    ///
     int update_entity_timeout(uint32_t entity_index, uint32_t timeout_ms);
 
-    /**
-     * Add a new Entity record to the entities variable.
-     */
+    ///
+    /// Add a new Entity record to the entities variable.
+    ///
     int add_entity(struct entities new_entity);
 
-    /**
-     * Remove an Entity record form the entities variable.
-     */
+    ///
+    /// Remove an Entity record form the entities variable.
+    ///
     int remove_entity(uint32_t entity_index);
 
-    /**
-     * Process the Timeout state of the ADP Discovery State Machine.
-     */
+    ///
+    /// Process the Timeout state of the ADP Discovery State Machine.
+    ///
     int state_timeout(uint32_t entity_index);
 };
 

--- a/controller/lib/src/aecp_controller_state_machine.h
+++ b/controller/lib/src/aecp_controller_state_machine.h
@@ -48,40 +48,39 @@ public:
     aecp_controller_state_machine();
 
     ~aecp_controller_state_machine();
-
-    /**
-     * Initialize and fill Ethernet frame payload with Ethernet frame information for AEM commands.
-     */
+    ///
+    /// Initialize and fill Ethernet frame payload with Ethernet frame information for AEM commands.
+    ///
     int ether_frame_init(uint64_t end_station_mac, struct jdksavdecc_frame *cmd_frame, uint16_t len);
 
-    /**
-     * Initialize and fill Ethernet frame payload with 1722 AECP Header information.
-     */
+    ///
+    /// Initialize and fill Ethernet frame payload with 1722 AECP Header information.
+    ///
     void common_hdr_init(int message_type, struct jdksavdecc_frame *cmd_frame, uint64_t target_entity_id, uint32_t cd_len);
 
-    /**
-     * Process the Send Command state of the AEM Controller State Machine.
-     */
+    ///
+    /// Process the Send Command state of the AEM Controller State Machine.
+    ///
     int state_send_cmd(void *notification_id, uint32_t notification_flag, struct jdksavdecc_frame *cmd_frame);
 
-    /**
-     * Process the Received Unsolicited state of the AEM Controller State Machine.
-     */
+    ///
+    /// Process the Received Unsolicited state of the AEM Controller State Machine.
+    ///
     int state_rcvd_unsolicited(struct jdksavdecc_frame *cmd_frame);
 
-    /**
-     * Process the Received Response state of the AEM Controller State Machine.
-     */
+    ///
+    /// Process the Received Response state of the AEM Controller State Machine.
+    ///
     int state_rcvd_resp(void *&notification_id, struct jdksavdecc_frame *cmd_frame);
 
-    /**
-    * Check timeout for the inflight commands.
-    */
+    ///
+    /// Check timeout for the inflight commands.
+    ///
     void tick();
 
-    /**
-     * Update inflight command for the response received.
-     */
+    ///
+    /// Update inflight command for the response received.
+    ///
     int update_inflight_for_rcvd_resp(void *&notification_id, uint32_t msg_type, bool u_field, struct jdksavdecc_frame *cmd_frame);
 
     int start_operation(void *&notification_id, uint16_t operation_id, uint16_t operation_type, const uint8_t *frame, ssize_t frame_len);
@@ -89,36 +88,36 @@ public:
 
     int update_operation_for_rcvd_resp(void *&notification_id, uint16_t operation_id, uint16_t percent_complete, struct jdksavdecc_frame *cmd_frame);
 
-    /**
-     * Check if the command with the corresponding notification id is already in the inflight command vector.
-     */
+    ///
+    /// Check if the command with the corresponding notification id is already in the inflight command vector.
+    ///
     bool is_inflight_cmd_with_notification_id(void *notification_id);
 
 private:
-    /**
-     * Transmit an AEM Command.
-     */
+    ///
+    /// Transmit an AEM Command.
+    ///
     int tx_cmd(void *notification_id, uint32_t notification_flag, struct jdksavdecc_frame *cmd_frame, bool resend);
 
-    /**
-     * Handle the receipt and processing of a received unsolicited response for a command sent.
-     */
+    ///
+    /// Handle the receipt and processing of a received unsolicited response for a command sent.
+    ///
     int proc_unsolicited(struct jdksavdecc_frame *cmd_frame);
 
-    /**
-     * Handle the receipt and processing of a received response for a command sent.
-     */
+    ///
+    /// Handle the receipt and processing of a received response for a command sent.
+    ///
     int proc_resp(void *&notification_id, struct jdksavdecc_frame *cmd_frame);
 
-    /**
-     * Notify the application that a command has timed out and the retry has timed out and the
-     * inflight command is removed from the inflight list.
-     */
+    ///
+    /// Notify the application that a command has timed out and the retry has timed out and the
+    /// inflight command is removed from the inflight list.
+    ///
     void state_timeout(uint32_t inflight_cmd_index);
 
-    /**
-     * Call notification or post_log_msg callback function for the command sent or response received.
-     */
+    ///
+    /// Call notification or post_log_msg callback function for the command sent or response received.
+    ///
     int callback(void *notification_id, uint32_t notification_flag, uint8_t *frame);
 };
 

--- a/controller/lib/src/audio_unit_descriptor_response_imp.h
+++ b/controller/lib/src/audio_unit_descriptor_response_imp.h
@@ -84,9 +84,9 @@ public:
     uint16_t sampling_rates_offset();
     uint16_t STDCALL sampling_rates_count();
 private:
-    /**
-     * Store the sampling rates of the AUDIO UNIT in a vector.
-     */
+    ///
+    /// Store the sampling rates of the AUDIO UNIT in a vector.
+    ///
     void sampling_rates_init(const uint8_t *frame);
 };
 }

--- a/controller/lib/src/cassert.h
+++ b/controller/lib/src/cassert.h
@@ -35,9 +35,8 @@
     typedef char msg[(cond) ? 1 : -1]
 #endif
 
-/* The following macro is often used in conjunction with compile_time_assert().
- * While a better location is found for its definitions, we will leave it here.
- */
+// The following macro is often used in conjunction with compile_time_assert().
+// While a better location is found for its definitions, we will leave it here.
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof(x[0]))
 
 #endif /* _CASSERT_H */

--- a/controller/lib/src/clock_domain_descriptor_response_imp.h
+++ b/controller/lib/src/clock_domain_descriptor_response_imp.h
@@ -40,9 +40,9 @@ class clock_domain_descriptor_response_imp : public clock_domain_descriptor_resp
 {
 private:
     std::vector<uint16_t> clk_src_vec; // Store clock sources in a vector
-    /**
-     * Store the Clock Sources of the CLOCK DOMAIN object.
-     */
+    ///
+    /// Store the Clock Sources of the CLOCK DOMAIN object.
+    ///
     void store_clock_sources();
 
 public:

--- a/controller/lib/src/cmd_wait_mgr.h
+++ b/controller/lib/src/cmd_wait_mgr.h
@@ -67,10 +67,9 @@ public:
     void * get_notify_id(void);
 
 private:
-
-    /**
-     * Wait states.
-     */
+    ///
+    /// Wait states.
+    ///
     enum wait_states
     {
         wait_idle,   /// idle state

--- a/controller/lib/src/configuration_descriptor_imp.h
+++ b/controller/lib/src/configuration_descriptor_imp.h
@@ -76,10 +76,10 @@ public:
     uint16_t STDCALL localized_description();
     uint16_t STDCALL descriptor_counts_count();
 
-    /**
-     * Get the offset to read the counts of the top level descriptor from the start of the descriptor.
-     * This field is set to 74 for this version of AEM.
-     */
+    ///
+    /// Get the offset to read the counts of the top level descriptor from the start of the descriptor.
+    /// This field is set to 74 for this version of AEM.
+    ///
     uint16_t descriptor_counts_offset();
 
     void store_entity_desc(end_station_imp *end_station_obj, const uint8_t *frame, ssize_t pos, size_t frame_len);
@@ -151,14 +151,14 @@ public:
     external_port_output_descriptor * STDCALL get_external_port_output_desc_by_index(size_t index);
 
 private:
-    /**
-     * Initialize the descriptor type vector with descriptor types present in the current configuration.
-     */
+    ///
+    /// Initialize the descriptor type vector with descriptor types present in the current configuration.
+    ///
     void desc_type_vec_init(const uint8_t *frame, size_t pos);
 
-    /**
-     * Initialize the descriptor count vector with the number of the corresponding type of descriptor present in the current configuration.
-     */
+    ///
+    /// Initialize the descriptor count vector with the number of the corresponding type of descriptor present in the current configuration.
+    ///
     void desc_count_vec_init(const uint8_t *frame, size_t pos);
 };
 }

--- a/controller/lib/src/controller_imp.h
+++ b/controller/lib/src/controller_imp.h
@@ -43,46 +43,46 @@ private:
     uint32_t m_talker_capabilities_flags;
     uint32_t m_listener_capabilities_flags;
 
-    /**
-     * Find an end station that matches the entity and controller IDs
-     */
+    ///
+    /// Find an end station that matches the entity and controller IDs
+    ///
     int find_in_end_station(struct jdksavdecc_eui64 &entity_entity_id, bool isUnsolicited, const uint8_t *frame);
 
 public:
-    /**
-     * A constructor for controller_imp used for constructing an object with notification, and post_log_msg callback functions.
-     */
+    ///
+    /// A constructor for controller_imp used for constructing an object with notification, and post_log_msg callback functions.
+    ///
     controller_imp(void (*notification_callback) (void *, int32_t, uint64_t, uint16_t, uint16_t, uint16_t, uint32_t, void *),
                    void (*log_callback) (void *, int32_t, const char *, int32_t));
 
     virtual ~controller_imp();
 
-    /**
-     * Call destructor for Controller used for destroying objects
-     */
+    ///
+    /// Call destructor for Controller used for destroying objects
+    ///
     void STDCALL destroy();
 
     const char * STDCALL get_version() const;
     size_t STDCALL get_end_station_count();
     end_station * STDCALL get_end_station_by_index(size_t end_station_index);
 
-    /**
-     * Check if the corresponding End Station with the Entity ID exists.
-     */
+    ///
+    /// Check if the corresponding End Station with the Entity ID exists.
+    ///
     bool STDCALL is_end_station_found_by_entity_id(uint64_t entity_entity_id, uint32_t &end_station_index);
 
-    /**
-     * Check if the corresponding End Station with the Mac Address exists.
-     */
+    ///
+    /// Check if the corresponding End Station with the Mac Address exists.
+    ///
     bool STDCALL is_end_station_found_by_mac_addr(uint64_t mac_addr, uint32_t &end_station_index);
 
     configuration_descriptor * STDCALL get_current_config_desc(size_t end_station_index, bool report_error=true);
 
     configuration_descriptor * STDCALL get_config_desc_by_entity_id(uint64_t entity_entity_id, uint16_t entity_index, uint16_t config_index);
 
-    /**
-     * Check if the command with the corresponding notification id is in the inflight list.
-     */
+    ///
+    /// Check if the command with the corresponding notification id is in the inflight list.
+    ///
     bool is_inflight_cmd_with_notification_id(void *notification_id);
 
     bool is_active_operation_with_notification_id(void *notification_id);
@@ -96,28 +96,28 @@ public:
     uint32_t STDCALL missed_notification_count();
     uint32_t STDCALL missed_log_count();
 
-    /**
-     * Check for End Station connection, command packet, and response packet timeouts.
-     */
+    ///
+    /// Check for End Station connection, command packet, and response packet timeouts.
+    ///
     void time_tick_event();
 
-    /**
-     * Lookup and process packet received.
-     */
+    ///
+    /// Lookup and process packet received.
+    ///
     void rx_packet_event(void *&notification_id, bool &is_notification_id_valid, const uint8_t *frame, size_t frame_len, int &status, uint16_t &operation_id, bool &is_operation_id_valid);
 
-    /**
-     * Send queued packet to the AEM Controller State Machine.
-     */
+    ///
+    /// Send queued packet to the AEM Controller State Machine.
+    ///
     void tx_packet_event(void *notification_id, uint32_t notification_flag, uint8_t *frame, size_t frame_len);
 
     int STDCALL send_controller_avail_cmd(void *notification_id, uint32_t end_station_index);
 
     int STDCALL send_controller_avail_response(const uint8_t *frame, size_t frame_len);
 
-    /**
-     * Process a CONTROLLER_AVAILABLE response for the CONTROLLER_AVAILABLE command.
-     */
+    ///
+    /// Process a CONTROLLER_AVAILABLE response for the CONTROLLER_AVAILABLE command.
+    ///
     int proc_controller_avail_resp(void *&notification_id, const uint8_t *frame, size_t frame_len, int &status);
 };
 

--- a/controller/lib/src/descriptor_base_imp.h
+++ b/controller/lib/src/descriptor_base_imp.h
@@ -77,34 +77,34 @@ public:
         else
             return nullptr;
     };
-    /**
-     * Replace the frame for counters/commands.
-     */
+    ///
+    /// Replace the frame for counters/commands.
+    ///
     virtual void STDCALL replace_frame(const uint8_t *frame, ssize_t pos, size_t size);
 
-    /**
-     * Replace the frame for descriptors.
-     */
+    ///
+    /// Replace the frame for descriptors.
+    ///
     virtual void STDCALL replace_desc_frame(const uint8_t *frame, ssize_t pos, size_t size);
 
-    /**
-     * Get the flags after sending a ACQUIRE_ENTITY command and receiving a response back for the command.
-     */
+    ///
+    /// Get the flags after sending a ACQUIRE_ENTITY command and receiving a response back for the command.
+    ///
     virtual uint32_t STDCALL acquire_entity_flags();
 
-    /**
-     * Get the owner id after sending a ACQUIRE_ENTITY command and receiving a response back for the command.
-     */
+    ///
+    /// Get the owner id after sending a ACQUIRE_ENTITY command and receiving a response back for the command.
+    ///
     virtual uint64_t STDCALL acquire_entity_owner_entity_id();
 
-    /**
-     * Get the flags after sending a LOCK_ENTITY command and receiving a response back for the command.
-     */
+    ///
+    /// Get the flags after sending a LOCK_ENTITY command and receiving a response back for the command.
+    ///
     virtual uint32_t STDCALL lock_entity_flags();
 
-    /**
-     * Get the locked entity id after sending a LOCK_ENTITY command and receiving a response back for the command.
-     */
+    ///
+    /// Get the locked entity id after sending a LOCK_ENTITY command and receiving a response back for the command.
+    ///
     virtual uint64_t STDCALL lock_entity_locked_entity_id();
 
     virtual int STDCALL send_acquire_entity_cmd(void *notification_id, uint32_t acquire_entity_flag);

--- a/controller/lib/src/end_station_imp.h
+++ b/controller/lib/src/end_station_imp.h
@@ -80,19 +80,19 @@ public:
     std::mutex locker;
     const char STDCALL get_connection_status() const;
 
-    /**
-     * Change the End Station connection status to connected.
-     */
+    ///
+    /// Change the End Station connection status to connected.
+    ///
     void set_connected();
 
-    /**
-     * Change the End Station connection status to disconnected.
-     */
+    ///
+    /// Change the End Station connection status to disconnected.
+    ///
     void set_disconnected();
 
-    /**
-     * Re-enumerate the endpoint by re-reading the descriptors
-     */
+    ///
+    /// Re-enumerate the endpoint by re-reading the descriptors
+    ///
     void end_station_reenumerate();
 
     uint64_t STDCALL entity_id();
@@ -117,9 +117,9 @@ public:
     void background_read_update_timeouts(void); ///< update timeout conditions
     void background_read_submit_pending(void); ///< Submit pending background reads
 
-    /**
-     * Process response received for the corresponding AECP Address Access command.
-     */
+    ///
+    /// Process response received for the corresponding AECP Address Access command.
+    ///
     int proc_rcvd_aecp_aa_resp(void *&notification_id, const uint8_t *frame, size_t frame_len, int &status);
 
     int proc_rcvd_acmp_resp(uint32_t msg_type, void *&notification_id, const uint8_t *frame, size_t frame_len, int &status);
@@ -136,21 +136,21 @@ public:
     int proc_deregister_unsolicited_resp(void *&notification_id, const uint8_t *frame, size_t frame_len, int &status);
 
 private:
-    /**
-     * Initialize End Station with Entity and Configuration descriptors information.
-     */
+    ///
+    /// Initialize End Station with Entity and Configuration descriptors information.
+    ///
     int end_station_init();
 
-    /**
-     * Initialize End Station by sending non blocking Read Descriptor commands to read
-     * all the descriptors for the End Station.
-     */
+    ///
+    /// Initialize End Station by sending non blocking Read Descriptor commands to read
+    /// all the descriptors for the End Station.
+    ///
     int read_desc_init(uint16_t desc_type, uint16_t desc_index);
 
-    /**
-     * Send a READ_DESCRIPTOR command with or without a notification id based on the post_notification_msg flag
-     * to read a descriptor from an AVDECC Entity.
-     */
+    ///
+    /// Send a READ_DESCRIPTOR command with or without a notification id based on the post_notification_msg flag
+    /// to read a descriptor from an AVDECC Entity.
+    ///
     int send_read_desc_cmd_with_flag(void *notification_id, uint32_t notification_flag, uint16_t desc_type, uint16_t desc_index);
 };
 }

--- a/controller/lib/src/inflight.h
+++ b/controller/lib/src/inflight.h
@@ -87,9 +87,9 @@ public:
     }
 };
 
-/*
- * Class for use in STL find_if() call to find matching sequence ID.
- */
+///
+/// Class for use in STL find_if() call to find matching sequence ID.
+///
 class SeqIdComp
 {
 private:
@@ -104,9 +104,9 @@ public:
     }
 };
 
-/*
- * Class for use in STL find_if() call to find matching notification ID.
- */
+///
+/// Class for use in STL find_if() call to find matching notification ID.
+///
 class NotificationComp
 {
 private:

--- a/controller/lib/src/jack_input_descriptor_imp.h
+++ b/controller/lib/src/jack_input_descriptor_imp.h
@@ -45,9 +45,9 @@ public:
 
     jack_input_descriptor_response * STDCALL get_jack_input_response();
 private:
-    /**
-     * Store the jack flags componenets of the JACK INPUT descriptor object in a vector.
-     */
+    ///
+    /// Store the jack flags componenets of the JACK INPUT descriptor object in a vector.
+    ///
     void jack_flags_init();
 };
 }

--- a/controller/lib/src/jack_input_descriptor_response_imp.h
+++ b/controller/lib/src/jack_input_descriptor_response_imp.h
@@ -58,9 +58,9 @@ public:
     uint16_t STDCALL number_of_controls();
     uint16_t STDCALL base_control();
 private:
-    /**
-     * Store the jack flags componenets of the JACK INPUT descriptor object in a vector.
-     */
+    ///
+    /// Store the jack flags componenets of the JACK INPUT descriptor object in a vector.
+    ///
     void jack_flags_init();
 };
 }

--- a/controller/lib/src/jack_output_descriptor_imp.h
+++ b/controller/lib/src/jack_output_descriptor_imp.h
@@ -45,9 +45,9 @@ public:
 
     jack_output_descriptor_response * STDCALL get_jack_output_response();
 private:
-    /**
-     * Store the jack flags componenets of the JACK INPUT descriptor object in a vector.
-     */
+    ///
+    /// Store the jack flags componenets of the JACK INPUT descriptor object in a vector.
+    ///
     void jack_flags_init();
 };
 }

--- a/controller/lib/src/jack_output_descriptor_response_imp.h
+++ b/controller/lib/src/jack_output_descriptor_response_imp.h
@@ -58,9 +58,9 @@ public:
     uint16_t STDCALL number_of_controls();
     uint16_t STDCALL base_control();
 private:
-    /**
-     * Store the jack flags componenets of the JACK INPUT descriptor object in a vector.
-     */
+    ///
+    /// Store the jack flags componenets of the JACK INPUT descriptor object in a vector.
+    ////
     void jack_flags_init();
 };
 }

--- a/controller/lib/src/log.h
+++ b/controller/lib/src/log.h
@@ -63,29 +63,29 @@ public:
 
     virtual ~log();
 
-    /**
-     * Update the base log level for messages to be logged by the logging callback.
-     */
+    ///
+    /// Update the base log level for messages to be logged by the logging callback.
+    ///
     void set_log_level(int32_t new_log_level);
 
-    /**
-     * AVDECC LIB modules call this function for logging purposes.
-     */
+    ///
+    /// AVDECC LIB modules call this function for logging purposes.
+    ///
     void post_log_msg(int32_t log_level, const char *fmt,...);
 
-    /**
-     * Release sempahore so that log callback function is called.
-     */
+    ///
+    /// Release sempahore so that log callback function is called.
+    ///
     virtual void post_log_event() = 0;
 
-    /**
-     * Change the logging callback function to a new logging callback function.
-     */
+    ///
+    /// Change the logging callback function to a new logging callback function.
+    ///
     void set_log_callback(void (*new_log_callback) (void *, int32_t, const char *, int32_t), void *);
 
-    /**
-     * Get the number of missed logs that exceeds the log buffer count.
-     */
+    ///
+    /// Get the number of missed logs that exceeds the log buffer count.
+    ///
     virtual uint32_t missed_log_event_count();
 };
 }

--- a/controller/lib/src/notification.h
+++ b/controller/lib/src/notification.h
@@ -42,19 +42,19 @@ public:
 
     ~notification();
 
-    /**
-     * AVDECC LIB modules call this function to generate a notification message.
-     */
+    ///
+    /// AVDECC LIB modules call this function to generate a notification message.
+    ///
     void post_notification_msg(int32_t notification_type, uint64_t entity_id, uint16_t cmd_type, uint16_t desc_type, uint16_t desc_index, uint32_t cmd_status, void *notification_id);
 
-    /**
-     * Change the notification callback function to a new post_notification_msg callback function.
-     */
+    ///
+    /// Change the notification callback function to a new post_notification_msg callback function.
+    ///
     void set_notification_callback(void (*new_notification_callback) (void *, int32_t, uint64_t, uint16_t, uint16_t, uint16_t, uint32_t, void *), void *);
 
-    /**
-     * Get the number of missed notifications that exceeds the notification buffer count.
-     */
+    ///
+    /// Get the number of missed notifications that exceeds the notification buffer count.
+    ///
     uint32_t missed_notification_event_count();
 
 protected:
@@ -83,9 +83,9 @@ protected:
 
     struct notification_data notification_buf[NOTIFICATION_BUF_COUNT];
 
-    /**
-     * Release sempahore so that notification callback function is called.
-     */
+    ///
+    /// Release sempahore so that notification callback function is called.
+    ///
     virtual void post_notification_event() = 0;
 
 };

--- a/controller/lib/src/operation.h
+++ b/controller/lib/src/operation.h
@@ -69,9 +69,9 @@ public:
     }
 };
 
-/*
- * Class for use in STL find_if() call to find matching operation ID.
- */
+//
+// Class for use in STL find_if() call to find matching operation ID.
+//
 class operation_id_comp
 {
 private:
@@ -86,9 +86,9 @@ public:
     }
 };
 
-/*
- * Class for use in STL find_if() call to find matching notification ID.
- */
+//
+// Class for use in STL find_if() call to find matching notification ID.
+//
 class notification_comp
 {
 private:

--- a/controller/lib/src/stream_input_descriptor_response_imp.h
+++ b/controller/lib/src/stream_input_descriptor_response_imp.h
@@ -88,19 +88,19 @@ public:
     uint32_t STDCALL buffer_length();
     uint64_t STDCALL get_supported_stream_fmt_by_index(size_t stream_fmt_index);
 private:
-    /**
-     * Store the stream flags components of the STREAM INPUT descriptor object in a vector.
-     */
+    ///
+    /// Store the stream flags components of the STREAM INPUT descriptor object in a vector.
+    ///
     void stream_flags_init();
 
-    /**
-     * Update the internal STREAM INPUT descriptor's stream format field.
-     */
+    ///
+    /// Update the internal STREAM INPUT descriptor's stream format field.
+    ///
     void update_stream_format(struct jdksavdecc_eui64 stream_format);
 
-    /**
-     * Store the supported stream formats for this STREAM INPUT descriptor.
-     */
+    ///
+    /// Store the supported stream formats for this STREAM INPUT descriptor.
+    ///
     void store_supported_stream_fmts();
 };
 }

--- a/controller/lib/src/stream_output_descriptor_response_imp.h
+++ b/controller/lib/src/stream_output_descriptor_response_imp.h
@@ -94,14 +94,14 @@ public:
     bool STDCALL get_stream_info_flag(const char *flag);
     uint64_t STDCALL get_supported_stream_fmt_by_index(size_t stream_fmt_index);
 private:
-    /**
-     * Store the stream flags components of the STREAM OUTPUT descriptor object in a vector.
-     */
+    ///
+    /// Store the stream flags components of the STREAM OUTPUT descriptor object in a vector.
+    ///
     void stream_flags_init();
 
-    /**
-     * Store the supported stream formats for this STREAM OUTPUT descriptor.
-     */
+    ///
+    /// Store the supported stream formats for this STREAM OUTPUT descriptor.
+    ///
     void store_supported_stream_fmts();
 };
 }

--- a/controller/lib/src/system_tx_queue.h
+++ b/controller/lib/src/system_tx_queue.h
@@ -34,8 +34,8 @@
 
 namespace avdecc_lib
 {
-/**
- * Store command in a queue to be transmitted.
- */
+///
+/// Store command in a queue to be transmitted.
+///
 size_t system_queue_tx(void *notification_id, uint32_t notification_flag, uint8_t *frame, size_t frame_len);
 }


### PR DESCRIPTION
clang-format recognizes '///' style Doxygen comments better than '/** ... */'