### PR TITLE
get_rx_state_response additions

### DIFF
--- a/controller/app/cmdline/src/cmd_line.cpp
+++ b/controller/app/cmdline/src/cmd_line.cpp
@@ -3032,7 +3032,9 @@ int cmd_line::cmd_get_rx_state(int total_matched, std::vector<cli_argument *> ar
         {
             avdecc_lib::stream_input_get_rx_state_response * stream_input_resp_ref = instream->get_stream_input_get_rx_state_response();
             atomic_cout << "\nstream_id = 0x" << std::hex << stream_input_resp_ref->get_rx_state_stream_id();
+            atomic_cout << "\ntalker_entity_id = 0x" << std::hex << stream_input_resp_ref->get_rx_state_talker_entity_id();
             atomic_cout << "\ntalker_unique_id = " << std::dec << std::dec << stream_input_resp_ref->get_rx_state_talker_unique_id();
+            atomic_cout << "\nlistener_entity_id = 0x" << std::hex << stream_input_resp_ref->get_rx_state_listener_entity_id();
             atomic_cout << "\nlistener_unique_id = " << std::dec << stream_input_resp_ref->get_rx_state_listener_unique_id();
             atomic_cout << "\nstream_dest_mac = 0x" << std::hex << stream_input_resp_ref->get_rx_state_stream_dest_mac();
             atomic_cout << "\nconnection_count = " << std::dec << stream_input_resp_ref->get_rx_state_connection_count();

--- a/controller/lib/include/stream_input_get_rx_state_response.h
+++ b/controller/lib/include/stream_input_get_rx_state_response.h
@@ -45,11 +45,21 @@ public:
     AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_rx_state_stream_id() = 0;
 
     ///
+    /// \return The talker_entity_id field used to identify the AVDECC Talker being targeted by the command.
+    ///
+    AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_rx_state_talker_entity_id() = 0;
+    
+    ///
     /// \return The Talker unique ID used to uniquely identify the stream source of the AVDECC Talker
     ///         after sending a GET_RX_STATE command and receiving a response back for the command.
     ///
     AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL get_rx_state_talker_unique_id() = 0;
 
+    ///
+    /// \return The listener_entity_id field used to identify the AVDECC Listener being targeted by the command.
+    ///
+    AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_rx_state_listener_entity_id() = 0;
+    
     ///
     /// \return The Listener unique ID used to uniquely identify the stream sink of the AVDECC Listener
     ///         after sending a GET_RX_STATE command and receiving a response back for the command.

--- a/controller/lib/src/stream_input_get_rx_state_response_imp.cpp
+++ b/controller/lib/src/stream_input_get_rx_state_response_imp.cpp
@@ -53,10 +53,24 @@ uint64_t STDCALL stream_input_get_rx_state_response_imp::get_rx_state_stream_id(
     stream_id = jdksavdecc_common_control_header_get_stream_id(m_frame, m_position);
     return jdksavdecc_eui64_convert_to_uint64(&stream_id);
 }
+    
+uint64_t STDCALL stream_input_get_rx_state_response_imp::get_rx_state_talker_entity_id()
+{
+    jdksavdecc_eui64 talker_entity_id;
+    talker_entity_id = jdksavdecc_acmpdu_get_talker_entity_id(m_frame, m_position);
+    return jdksavdecc_eui64_convert_to_uint64(&talker_entity_id);
+}
 
 uint16_t STDCALL stream_input_get_rx_state_response_imp::get_rx_state_talker_unique_id()
 {
     return jdksavdecc_acmpdu_get_talker_unique_id(m_frame, m_position);
+}
+    
+uint64_t STDCALL stream_input_get_rx_state_response_imp::get_rx_state_listener_entity_id()
+{
+    jdksavdecc_eui64 listener_entity_id;
+    listener_entity_id = jdksavdecc_acmpdu_get_listener_entity_id(m_frame, m_position);
+    return jdksavdecc_eui64_convert_to_uint64(&listener_entity_id);
 }
 
 uint16_t STDCALL stream_input_get_rx_state_response_imp::get_rx_state_listener_unique_id()

--- a/controller/lib/src/stream_input_get_rx_state_response_imp.h
+++ b/controller/lib/src/stream_input_get_rx_state_response_imp.h
@@ -46,7 +46,9 @@ public:
     virtual ~stream_input_get_rx_state_response_imp();
 
     uint64_t STDCALL get_rx_state_stream_id();
+    uint64_t STDCALL get_rx_state_talker_entity_id();
     uint16_t STDCALL get_rx_state_talker_unique_id();
+    uint64_t STDCALL get_rx_state_listener_entity_id();
     uint16_t STDCALL get_rx_state_listener_unique_id();
     uint64_t STDCALL get_rx_state_stream_dest_mac();
     uint16_t STDCALL get_rx_state_connection_count();


### PR DESCRIPTION
add methods to read talker entity id and listener entity id fields