### PR TITLE
osx/msvc network interface

### DIFF
--- a/controller/app/cmdline/src/cmd_line.cpp
+++ b/controller/app/cmdline/src/cmd_line.cpp
@@ -158,6 +158,16 @@ int cmd_line::print_interfaces_and_select(char * interface)
         if (!interface)
         {
             printf("%d (%s)", i, dev_desc);
+            
+            uint64_t dev_mac = netif->get_dev_mac_addr_by_index(dev_index);
+            if (dev_mac)
+            {
+                avdecc_lib::utility::MacAddr mac(dev_mac);
+                char mac_str[20];
+                mac.tostring(mac_str);
+                printf(" (%s)", mac_str);
+            }
+            
             size_t ip_addr_count = netif->device_ip_address_count(dev_index);
             if (ip_addr_count > 0)
             {
@@ -165,17 +175,33 @@ int cmd_line::print_interfaces_and_select(char * interface)
                 {
                     const char * dev_ip = netif->get_dev_ip_address_by_index(dev_index, ip_index);
                     if (dev_ip)
-                        printf(" (%s)", dev_ip);
+                        printf(" <%s>", dev_ip);
                 }
             }
             printf("\n");
         }
         else
         {
-            if (strcmp(dev_desc, interface) == 0)
+            // try to find the selected interface by ip address
+            if (netif->find_selected_interface_by_ip_address(dev_index, interface))
             {
                 interface_num = i;
                 break;
+            }
+
+            // try to find the selected interface by MAC address
+            avdecc_lib::utility::MacAddr mac(interface);
+            if (mac.fromstring(interface)) // valid format? (xx:xx:...)
+            {
+                uint64_t mac_val = mac.tovalue();
+                if (mac_val)
+                {
+                    if (netif->find_selected_interface_by_mac_address(dev_index, mac_val))
+                    {
+                        interface_num = i;
+                        break;
+                    }
+                }
             }
         }
     }
@@ -185,7 +211,26 @@ int cmd_line::print_interfaces_and_select(char * interface)
         atomic_cout << "Enter the interface number (1-" << std::dec << netif->devs_count() << "): ";
         std::cin >> interface_num;
     }
+    else
+    {
+        // if the interface was not found by IP Address or MAC address...
+        if (interface_num == -1)
+        {
+            // treat the selected interface as an index
+            char * tmp;
+            long if_num = strtol(interface, &tmp, 10);
+            if (interface != tmp)
+                interface_num = if_num;
+        }
+    }
 
+    if (interface_num == -1 ||
+        interface_num > netif->devs_count() + 1)
+    {
+        printf("Invalid Interface: (%s).  Exiting...\n", interface);
+        exit(EXIT_FAILURE);
+    }
+    
     netif->select_interface_by_num(interface_num);
 
     return 0;

--- a/controller/app/cmdline/src/cmd_line.cpp
+++ b/controller/app/cmdline/src/cmd_line.cpp
@@ -183,7 +183,7 @@ int cmd_line::print_interfaces_and_select(char * interface)
         else
         {
             // try to find the selected interface by ip address
-            if (netif->find_selected_interface_by_ip_address(dev_index, interface))
+            if (netif->does_interface_have_ip_address(dev_index, interface))
             {
                 interface_num = i;
                 break;
@@ -196,7 +196,7 @@ int cmd_line::print_interfaces_and_select(char * interface)
                 uint64_t mac_val = mac.tovalue();
                 if (mac_val)
                 {
-                    if (netif->find_selected_interface_by_mac_address(dev_index, mac_val))
+                    if (netif->does_interface_have_mac_address(dev_index, mac_val))
                     {
                         interface_num = i;
                         break;

--- a/controller/lib/include/net_interface.h
+++ b/controller/lib/include/net_interface.h
@@ -75,14 +75,20 @@ public:
     AVDECC_CONTROLLER_LIB32_API virtual char * STDCALL get_dev_name_by_index(size_t dev_index) = 0;
     
     ///
+    /// \param dev_index The index of a network interface.
+    /// \param ip_addr_str The IP Address to check for.
+    ///
     /// \return True if ip_addr_str is the IP address of the device specified by dev_index.
     ///
-    AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL find_selected_interface_by_ip_address(size_t dev_index, char * ip_addr_str) = 0;
+    AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL does_interface_have_ip_address(size_t dev_index, char * ip_addr_str) = 0;
     
+    ///
+    /// \param dev_index The index of a network interface.
+    /// \param mac_addr The MAC address to check for.
     ///
     /// \return True if mac_addr is the MAC address of the device specified by dev_index.
     ///
-    AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL find_selected_interface_by_mac_address(size_t dev_index, uint64_t mac_addr) = 0;
+    AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL does_interface_have_mac_address(size_t dev_index, uint64_t mac_addr) = 0;
 
     ///
     /// Select the corresponding interface by number.

--- a/controller/lib/include/net_interface.h
+++ b/controller/lib/include/net_interface.h
@@ -62,12 +62,27 @@ public:
     /// \return The network interface IP address by index for a device.
     ///
     AVDECC_CONTROLLER_LIB32_API virtual const char * STDCALL get_dev_ip_address_by_index(size_t dev_index, size_t ip_index) = 0;
+    
+    ///
+    /// \return The network interface MAC address by index for a device.
+    ///
+    AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_dev_mac_addr_by_index(size_t dev_index) = 0;
 
     /// This function is OS dependant. In linux and OSX the return is the same as for a call to
     /// get_dev_desc_by_index(). In Windows this function returns a GUID as a string.
     /// \return The corresponding network interface name by index.
     ///
     AVDECC_CONTROLLER_LIB32_API virtual char * STDCALL get_dev_name_by_index(size_t dev_index) = 0;
+    
+    ///
+    /// \return True if ip_addr_str is the IP address of the device specified by dev_index.
+    ///
+    AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL find_selected_interface_by_ip_address(size_t dev_index, char * ip_addr_str) = 0;
+    
+    ///
+    /// \return True if mac_addr is the MAC address of the device specified by dev_index.
+    ///
+    AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL find_selected_interface_by_mac_address(size_t dev_index, uint64_t mac_addr) = 0;
 
     ///
     /// Select the corresponding interface by number.

--- a/controller/lib/include/util.h
+++ b/controller/lib/include/util.h
@@ -170,6 +170,7 @@ namespace utility
                                     byte6((mac_val & 0XFF)) {}
         MacAddr(const char * p) { fromstring(p); }
 
+        uint64_t tovalue();
         void tostring(char * p, char d = ':') const;
         bool fromstring(const char * p);
 
@@ -267,6 +268,14 @@ namespace utility
         if (i < 6)
             valid = false;
         return valid;
+    }
+    inline uint64_t MacAddr::tovalue()
+    {
+        uint64_t mac_val = 0;
+        for (int i = 0; i < 6; i++)
+            mac_val = uint64_t(getByte(i)) << (40 - (8 * i)) | mac_val;
+        
+        return mac_val;
     }
     inline void MacAddr::tostring(char * p, char d) const
     {

--- a/controller/lib/src/linux/net_interface_imp.cpp
+++ b/controller/lib/src/linux/net_interface_imp.cpp
@@ -143,6 +143,24 @@ void STDCALL net_interface_imp::destroy()
 {
     delete this;
 }
+    
+bool STDCALL net_interface_imp::find_selected_interface_by_ip_address(size_t dev_index, char * ip_addr_str)
+{
+    // need to implement
+    return false;
+}
+
+bool STDCALL net_interface_imp::find_selected_interface_by_mac_address(size_t dev_index, uint64_t mac_addr)
+{
+    // need to implement
+    return false;
+}
+
+uint64_t net_interface_imp::get_dev_mac_addr_by_index(size_t dev_index)
+{
+    //need to implement
+    return 0;
+}
 
 uint32_t STDCALL net_interface_imp::devs_count()
 {

--- a/controller/lib/src/linux/net_interface_imp.cpp
+++ b/controller/lib/src/linux/net_interface_imp.cpp
@@ -144,13 +144,13 @@ void STDCALL net_interface_imp::destroy()
     delete this;
 }
     
-bool STDCALL net_interface_imp::find_selected_interface_by_ip_address(size_t dev_index, char * ip_addr_str)
+bool STDCALL net_interface_imp::does_interface_have_ip_address(size_t dev_index, char * ip_addr_str)
 {
     // need to implement
     return false;
 }
 
-bool STDCALL net_interface_imp::find_selected_interface_by_mac_address(size_t dev_index, uint64_t mac_addr)
+bool STDCALL net_interface_imp::does_interface_have_mac_address(size_t dev_index, uint64_t mac_addr)
 {
     // need to implement
     return false;

--- a/controller/lib/src/linux/net_interface_imp.h
+++ b/controller/lib/src/linux/net_interface_imp.h
@@ -112,12 +112,12 @@ public:
     ///
     /// Check whether ip_addr_str is a valid IP Address for a device.
     ///
-    bool STDCALL find_selected_interface_by_ip_address(size_t dev_index, char * ip_addr_str);
+    bool STDCALL does_interface_have_ip_address(size_t dev_index, char * ip_addr_str);
     
     ///
     /// Check whether mac_addr is the MAC Address for a device.
     ///
-    bool STDCALL find_selected_interface_by_mac_address(size_t dev_index, uint64_t mac_addr);
+    bool STDCALL does_interface_have_mac_address(size_t dev_index, uint64_t mac_addr);
 
     ///
     /// Get the corresponding network interface name by index.

--- a/controller/lib/src/linux/net_interface_imp.h
+++ b/controller/lib/src/linux/net_interface_imp.h
@@ -95,6 +95,11 @@ public:
     uint64_t mac_addr();
 
     ///
+    /// Get the MAC address of a network interface.
+    ///
+    uint64_t STDCALL get_dev_mac_addr_by_index(size_t dev_index);
+
+    ///
     /// Get network interface description by index.
     ///
     char * STDCALL get_dev_desc_by_index(size_t dev_index);
@@ -103,6 +108,16 @@ public:
     /// Get the corresponding network interface IP address by index.
     ///
     const char * STDCALL get_dev_ip_address_by_index(size_t dev_index, size_t ip_index);
+    
+    ///
+    /// Check whether ip_addr_str is a valid IP Address for a device.
+    ///
+    bool STDCALL find_selected_interface_by_ip_address(size_t dev_index, char * ip_addr_str);
+    
+    ///
+    /// Check whether mac_addr is the MAC Address for a device.
+    ///
+    bool STDCALL find_selected_interface_by_mac_address(size_t dev_index, uint64_t mac_addr);
 
     ///
     /// Get the corresponding network interface name by index.

--- a/controller/lib/src/msvc/net_interface_imp.cpp
+++ b/controller/lib/src/msvc/net_interface_imp.cpp
@@ -27,6 +27,7 @@
  * Network interface implementation class
  */
 
+#include <algorithm>
 #include <winsock2.h>
 #include <iphlpapi.h>
 #include "util.h"
@@ -62,8 +63,17 @@ net_interface_imp::net_interface_imp()
                 if (dev_addr->addr->sa_family == AF_INET && dev_addr->addr)
                 {
                     char ip_str[INET_ADDRSTRLEN] = {0};
-                    inet_ntop(AF_INET, &((struct sockaddr_in *)dev_addr->addr)->sin_addr, ip_str, INET_ADDRSTRLEN);
+                    struct sockaddr_in * sa = (struct sockaddr_in *)dev_addr->addr;
+                    inet_ntop(AF_INET, &sa->sin_addr, ip_str, INET_ADDRSTRLEN);
                     device_ip_addresses.push_back(std::string(ip_str));
+                    
+                    uint64_t dev_mac;
+                    ULONG len;
+                    uint8_t tmp[16];
+                    len = sizeof(tmp);
+                    SendARP(sa->sin_addr.S_un.S_addr, INADDR_ANY, tmp, &len);
+                    utility::convert_eui48_to_uint64(&tmp[0], dev_mac);
+                    all_mac_addresses.push_back(dev_mac);
                 }
             }
             
@@ -106,7 +116,7 @@ size_t STDCALL net_interface_imp::device_ip_address_count(size_t dev_index)
 
 uint64_t net_interface_imp::mac_addr()
 {
-    return mac;
+    return selected_dev_mac;
 }
 
 char * STDCALL net_interface_imp::get_dev_desc_by_index(size_t dev_index)
@@ -148,6 +158,37 @@ const char * STDCALL net_interface_imp::get_dev_ip_address_by_index(size_t dev_i
     }
     
     return NULL;
+}
+    
+bool STDCALL net_interface_imp::find_selected_interface_by_ip_address(size_t dev_index, char * ip_addr_str)
+{
+    if (dev_index < all_ip_addresses.size())
+    {
+        if (std::find(all_ip_addresses.at(dev_index).begin(), all_ip_addresses.at(dev_index).end(),
+                      std::string(ip_addr_str)) != all_ip_addresses.at(dev_index).end())
+            return true;
+    }
+    
+    return false;
+}
+
+bool STDCALL net_interface_imp::find_selected_interface_by_mac_address(size_t dev_index, uint64_t mac_addr)
+{
+    if (dev_index < all_mac_addresses.size())
+    {
+        if (all_mac_addresses.at(dev_index) == mac_addr)
+            return true;
+    }
+    
+    return false;
+}
+    
+uint64_t net_interface_imp::get_dev_mac_addr_by_index(size_t dev_index)
+{
+    if (dev_index < all_mac_addresses.size())
+        return all_mac_addresses.at(dev_index);
+    
+    return 0;
 }
 
 int STDCALL net_interface_imp::select_interface_by_num(uint32_t interface_num)
@@ -212,13 +253,13 @@ int STDCALL net_interface_imp::select_interface_by_num(uint32_t interface_num)
     {
         if (strstr(dev->name, Current->AdapterName) != 0)
         {
-            struct sockaddr_in sa;
-            ULONG len;
-            uint8_t tmp[16];
-            inet_pton(AF_INET, Current->IpAddressList.IpAddress.String, &(sa.sin_addr));
-            len = sizeof(tmp);
-            SendARP(sa.sin_addr.S_un.S_addr, INADDR_ANY, tmp, &len);
-            utility::convert_eui48_to_uint64(&tmp[0], mac);
+            if (index >= all_mac_addresses.size())
+            {
+                perror("Cannot find selected interface MAC address");
+                exit(EXIT_FAILURE);
+            }
+            
+            selected_dev_mac = all_mac_addresses.at(index);
         }
     }
 

--- a/controller/lib/src/msvc/net_interface_imp.cpp
+++ b/controller/lib/src/msvc/net_interface_imp.cpp
@@ -160,7 +160,7 @@ const char * STDCALL net_interface_imp::get_dev_ip_address_by_index(size_t dev_i
     return NULL;
 }
     
-bool STDCALL net_interface_imp::find_selected_interface_by_ip_address(size_t dev_index, char * ip_addr_str)
+bool STDCALL net_interface_imp::does_interface_have_ip_address(size_t dev_index, char * ip_addr_str)
 {
     if (dev_index < all_ip_addresses.size())
     {
@@ -172,7 +172,7 @@ bool STDCALL net_interface_imp::find_selected_interface_by_ip_address(size_t dev
     return false;
 }
 
-bool STDCALL net_interface_imp::find_selected_interface_by_mac_address(size_t dev_index, uint64_t mac_addr)
+bool STDCALL net_interface_imp::does_interface_have_mac_address(size_t dev_index, uint64_t mac_addr)
 {
     if (dev_index < all_mac_addresses.size())
     {

--- a/controller/lib/src/msvc/net_interface_imp.h
+++ b/controller/lib/src/msvc/net_interface_imp.h
@@ -43,9 +43,10 @@ class net_interface_imp : public net_interface
 {
 private:
     std::vector<std::vector<std::string> > all_ip_addresses;
+    std::vector<uint64_t> all_mac_addresses;
     pcap_if_t * all_devs;
     pcap_if_t * dev;
-    uint64_t mac;
+    uint64_t selected_dev_mac;
     uint32_t total_devs;
     pcap_t * pcap_interface;
     char err_buf[PCAP_ERRBUF_SIZE];
@@ -73,9 +74,14 @@ public:
     size_t STDCALL device_ip_address_count(size_t dev_index);
 
     ///
-    /// Get the MAC address of the network interface.
+    /// Get the MAC address of the selected network interface.
     ///
     uint64_t mac_addr();
+
+    ///
+    /// Get the MAC address of a network interface.
+    ///
+    uint64_t STDCALL get_dev_mac_addr_by_index(size_t dev_index);
 
     ///
     /// Get the corresponding network interface description by index.
@@ -86,6 +92,16 @@ public:
     /// Get the corresponding network interface IP address by index.
     ///
     const char * STDCALL get_dev_ip_address_by_index(size_t dev_index, size_t ip_index);
+    
+    ///
+    /// Check whether ip_addr_str is a valid IP Address for a device.
+    ///
+    bool STDCALL find_selected_interface_by_ip_address(size_t dev_index, char * ip_addr_str);
+    
+    ///
+    /// Check whether mac_addr is the MAC Address for a device.
+    ///
+    bool STDCALL find_selected_interface_by_mac_address(size_t dev_index, uint64_t mac_addr);
 
     ///
     /// Get the corresponding network interface name by index.

--- a/controller/lib/src/msvc/net_interface_imp.h
+++ b/controller/lib/src/msvc/net_interface_imp.h
@@ -96,12 +96,12 @@ public:
     ///
     /// Check whether ip_addr_str is a valid IP Address for a device.
     ///
-    bool STDCALL find_selected_interface_by_ip_address(size_t dev_index, char * ip_addr_str);
+    bool STDCALL does_interface_have_ip_address(size_t dev_index, char * ip_addr_str);
     
     ///
     /// Check whether mac_addr is the MAC Address for a device.
     ///
-    bool STDCALL find_selected_interface_by_mac_address(size_t dev_index, uint64_t mac_addr);
+    bool STDCALL does_interface_have_mac_address(size_t dev_index, uint64_t mac_addr);
 
     ///
     /// Get the corresponding network interface name by index.

--- a/controller/lib/src/osx/net_interface_imp.cpp
+++ b/controller/lib/src/osx/net_interface_imp.cpp
@@ -199,7 +199,7 @@ const char * STDCALL net_interface_imp::get_dev_ip_address_by_index(size_t dev_i
     return NULL;
 }
     
-bool STDCALL net_interface_imp::find_selected_interface_by_ip_address(size_t dev_index, char * ip_addr_str)
+bool STDCALL net_interface_imp::does_interface_have_ip_address(size_t dev_index, char * ip_addr_str)
 {
     if (dev_index < all_ip_addresses.size())
     {
@@ -211,7 +211,7 @@ bool STDCALL net_interface_imp::find_selected_interface_by_ip_address(size_t dev
     return false;
 }
     
-bool STDCALL net_interface_imp::find_selected_interface_by_mac_address(size_t dev_index, uint64_t mac_addr)
+bool STDCALL net_interface_imp::does_interface_have_mac_address(size_t dev_index, uint64_t mac_addr)
 {
     if (dev_index < all_mac_addresses.size())
     {

--- a/controller/lib/src/osx/net_interface_imp.h
+++ b/controller/lib/src/osx/net_interface_imp.h
@@ -103,12 +103,12 @@ public:
     ///
     /// Check whether ip_addr_str is a valid IP Address for a device.
     ///
-    bool STDCALL find_selected_interface_by_ip_address(size_t dev_index, char * ip_addr_str);
+    bool STDCALL does_interface_have_ip_address(size_t dev_index, char * ip_addr_str);
     
     ///
     /// Check whether mac_addr is the MAC Address for a device.
     ///
-    bool STDCALL find_selected_interface_by_mac_address(size_t dev_index, uint64_t mac_addr);
+    bool STDCALL does_interface_have_mac_address(size_t dev_index, uint64_t mac_addr);
 
     ///
     /// Get the corresponding network interface name by index.

--- a/controller/lib/src/osx/net_interface_imp.h
+++ b/controller/lib/src/osx/net_interface_imp.h
@@ -43,9 +43,10 @@ class net_interface_imp : public virtual net_interface
 {
 private:
     std::vector<std::vector<std::string> > all_ip_addresses;
+    std::vector<uint64_t> all_mac_addresses;
     pcap_if_t * all_devs;
     pcap_if_t * dev;
-    uint64_t mac;
+    uint64_t selected_dev_mac;
     uint32_t total_devs;
     pcap_t * pcap_interface;
     char err_buf[PCAP_ERRBUF_SIZE];
@@ -75,10 +76,20 @@ public:
     size_t STDCALL device_ip_address_count(size_t dev_index);
 
     ///
-    /// Get the MAC address of the network interface.
+    /// Get the MAC address of the selected network interface.
     ///
     uint64_t mac_addr();
 
+    ///
+    /// Find and store the MAC address string of a network interface.
+    ///
+    void find_and_store_device_mac_addr(char * dev_name);
+    
+    ///
+    /// Get the MAC address of a network interface.
+    ///
+    uint64_t STDCALL get_dev_mac_addr_by_index(size_t dev_index);
+    
     ///
     /// Get the corresponding network interface description by index.
     ///
@@ -88,6 +99,16 @@ public:
     /// Get the corresponding network interface IP address by index.
     ///
     const char * STDCALL get_dev_ip_address_by_index(size_t dev_index, size_t ip_index);
+    
+    ///
+    /// Check whether ip_addr_str is a valid IP Address for a device.
+    ///
+    bool STDCALL find_selected_interface_by_ip_address(size_t dev_index, char * ip_addr_str);
+    
+    ///
+    /// Check whether mac_addr is the MAC Address for a device.
+    ///
+    bool STDCALL find_selected_interface_by_mac_address(size_t dev_index, uint64_t mac_addr);
 
     ///
     /// Get the corresponding network interface name by index.


### PR DESCRIPTION
 1) Add MAC address to network interface list.
 2) Allow for an interface to be selected by IP Address or MAC via the -i command line argument
 2) Add command line argument -p to print the available interfaces and exit.