### PR TITLE
Fix for XMOS firmware upgrade issue

### DIFF
--- a/controller/lib/src/aecp_controller_state_machine.cpp
+++ b/controller/lib/src/aecp_controller_state_machine.cpp
@@ -163,7 +163,7 @@ int aecp_controller_state_machine::proc_resp(void *& notification_id, struct jdk
         callback(notification_id, notification_flag, cmd_frame->payload);
 
         // Restart the timer if response is indicating the operation is still in progress so that it won't be timed out
-        if (status == JDKSAVDECC_AECP_STATUS_IN_PROGRESS)
+        if (status == AEM_STATUS_IN_PROGRESS)
         {
             j->restart_timer();
         }

--- a/controller/lib/src/inflight.h
+++ b/controller/lib/src/inflight.h
@@ -66,6 +66,12 @@ public:
         cmd_timer.start(cmd_timeout_ms);
     }
 
+    inline void restart_timer()
+    {
+        cmd_timer.stop();
+        cmd_timer.start(cmd_timeout_ms);
+    }
+
     inline struct jdksavdecc_frame frame()
     {
         return cmd_frame;

--- a/controller/lib/src/linux/system_layer2_multithreaded_callback.cpp
+++ b/controller/lib/src/linux/system_layer2_multithreaded_callback.cpp
@@ -297,7 +297,12 @@ int system_layer2_multithreaded_callback::fn_netif(struct epoll_priv * priv)
         {
             int status = wait_mgr->set_completion_status(rx_status);
             assert(status == 0);
-            sem_post(waiting_sem);
+
+            // Only unlock the semaphore if the status is zero i.e. SUCCESS
+            if (rx_status == JDKSAVDECC_AECP_STATUS_SUCCESS)
+            {
+                sem_post(waiting_sem);
+            }
         }
     }
     return 0;

--- a/controller/lib/src/linux/system_layer2_multithreaded_callback.cpp
+++ b/controller/lib/src/linux/system_layer2_multithreaded_callback.cpp
@@ -299,7 +299,7 @@ int system_layer2_multithreaded_callback::fn_netif(struct epoll_priv * priv)
             assert(status == 0);
 
             // Only unlock the semaphore if the status is zero i.e. SUCCESS
-            if (rx_status == JDKSAVDECC_AECP_STATUS_SUCCESS)
+            if (rx_status == AEM_STATUS_SUCCESS)
             {
                 sem_post(waiting_sem);
             }


### PR DESCRIPTION
Fix for the XMOS firmware upgrade issue as reported in Issue #303: AECP in-progress responses in firmware upgrade should be polled rather than checked once.