### PR TITLE
cmd_line_main - support both libedit and GNU Readline libraries

### DIFF
--- a/controller/app/cmdline/src/cmd_line_main.cpp
+++ b/controller/app/cmdline/src/cmd_line_main.cpp
@@ -316,7 +316,13 @@ int main(int argc, char * argv[])
 #endif
 // Override to prevent filename completion
 #if defined(__MACH__)
+#if defined (READLINE_LIBRARY)
+    // GNU Readline library
+    rl_completion_entry_function = (rl_compentry_func_t *)null_completer;
+#else
+    // OSX default libedit library
     rl_completion_entry_function = (Function *)null_completer;
+#endif
 #elif defined(__linux__)
     rl_completion_entry_function = null_completer;
 #endif


### PR DESCRIPTION
GNU's Readline and OSX's default Libedit libraries have different types for 'rl_completion_entry_function'.