### PR TITLE
store 1722.1 get_ cmd response buffers in a map

### DIFF
--- a/controller/lib/include/response_frame.h
+++ b/controller/lib/include/response_frame.h
@@ -33,37 +33,43 @@
 #include <stdint.h>
 #include <cstring>
 #include <assert.h>
+#include <map>
 
 namespace avdecc_lib
 {
+struct cmd_resp_frame_info
+{
+    uint8_t * buffer;
+    size_t frame_size;
+    size_t position;
+    
+    cmd_resp_frame_info(uint8_t * buf, size_t f_size, size_t pos) :
+        buffer(buf), frame_size(f_size), position(pos) {}
+    
+};
 class response_frame
 {
 public:
     response_frame(const uint8_t * frame, size_t size, size_t pos);
     virtual ~response_frame();
+private:
+    // <key, value> : <command type, command response frame info>
+    std::map<uint16_t, struct cmd_resp_frame_info * > cmd_resp_buffers;
 
-    //
-    // Buffer to store counters and command response frames.  Will be updated
-    // by command response processing methods.
-    //
-    uint8_t * buffer;
     //
     // Buffer to store descriptor response frames.  Will be updated by
     // update_desc_database() method in configuration descriptor.
     //
     uint8_t * desc_buffer;
-    size_t frame_size;
     size_t desc_frame_size;
-    size_t position;
     size_t desc_position;
 
-    int replace_frame(const uint8_t * frame, size_t pos, size_t size);
+public:
+    struct cmd_resp_frame_info * get_cmd_resp_frame_info(uint16_t cmd_type);
+    int store_cmd_resp_frame(uint16_t cmd_type, const uint8_t * frame, size_t pos, size_t size);
     int replace_desc_frame(const uint8_t * frame, size_t pos, size_t size);
-    uint8_t * get_buffer();
     uint8_t * get_desc_buffer();
-    size_t get_pos();
     size_t get_desc_pos();
-    size_t get_size();
     size_t get_desc_size();
 };
 }

--- a/controller/lib/src/descriptor_base_imp.h
+++ b/controller/lib/src/descriptor_base_imp.h
@@ -105,7 +105,7 @@ public:
     ///
     /// Replace the frame for counters/commands.
     ///
-    virtual void STDCALL replace_frame(const uint8_t * frame, ssize_t pos, size_t size);
+    virtual void STDCALL store_cmd_resp_frame(uint16_t cmd_type, const uint8_t * frame, ssize_t pos, size_t size);
 
     ///
     /// Replace the frame for descriptors.

--- a/controller/lib/src/response_frame.cpp
+++ b/controller/lib/src/response_frame.cpp
@@ -56,7 +56,7 @@ response_frame::~response_frame()
 
     free(desc_buffer);
 }
-    
+
 int response_frame::store_cmd_resp_frame(uint16_t cmd_type, const uint8_t *frame, size_t pos, size_t size)
 {
     uint8_t * buffer = NULL;

--- a/controller/lib/src/stream_output_descriptor_imp.cpp
+++ b/controller/lib/src/stream_output_descriptor_imp.cpp
@@ -60,29 +60,45 @@ stream_output_descriptor_response * STDCALL stream_output_descriptor_imp::get_st
 stream_output_get_stream_format_response * STDCALL stream_output_descriptor_imp::get_stream_output_get_stream_format_response()
 {
     std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
-    return get_format_resp = new stream_output_get_stream_format_response_imp(resp_ref->get_buffer(),
-                                                                              resp_ref->get_size(), resp_ref->get_pos());
+    struct cmd_resp_frame_info * resp_frame = resp_ref->get_cmd_resp_frame_info(AEM_CMD_GET_STREAM_FORMAT);
+    if (!resp_frame)
+        return NULL;
+
+    return get_format_resp = new stream_output_get_stream_format_response_imp(resp_frame->buffer,
+                                                                              resp_frame->frame_size, resp_frame->position);
 }
 
 stream_output_get_stream_info_response * STDCALL stream_output_descriptor_imp::get_stream_output_get_stream_info_response()
 {
     std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
-    return get_info_resp = new stream_output_get_stream_info_response_imp(resp_ref->get_buffer(),
-                                                                          resp_ref->get_size(), resp_ref->get_pos());
+    struct cmd_resp_frame_info * resp_frame = resp_ref->get_cmd_resp_frame_info(AEM_CMD_GET_STREAM_INFO);
+    if (!resp_frame)
+        return NULL;
+
+    return get_info_resp = new stream_output_get_stream_info_response_imp(resp_frame->buffer,
+                                                                          resp_frame->frame_size, resp_frame->position);
 }
 
 stream_output_get_tx_state_response * STDCALL stream_output_descriptor_imp::get_stream_output_get_tx_state_response()
 {
     std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
-    return get_tx_state_resp = new stream_output_get_tx_state_response_imp(resp_ref->get_buffer(),
-                                                                           resp_ref->get_size(), resp_ref->get_pos());
+    struct cmd_resp_frame_info * resp_frame = resp_ref->get_cmd_resp_frame_info(GET_TX_STATE_RESPONSE);
+    if (!resp_frame)
+        return NULL;
+
+    return get_tx_state_resp = new stream_output_get_tx_state_response_imp(resp_frame->buffer,
+                                                                           resp_frame->frame_size, resp_frame->position);
 }
 
 stream_output_get_tx_connection_response * STDCALL stream_output_descriptor_imp::get_stream_output_get_tx_connection_response()
 {
     std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
-    return get_tx_connection_resp = new stream_output_get_tx_connection_response_imp(resp_ref->get_buffer(),
-                                                                                     resp_ref->get_size(), resp_ref->get_pos());
+    struct cmd_resp_frame_info * resp_frame = resp_ref->get_cmd_resp_frame_info(GET_TX_CONNECTION_RESPONSE);
+    if (!resp_frame)
+        return NULL;
+
+    return get_tx_connection_resp = new stream_output_get_tx_connection_response_imp(resp_frame->buffer,
+                                                                                     resp_frame->frame_size, resp_frame->position);
 }
 
 int STDCALL stream_output_descriptor_imp::send_set_stream_format_cmd(void * notification_id, uint64_t new_stream_format)
@@ -234,7 +250,7 @@ int stream_output_descriptor_imp::proc_get_stream_format_resp(void *& notificati
         return -1;
     }
 
-    replace_frame(frame, ETHER_HDR_SIZE, frame_len);
+    store_cmd_resp_frame(AEM_CMD_GET_STREAM_FORMAT, frame, ETHER_HDR_SIZE, frame_len);
 
     msg_type = aem_cmd_get_stream_format_resp.aem_header.aecpdu_header.header.message_type;
     status = aem_cmd_get_stream_format_resp.aem_header.aecpdu_header.header.status;
@@ -353,7 +369,7 @@ int stream_output_descriptor_imp::proc_set_stream_info_resp(void *& notification
         return -1;
     }
 
-    replace_frame(frame, ETHER_HDR_SIZE, frame_len);
+    store_cmd_resp_frame(AEM_CMD_GET_STREAM_INFO, frame, ETHER_HDR_SIZE, frame_len);
 
     msg_type = aem_cmd_set_stream_info_resp.aem_header.aecpdu_header.header.message_type;
     status = aem_cmd_set_stream_info_resp.aem_header.aecpdu_header.header.status;
@@ -429,7 +445,7 @@ int stream_output_descriptor_imp::proc_get_stream_info_resp(void *& notification
         return -1;
     }
 
-    replace_frame(frame, ETHER_HDR_SIZE, frame_len);
+    store_cmd_resp_frame(AEM_CMD_GET_STREAM_INFO, frame, ETHER_HDR_SIZE, frame_len);
 
     msg_type = aem_cmd_get_stream_info_resp.aem_header.aecpdu_header.header.message_type;
     status = aem_cmd_get_stream_info_resp.aem_header.aecpdu_header.header.status;
@@ -646,7 +662,7 @@ int stream_output_descriptor_imp::proc_get_tx_state_resp(void *& notification_id
         return -1;
     }
 
-    replace_frame(frame, ETHER_HDR_SIZE, frame_len);
+    store_cmd_resp_frame(GET_TX_STATE_RESPONSE, frame, ETHER_HDR_SIZE, frame_len);
 
     status = acmp_cmd_get_tx_state_resp.header.status;
 
@@ -715,7 +731,7 @@ int stream_output_descriptor_imp::proc_get_tx_connection_resp(void *& notificati
         return -1;
     }
 
-    replace_frame(frame, ETHER_HDR_SIZE, frame_len);
+    store_cmd_resp_frame(GET_TX_CONNECTION_RESPONSE, frame, ETHER_HDR_SIZE, frame_len);
 
     status = acmp_cmd_get_tx_connection_resp.header.status;
 

--- a/controller/lib/src/stream_port_input_descriptor_imp.cpp
+++ b/controller/lib/src/stream_port_input_descriptor_imp.cpp
@@ -55,8 +55,12 @@ stream_port_input_descriptor_response * STDCALL stream_port_input_descriptor_imp
 stream_port_input_get_audio_map_response * STDCALL stream_port_input_descriptor_imp::get_stream_port_input_audio_map_response()
 {
     std::lock_guard<std::mutex> guard(base_end_station_imp_ref->locker); //mutex lock end station
-    return audio_map_resp = new stream_port_input_get_audio_map_response_imp(resp_ref->get_buffer(),
-                                                                             resp_ref->get_size(), resp_ref->get_pos());
+    struct cmd_resp_frame_info * resp_frame = resp_ref->get_cmd_resp_frame_info(AEM_CMD_GET_AUDIO_MAP);
+    if (!resp_frame)
+        return NULL;
+
+    return audio_map_resp = new stream_port_input_get_audio_map_response_imp(resp_frame->buffer,
+                                                                             resp_frame->frame_size, resp_frame->position);
 }
 
 int stream_port_input_descriptor_imp::store_pending_map(struct audio_map_mapping & map)
@@ -157,7 +161,7 @@ int stream_port_input_descriptor_imp::proc_get_audio_map_resp(void *& notificati
         return -1;
     }
 
-    replace_frame(frame, ETHER_HDR_SIZE, frame_len);
+    store_cmd_resp_frame(AEM_CMD_GET_AUDIO_MAP, frame, ETHER_HDR_SIZE, frame_len);
 
     msg_type = aem_cmd_get_audio_map_resp.aem_header.aecpdu_header.header.message_type;
     status = aem_cmd_get_audio_map_resp.aem_header.aecpdu_header.header.status;


### PR DESCRIPTION
Store get_ command response buffers in a map by command type so client code can asynchronously send and process multiple commands per descriptor. 