### PR TITLE
network interface IP address

### DIFF
--- a/controller/app/cmdline/src/cmd_line.cpp
+++ b/controller/app/cmdline/src/cmd_line.cpp
@@ -153,10 +153,22 @@ int cmd_line::print_interfaces_and_select(char * interface)
 
     for (uint32_t i = 1; i < netif->devs_count() + 1; i++)
     {
-        char * dev_desc = netif->get_dev_desc_by_index(i - 1);
+        size_t dev_index = i - 1;
+        char * dev_desc = netif->get_dev_desc_by_index(dev_index);
         if (!interface)
         {
-            printf("%d (%s)\n", i, dev_desc);
+            printf("%d (%s)", i, dev_desc);
+            size_t ip_addr_count = netif->device_ip_address_count(dev_index);
+            if (ip_addr_count > 0)
+            {
+                for(size_t ip_index = 0; ip_index < ip_addr_count; ip_index++)
+                {
+                    std::string dev_ip = netif->get_dev_ip_address_by_index(dev_index, ip_index);
+                    if (!dev_ip.empty())
+                        printf(" (%s)", dev_ip.c_str());
+                }
+            }
+            printf("\n");
         }
         else
         {

--- a/controller/app/cmdline/src/cmd_line.cpp
+++ b/controller/app/cmdline/src/cmd_line.cpp
@@ -163,9 +163,9 @@ int cmd_line::print_interfaces_and_select(char * interface)
             {
                 for(size_t ip_index = 0; ip_index < ip_addr_count; ip_index++)
                 {
-                    std::string dev_ip = netif->get_dev_ip_address_by_index(dev_index, ip_index);
-                    if (!dev_ip.empty())
-                        printf(" (%s)", dev_ip.c_str());
+                    const char * dev_ip = netif->get_dev_ip_address_by_index(dev_index, ip_index);
+                    if (dev_ip)
+                        printf(" (%s)", dev_ip);
                 }
             }
             printf("\n");

--- a/controller/lib/include/net_interface.h
+++ b/controller/lib/include/net_interface.h
@@ -61,7 +61,7 @@ public:
     ///
     /// \return The network interface IP address by index for a device.
     ///
-    AVDECC_CONTROLLER_LIB32_API virtual std::string STDCALL get_dev_ip_address_by_index(size_t dev_index, size_t ip_index) = 0;
+    AVDECC_CONTROLLER_LIB32_API virtual const char * STDCALL get_dev_ip_address_by_index(size_t dev_index, size_t ip_index) = 0;
 
     /// This function is OS dependant. In linux and OSX the return is the same as for a call to
     /// get_dev_desc_by_index(). In Windows this function returns a GUID as a string.

--- a/controller/lib/include/net_interface.h
+++ b/controller/lib/include/net_interface.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <string>
 #include "avdecc-lib_build.h"
 
 namespace avdecc_lib
@@ -46,11 +47,21 @@ public:
     /// \return The number of devices.
     ///
     AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL devs_count() = 0;
+    
+    ///
+    /// \return The number of IP addresses for a device.
+    ///
+    AVDECC_CONTROLLER_LIB32_API virtual size_t STDCALL device_ip_address_count(size_t dev_index) = 0;
 
     ///
     /// \return The corresponding network interface description by index.
     ///
     AVDECC_CONTROLLER_LIB32_API virtual char * STDCALL get_dev_desc_by_index(size_t dev_index) = 0;
+    
+    ///
+    /// \return The network interface IP address by index for a device.
+    ///
+    AVDECC_CONTROLLER_LIB32_API virtual std::string STDCALL get_dev_ip_address_by_index(size_t dev_index, size_t ip_index) = 0;
 
     /// This function is OS dependant. In linux and OSX the return is the same as for a call to
     /// get_dev_desc_by_index(). In Windows this function returns a GUID as a string.

--- a/controller/lib/src/linux/net_interface_imp.cpp
+++ b/controller/lib/src/linux/net_interface_imp.cpp
@@ -149,6 +149,12 @@ uint32_t STDCALL net_interface_imp::devs_count()
     return total_devs;
 }
 
+size_t STDCALL net_interface_imp::device_ip_address_count(size_t dev_index)
+{
+    // need to implement
+    return -1;
+}
+
 uint64_t net_interface_imp::mac_addr()
 {
     return mac;
@@ -162,6 +168,12 @@ char * STDCALL net_interface_imp::get_dev_desc_by_index(size_t dev_index)
 char * STDCALL net_interface_imp::get_dev_name_by_index(size_t dev_index)
 {
     return get_dev_desc_by_index(dev_index);
+}
+    
+std::string STDCALL net_interface_imp::get_dev_ip_address_by_index(size_t dev_index, size_t ip_index)
+{
+    // need to implement
+    return "";
 }
 
 int net_interface_imp::get_fd()

--- a/controller/lib/src/linux/net_interface_imp.cpp
+++ b/controller/lib/src/linux/net_interface_imp.cpp
@@ -151,7 +151,7 @@ uint32_t STDCALL net_interface_imp::devs_count()
 
 size_t STDCALL net_interface_imp::device_ip_address_count(size_t dev_index)
 {
-    // not needed
+    // not needed on this platform as the device IP is embedded in the string returned by get_dev_desc_by_index()
     return -1;
 }
 
@@ -172,7 +172,7 @@ char * STDCALL net_interface_imp::get_dev_name_by_index(size_t dev_index)
     
 const char * STDCALL net_interface_imp::get_dev_ip_address_by_index(size_t dev_index, size_t ip_index)
 {
-    // not needed
+    // not needed on this platform as the device IP is embedded in the string returned by get_dev_desc_by_index()
     return NULL;
 }
 

--- a/controller/lib/src/linux/net_interface_imp.cpp
+++ b/controller/lib/src/linux/net_interface_imp.cpp
@@ -151,7 +151,7 @@ uint32_t STDCALL net_interface_imp::devs_count()
 
 size_t STDCALL net_interface_imp::device_ip_address_count(size_t dev_index)
 {
-    // need to implement
+    // not needed
     return -1;
 }
 
@@ -170,10 +170,10 @@ char * STDCALL net_interface_imp::get_dev_name_by_index(size_t dev_index)
     return get_dev_desc_by_index(dev_index);
 }
     
-std::string STDCALL net_interface_imp::get_dev_ip_address_by_index(size_t dev_index, size_t ip_index)
+const char * STDCALL net_interface_imp::get_dev_ip_address_by_index(size_t dev_index, size_t ip_index)
 {
-    // need to implement
-    return "";
+    // not needed
+    return NULL;
 }
 
 int net_interface_imp::get_fd()

--- a/controller/lib/src/linux/net_interface_imp.h
+++ b/controller/lib/src/linux/net_interface_imp.h
@@ -83,6 +83,11 @@ public:
     /// Count the number of devices.
     ///
     uint32_t STDCALL devs_count();
+    
+    ///
+    /// Count the number of IP addresses for a device.
+    ///
+    size_t STDCALL device_ip_address_count(size_t dev_index);
 
     ///
     /// Get the MAC address of the network interface.
@@ -93,6 +98,11 @@ public:
     /// Get network interface description by index.
     ///
     char * STDCALL get_dev_desc_by_index(size_t dev_index);
+
+    ///
+    /// Get the corresponding network interface IP address by index.
+    ///
+    std::string STDCALL get_dev_ip_address_by_index(size_t dev_index, size_t ip_index);
 
     ///
     /// Get the corresponding network interface name by index.

--- a/controller/lib/src/linux/net_interface_imp.h
+++ b/controller/lib/src/linux/net_interface_imp.h
@@ -102,7 +102,7 @@ public:
     ///
     /// Get the corresponding network interface IP address by index.
     ///
-    std::string STDCALL get_dev_ip_address_by_index(size_t dev_index, size_t ip_index);
+    const char * STDCALL get_dev_ip_address_by_index(size_t dev_index, size_t ip_index);
 
     ///
     /// Get the corresponding network interface name by index.

--- a/controller/lib/src/msvc/net_interface_imp.cpp
+++ b/controller/lib/src/msvc/net_interface_imp.cpp
@@ -139,15 +139,15 @@ char * STDCALL net_interface_imp::get_dev_name_by_index(size_t dev_index)
     return dev->name;
 }
     
-std::string STDCALL net_interface_imp::get_dev_ip_address_by_index(size_t dev_index, size_t ip_index)
+const char * STDCALL net_interface_imp::get_dev_ip_address_by_index(size_t dev_index, size_t ip_index)
 {
     if (dev_index < all_ip_addresses.size())
     {
         if (ip_index < all_ip_addresses.at(dev_index).size())
-            return all_ip_addresses.at(dev_index).at(ip_index);
+            return all_ip_addresses.at(dev_index).at(ip_index).c_str();
     }
     
-    return "";
+    return NULL;
 }
 
 int STDCALL net_interface_imp::select_interface_by_num(uint32_t interface_num)

--- a/controller/lib/src/msvc/net_interface_imp.cpp
+++ b/controller/lib/src/msvc/net_interface_imp.cpp
@@ -54,6 +54,20 @@ net_interface_imp::net_interface_imp()
     {
         for (dev = all_devs; dev; dev = dev->next)
         {
+            // store the valid IPv4 addresses associated with the device
+            std::vector<std::string> device_ip_addresses;
+            pcap_addr_t * dev_addr;
+            for (dev_addr = dev->addresses; dev_addr != NULL; dev_addr = dev_addr->next)
+            {
+                if (dev_addr->addr->sa_family == AF_INET && dev_addr->addr)
+                {
+                    char ip_str[INET_ADDRSTRLEN] = {0};
+                    inet_ntop(AF_INET, &((struct sockaddr_in *)dev_addr->addr)->sin_addr, ip_str, INET_ADDRSTRLEN);
+                    device_ip_addresses.push_back(std::string(ip_str));
+                }
+            }
+            
+            all_ip_addresses.push_back(device_ip_addresses);
             total_devs++;
         }
     }
@@ -80,6 +94,14 @@ void STDCALL net_interface_imp::destroy()
 uint32_t STDCALL net_interface_imp::devs_count()
 {
     return total_devs;
+}
+
+size_t STDCALL net_interface_imp::device_ip_address_count(size_t dev_index)
+{
+    if (dev_index < all_ip_addresses.size())
+        return all_ip_addresses.at(dev_index).size();
+
+    return -1;
 }
 
 uint64_t net_interface_imp::mac_addr()
@@ -115,6 +137,17 @@ char * STDCALL net_interface_imp::get_dev_name_by_index(size_t dev_index)
     }
 
     return dev->name;
+}
+    
+std::string STDCALL net_interface_imp::get_dev_ip_address_by_index(size_t dev_index, size_t ip_index)
+{
+    if (dev_index < all_ip_addresses.size())
+    {
+        if (ip_index < all_ip_addresses.at(dev_index).size())
+            return all_ip_addresses.at(dev_index).at(ip_index);
+    }
+    
+    return "";
 }
 
 int STDCALL net_interface_imp::select_interface_by_num(uint32_t interface_num)

--- a/controller/lib/src/msvc/net_interface_imp.h
+++ b/controller/lib/src/msvc/net_interface_imp.h
@@ -85,7 +85,7 @@ public:
     ///
     /// Get the corresponding network interface IP address by index.
     ///
-    std::string STDCALL get_dev_ip_address_by_index(size_t dev_index, size_t ip_index);
+    const char * STDCALL get_dev_ip_address_by_index(size_t dev_index, size_t ip_index);
 
     ///
     /// Get the corresponding network interface name by index.

--- a/controller/lib/src/msvc/net_interface_imp.h
+++ b/controller/lib/src/msvc/net_interface_imp.h
@@ -32,6 +32,7 @@
 #define HAVE_REMOTE
 
 #include <stdint.h>
+#include <vector>
 #include <pcap.h>
 #include "avdecc-lib_build.h"
 #include "net_interface.h"
@@ -41,6 +42,7 @@ namespace avdecc_lib
 class net_interface_imp : public net_interface
 {
 private:
+    std::vector<std::vector<std::string> > all_ip_addresses;
     pcap_if_t * all_devs;
     pcap_if_t * dev;
     uint64_t mac;
@@ -64,6 +66,11 @@ public:
     /// Count the number of devices.
     ///
     uint32_t STDCALL devs_count();
+    
+    ///
+    /// Count the number of IP addresses for a device.
+    ///
+    size_t STDCALL device_ip_address_count(size_t dev_index);
 
     ///
     /// Get the MAC address of the network interface.
@@ -74,6 +81,11 @@ public:
     /// Get the corresponding network interface description by index.
     ///
     char * STDCALL get_dev_desc_by_index(size_t dev_index);
+
+    ///
+    /// Get the corresponding network interface IP address by index.
+    ///
+    std::string STDCALL get_dev_ip_address_by_index(size_t dev_index, size_t ip_index);
 
     ///
     /// Get the corresponding network interface name by index.

--- a/controller/lib/src/osx/net_interface_imp.cpp
+++ b/controller/lib/src/osx/net_interface_imp.cpp
@@ -64,6 +64,20 @@ net_interface_imp::net_interface_imp()
 
     for (dev = all_devs, total_devs = 0; dev; dev = dev->next)
     {
+        // store the valid IPv4 addresses associated with the device
+        std::vector<std::string> device_ip_addresses;
+        pcap_addr_t * dev_addr;
+        for (dev_addr = dev->addresses; dev_addr != NULL; dev_addr = dev_addr->next)
+        {
+            if (dev_addr->addr->sa_family == AF_INET && dev_addr->addr)
+            {
+                char ip_str[INET_ADDRSTRLEN] = {0};
+                inet_ntop(AF_INET, &((struct sockaddr_in *)dev_addr->addr)->sin_addr, ip_str, INET_ADDRSTRLEN);
+                device_ip_addresses.push_back(std::string(ip_str));
+            }
+        }
+        
+        all_ip_addresses.push_back(device_ip_addresses);
         total_devs++;
     }
 
@@ -89,6 +103,14 @@ uint32_t STDCALL net_interface_imp::devs_count()
 {
     return total_devs;
 }
+    
+size_t STDCALL net_interface_imp::device_ip_address_count(size_t dev_index)
+{
+    if (dev_index < all_ip_addresses.size())
+        return all_ip_addresses.at(dev_index).size();
+
+    return -1;
+}
 
 uint64_t net_interface_imp::mac_addr()
 {
@@ -110,7 +132,18 @@ char * STDCALL net_interface_imp::get_dev_desc_by_index(size_t dev_index)
 
     return dev->name;
 }
-
+    
+std::string STDCALL net_interface_imp::get_dev_ip_address_by_index(size_t dev_index, size_t ip_index)
+{
+    if (dev_index < all_ip_addresses.size())
+    {
+        if (ip_index < all_ip_addresses.at(dev_index).size())
+            return all_ip_addresses.at(dev_index).at(ip_index);
+    }
+    
+    return "";
+}
+    
 char * STDCALL net_interface_imp::get_dev_name_by_index(size_t dev_index)
 {
     return get_dev_desc_by_index(dev_index);

--- a/controller/lib/src/osx/net_interface_imp.cpp
+++ b/controller/lib/src/osx/net_interface_imp.cpp
@@ -133,15 +133,15 @@ char * STDCALL net_interface_imp::get_dev_desc_by_index(size_t dev_index)
     return dev->name;
 }
     
-std::string STDCALL net_interface_imp::get_dev_ip_address_by_index(size_t dev_index, size_t ip_index)
+const char * STDCALL net_interface_imp::get_dev_ip_address_by_index(size_t dev_index, size_t ip_index)
 {
     if (dev_index < all_ip_addresses.size())
     {
         if (ip_index < all_ip_addresses.at(dev_index).size())
-            return all_ip_addresses.at(dev_index).at(ip_index);
+            return all_ip_addresses.at(dev_index).at(ip_index).c_str();
     }
     
-    return "";
+    return NULL;
 }
     
 char * STDCALL net_interface_imp::get_dev_name_by_index(size_t dev_index)

--- a/controller/lib/src/osx/net_interface_imp.h
+++ b/controller/lib/src/osx/net_interface_imp.h
@@ -32,6 +32,7 @@
 #define HAVE_REMOTE
 
 #include <stdint.h>
+#include <vector>
 #include <pcap.h>
 #include "avdecc-lib_build.h"
 #include "net_interface.h"
@@ -41,6 +42,7 @@ namespace avdecc_lib
 class net_interface_imp : public virtual net_interface
 {
 private:
+    std::vector<std::vector<std::string> > all_ip_addresses;
     pcap_if_t * all_devs;
     pcap_if_t * dev;
     uint64_t mac;
@@ -66,6 +68,11 @@ public:
     /// Count the number of devices.
     ///
     uint32_t STDCALL devs_count();
+    
+    ///
+    /// Count the number of IP addresses for a device.
+    ///
+    size_t STDCALL device_ip_address_count(size_t dev_index);
 
     ///
     /// Get the MAC address of the network interface.
@@ -76,6 +83,11 @@ public:
     /// Get the corresponding network interface description by index.
     ///
     char * STDCALL get_dev_desc_by_index(size_t dev_index);
+    
+    ///
+    /// Get the corresponding network interface IP address by index.
+    ///
+    std::string STDCALL get_dev_ip_address_by_index(size_t dev_index, size_t ip_index);
 
     ///
     /// Get the corresponding network interface name by index.

--- a/controller/lib/src/osx/net_interface_imp.h
+++ b/controller/lib/src/osx/net_interface_imp.h
@@ -87,7 +87,7 @@ public:
     ///
     /// Get the corresponding network interface IP address by index.
     ///
-    std::string STDCALL get_dev_ip_address_by_index(size_t dev_index, size_t ip_index);
+    const char * STDCALL get_dev_ip_address_by_index(size_t dev_index, size_t ip_index);
 
     ///
     /// Get the corresponding network interface name by index.


### PR DESCRIPTION
Add API's to fetch the ipv4 address(es) associated with a network interface.
Linux implementation needed.