### PR TITLE
end station - ACMP - check entity_desc_vec size to avoid std::vector out_of_range exception

### DIFF
--- a/controller/lib/src/end_station_imp.cpp
+++ b/controller/lib/src/end_station_imp.cpp
@@ -1927,6 +1927,12 @@ int end_station_imp::proc_rcvd_acmp_resp(uint32_t msg_type, void *& notification
     entity_descriptor_imp * e = nullptr;
     uint16_t desc_index = 0;
 
+    if (current_entity_desc >= entity_desc_vec.size())
+    {
+        log_imp_ref->post_log_msg(LOGGING_LEVEL_ERROR, "proc_rcvd_acmp_resp entity desc not present, skipping");
+        return 0;
+    }
+    
     e = entity_desc_vec.at(current_entity_desc);
     if (e)
     {


### PR DESCRIPTION
Fixes the scenario where an unsolicited ACMP response is processed before the Entity Descriptor is stored.