### PR TITLE
Fix compile on OSX.

### DIFF
--- a/controller/app/cmdline/src/cmd_line_main.cpp
+++ b/controller/app/cmdline/src/cmd_line_main.cpp
@@ -283,7 +283,7 @@ int main(int argc, char * argv[])
 #endif
 // Override to prevent filename completion
 #if defined(__MACH__)
-    rl_completion_entry_function = (Function *)null_completer;
+    rl_completion_entry_function = (rl_compentry_func_t *)null_completer;
 #elif defined(__linux__)
     rl_completion_entry_function = null_completer;
 #endif


### PR DESCRIPTION
Won't compile on OSX for me:
avb-controller/avdecc-lib/controller/app/cmdline/src/cmd_line_main.cpp:286:34: error: assigning to
      'rl_compentry_func_t _' (aka 'char *(_)(const char _, int)') from incompatible type 'Function *' (aka 'int (_)()'): different
      number of parameters (2 vs 0)
    rl_completion_entry_function = (Function *)null_completer;
