### PR TITLE
cmdline - #287 - readline library fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,11 @@ Get the lib from github:
 Compile
 * cd avdecc-lib
 * cmake .
+
+* NOTE: the Readline library used by avdecccmdline can be specified via cmake.
+* NetBSD Editline (libedit) is the default, but the GNU Readline Library can be referenced by passing in 
+* the argument: -DUSE_GNU_READLINE=ON
+
 * make
 
 

--- a/controller/app/cmdline/CMakeLists.txt
+++ b/controller/app/cmdline/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required (VERSION 2.8)
 project (avdecc-lib_controller)
 enable_testing()
 
+option(USE_GNU_READLINE "Use GNU Readline" OFF)
+
 include_directories( src ../../lib/include ../../jdksavdecc-c/include )
 
 file(GLOB_RECURSE CMDLINE_INCLUDES "src/*.h" )
@@ -12,6 +14,9 @@ if(APPLE)
   add_executable (avdecccmdline ${CMDLINE_INCLUDES} ${CMDLINE_SRC})
   set(PCAP_NAME pcap)
   set(READLINE_NAME edit)
+  if(USE_GNU_READLINE)
+    add_definitions(-DUSE_GNU_READLINE)
+  endif(USE_GNU_READLINE)
 elseif(UNIX)
   add_executable (avdecccmdline ${CMDLINE_INCLUDES} ${CMDLINE_SRC})
   set(PCAP_NAME pcap)

--- a/controller/app/cmdline/src/cmd_line_main.cpp
+++ b/controller/app/cmdline/src/cmd_line_main.cpp
@@ -364,7 +364,9 @@ int main(int argc, char * argv[])
 #endif
 // Override to prevent filename completion
 #if defined(__MACH__)
-#if defined (READLINE_LIBRARY)
+
+// This macro can be set via cmake command line argument -DUSE_GNU_READLINE=ON
+#ifdef USE_GNU_READLINE
     // GNU Readline library
     rl_completion_entry_function = (rl_compentry_func_t *)null_completer;
 #else


### PR DESCRIPTION
 add optional cmake command line argument to use GNU Readline rather than default libedit