### PR TITLE
Fix get_tx_connection API

### DIFF
--- a/controller/app/cmdline/src/cmd_line.cpp
+++ b/controller/app/cmdline/src/cmd_line.cpp
@@ -655,6 +655,7 @@ void cmd_line::cmd_line_commands_init()
         &cmd_line::cmd_get_tx_connection);
     get_tx_connection_fmt->add_argument(new cli_argument_end_station(this, "s_e_s", SRC_END_STATION_HELP));
     get_tx_connection_fmt->add_argument(new cli_argument_int(this, "s_d_i", "the source descriptor index"));
+    get_tx_connection_fmt->add_argument(new cli_argument_int(this, "c_i", "the connection index"));
     get_tx_connection_cmd->add_format(get_tx_connection_fmt);
 
     // entity
@@ -3141,6 +3142,7 @@ int cmd_line::cmd_get_tx_connection(int total_matched, std::vector<cli_argument 
 {
     uint32_t outstream_end_station_index = args[0]->get_value_uint();
     uint16_t outstream_desc_index = args[1]->get_value_int();
+    uint16_t connection_index = args[2]->get_value_int();
     avdecc_lib::configuration_descriptor * configuration = controller_obj->get_current_config_desc(outstream_end_station_index, false);
     bool is_valid = (configuration &&
                      (outstream_end_station_index < controller_obj->get_end_station_count()) &&
@@ -3151,7 +3153,7 @@ int cmd_line::cmd_get_tx_connection(int total_matched, std::vector<cli_argument 
         intptr_t cmd_notification_id = get_next_notification_id();
         sys->set_wait_for_next_cmd((void *)cmd_notification_id);
         avdecc_lib::stream_output_descriptor * outstream = configuration->get_stream_output_desc_by_index(outstream_desc_index);
-        outstream->send_get_tx_connection_cmd((void *)cmd_notification_id, 0, 0);
+        outstream->send_get_tx_connection_cmd((void *)cmd_notification_id, connection_index);
         int status = sys->get_last_resp_status();
 
         if (status == avdecc_lib::ACMP_STATUS_SUCCESS)

--- a/controller/lib/include/stream_output_descriptor.h
+++ b/controller/lib/include/stream_output_descriptor.h
@@ -158,16 +158,10 @@ public:
     /// Send a GET_TX_CONNECTION command with a notification id to get a specific Talker connection information.
     ///
     /// \param notification_id A void pointer to the unique identifier associated with the command.
-    /// \param talker_entity_id The Talker Entity ID used to identify the AVDECC Talker being targed by
-    ///                    the command. In the case of Talker commands, this is the AVDECC Entity
-    ///                    receiving the command. In the case of Listener commands, this is the
-    ///                    AVDECC Entity that any Talker command is to be sent to. This field is
-    ///                    either the Entity ID of the AVDECC Entity being targets to or 0.
-    /// \param talker_unique_id The Talker Unique ID is used to uniquely identify the stream source
-    ///                         of the AVDECC Talker. For entities using the AVDECC Entity Model,
-    ///                         this corresponds to the id of the STREAM OUTPUT descriptor.
+    /// \param connection_index The Index of the connection which is the target of the command (the first
+    ///                         connection of the list has index 0).
     /// \return Returns 0 on success.
     ///
-    AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_get_tx_connection_cmd(void * notification_id, uint64_t listener_entity_id, uint16_t listener_unique_id) = 0;
+    AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_get_tx_connection_cmd(void * notification_id, uint16_t connection_index) = 0;
 };
 }

--- a/controller/lib/src/stream_output_descriptor_imp.cpp
+++ b/controller/lib/src/stream_output_descriptor_imp.cpp
@@ -671,7 +671,7 @@ int stream_output_descriptor_imp::proc_get_tx_state_resp(void *& notification_id
     return 0;
 }
 
-int STDCALL stream_output_descriptor_imp::send_get_tx_connection_cmd(void * notification_id, uint64_t listener_entity_id, uint16_t listener_unique_id)
+int STDCALL stream_output_descriptor_imp::send_get_tx_connection_cmd(void * notification_id, uint16_t connection_index)
 {
     entity_descriptor_response * entity_resp_ref = base_end_station_imp_ref->get_entity_desc_by_index(0)->get_entity_response();
     struct jdksavdecc_frame cmd_frame;
@@ -682,11 +682,11 @@ int STDCALL stream_output_descriptor_imp::send_get_tx_connection_cmd(void * noti
     /********************************************* ACMP Common Data *********************************************/
     acmp_cmd_get_tx_connection.controller_entity_id = base_end_station_imp_ref->get_adp()->get_controller_entity_id();
     jdksavdecc_uint64_write(talker_entity_id, &acmp_cmd_get_tx_connection.talker_entity_id, 0, sizeof(uint64_t));
-    jdksavdecc_uint64_write(listener_entity_id, &acmp_cmd_get_tx_connection.listener_entity_id, 0, sizeof(uint64_t));
+    jdksavdecc_uint64_write(0, &acmp_cmd_get_tx_connection.listener_entity_id, 0, sizeof(uint64_t));
     acmp_cmd_get_tx_connection.talker_unique_id = descriptor_index();
-    acmp_cmd_get_tx_connection.listener_unique_id = listener_unique_id;
+    acmp_cmd_get_tx_connection.listener_unique_id = 0;
     jdksavdecc_eui48_init(&acmp_cmd_get_tx_connection.stream_dest_mac);
-    acmp_cmd_get_tx_connection.connection_count = 0;
+    acmp_cmd_get_tx_connection.connection_count = connection_index;
     // Fill acmp_cmd_get_tx_connection.sequence_id in AEM Controller State Machine
     acmp_cmd_get_tx_connection.flags = 0;
     acmp_cmd_get_tx_connection.stream_vlan_id = 0;

--- a/controller/lib/src/stream_output_descriptor_imp.h
+++ b/controller/lib/src/stream_output_descriptor_imp.h
@@ -87,7 +87,7 @@ public:
     int STDCALL send_get_tx_state_cmd(void * notification_id);
     int proc_get_tx_state_resp(void *& notification_id, const uint8_t * frame, size_t frame_len, int & status);
 
-    int STDCALL send_get_tx_connection_cmd(void * notification_id, uint64_t listener_entity_id, uint16_t listener_unique_id);
+    int STDCALL send_get_tx_connection_cmd(void * notification_id, uint16_t connection_index);
     int proc_get_tx_connection_resp(void *& notification_id, const uint8_t * frame, size_t frame_len, int & status);
 };
 }


### PR DESCRIPTION
1. Connection_count was hardcoded to 0 
2. Listener GUID and Listener stream index were provided as arguments
(They are always '00:00:00:00:00:00:00:00' and '0' for a get_tx_connection commands)