### PR TITLE
Quoted-Printable string encoding

### DIFF
--- a/controller/app/cmdline/src/cmd_line.cpp
+++ b/controller/app/cmdline/src/cmd_line.cpp
@@ -1181,9 +1181,9 @@ int cmd_line::cmd_list(int total_matched, std::vector<cli_argument *> args)
             uint64_t end_station_mac = end_station->mac();
             atomic_cout << (std::stringstream() << end_station->get_connection_status()
                                                 << std::setw(10) << std::dec << std::setfill(' ') << i << "  |  "
-                                                << std::setw(20) << std::hex << std::setfill(' ') << (ent_desc_resp ? end_station_name : "UNKNOWN") << "  |  0x"
+                                                << std::setw(20) << std::hex << std::setfill(' ') << (ent_desc_resp ? avdecc_lib::utility::qprintable_encode(end_station_name) : "UNKNOWN") << "  |  0x"
                                                 << std::setw(16) << std::hex << std::setfill('0') << end_station_entity_id << "  |  "
-                                                << std::setw(16) << std::hex << std::setfill(' ') << (ent_desc_resp ? fw_ver : "UNKNOWN") << "  |  "
+                                                << std::setw(16) << std::hex << std::setfill(' ') << (ent_desc_resp ? avdecc_lib::utility::qprintable_encode(fw_ver) : "UNKNOWN") << "  |  "
                                                 << std::setw(12) << std::hex << std::setfill('0') << end_station_mac)
                                .rdbuf()
                         << std::endl;

--- a/controller/lib/include/util.h
+++ b/controller/lib/include/util.h
@@ -145,6 +145,11 @@ namespace utility
     /// Convert an eui48 value to uint64_t.
     ///
     AVDECC_CONTROLLER_LIB32_API void convert_eui48_to_uint64(const uint8_t value[6], uint64_t & new_value);
+    
+    ///
+    /// Encode a string with Quoted-Printable encoding.
+    ///
+    AVDECC_CONTROLLER_LIB32_API const char * qprintable_encode(const char * input_cstr);
 
     /* 6 byte mac address in network byte order */
     class MacAddr

--- a/controller/lib/src/util.cpp
+++ b/controller/lib/src/util.cpp
@@ -639,5 +639,33 @@ namespace utility
             new_value |= (uint64_t)value[i] << ((5 - i) * 8);
         }
     }
+    
+    const char * qprintable_encode(const char * input_cstr)
+    {
+        std::string input_str(input_cstr);
+        static std::string output;
+        output.clear();
+        
+        char byte;
+        const char hex[] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
+        
+        for (int i = 0; i < input_str.length() ; ++i)
+        {
+            byte = input_str[i];
+            
+            if ((byte == 0x20) || ((byte >= 33) && (byte <= 126) && (byte != 61)))
+            {
+                output += byte;
+            }
+            else
+            {
+                output += '=';
+                output += hex[((byte >> 4) & 0x0F)];
+                output += hex[(byte & 0x0F)];
+            }
+        }
+        
+        return output.c_str();
+    }
 }
 }


### PR DESCRIPTION
- Add utility API
```c++
    ///
    /// Encode a string with Quoted-Printable encoding.
    ///
    AVDECC_CONTROLLER_LIB32_API const char * qprintable_encode(const char * input_cstr);
```
- Encode avdecccmdline cmd_list() strings 