### PR TITLE
Vfr/staging

### DIFF
--- a/controller/lib/src/aecp_controller_state_machine.cpp
+++ b/controller/lib/src/aecp_controller_state_machine.cpp
@@ -257,11 +257,11 @@ int aecp_controller_state_machine::update_inflight_for_rcvd_resp(void *& notific
     case JDKSAVDECC_AECP_MESSAGE_TYPE_ADDRESS_ACCESS_RESPONSE: // Fallthrough intentional
         if (u_field)
         {
-            state_rcvd_unsolicited(cmd_frame);
+            return state_rcvd_unsolicited(cmd_frame);
         }
         else
         {
-            state_rcvd_resp(notification_id, cmd_frame);
+            return state_rcvd_resp(notification_id, cmd_frame);
         }
         break;
     default:

--- a/controller/lib/src/end_station_imp.cpp
+++ b/controller/lib/src/end_station_imp.cpp
@@ -814,13 +814,17 @@ int end_station_imp::proc_rcvd_aem_resp(void *& notification_id,
     {
         if (current_entity_desc >= entity_desc_vec.size())
         {
-            log_imp_ref->post_log_msg(LOGGING_LEVEL_ERROR, "proc_rcvd_aem_resp entity desc not present, skipping");
+            log_imp_ref->post_log_msg(LOGGING_LEVEL_ERROR, "proc_rcvd_aem_resp (0x%llx, %s) entity desc not present, skipping",
+                                      end_station_entity_id,
+                                      utility::aem_cmd_value_to_name(cmd_type));
             return 0;
         }
         
         if (current_config_desc >= entity_desc_vec.at(current_entity_desc)->config_desc_count())
         {
-            log_imp_ref->post_log_msg(LOGGING_LEVEL_ERROR, "proc_rcvd_aem_resp config desc not present, skipping");
+            log_imp_ref->post_log_msg(LOGGING_LEVEL_ERROR, "proc_rcvd_aem_resp (0x%llx, %s) config desc not present, skipping",
+                                      end_station_entity_id,
+                                      utility::aem_cmd_value_to_name(cmd_type));
             return 0;
         }
     }

--- a/controller/lib/src/end_station_imp.cpp
+++ b/controller/lib/src/end_station_imp.cpp
@@ -234,7 +234,15 @@ int end_station_imp::proc_read_desc_resp(void *& notification_id, const uint8_t 
     status = aem_cmd_read_desc_resp.aem_header.aecpdu_header.header.status;
     u_field = aem_cmd_read_desc_resp.aem_header.command_type >> 15 & 0x01; // u_field = the msb of the uint16_t command_type
 
-    aecp_controller_state_machine_ref->update_inflight_for_rcvd_resp(notification_id, msg_type, u_field, &cmd_frame);
+    int retval = aecp_controller_state_machine_ref->update_inflight_for_rcvd_resp(notification_id, msg_type, u_field, &cmd_frame);
+    if (retval == -1)
+    {
+        log_imp_ref->post_log_msg(LOGGING_LEVEL_DEBUG, "0x%llx, aem_cmd_read_desc_resp (%s, %d).  Not found in inflight - skipping",
+                                  end_station_entity_id,
+                                  utility::aem_desc_value_to_name(desc_type), desc_index);
+
+        return 0;
+    }
 
     bool store_descriptor = false;
     if (status == avdecc_lib::AEM_STATUS_SUCCESS)

--- a/controller/lib/src/entity_descriptor_imp.h
+++ b/controller/lib/src/entity_descriptor_imp.h
@@ -41,7 +41,7 @@ namespace avdecc_lib
 class entity_descriptor_imp : public entity_descriptor, public virtual descriptor_base_imp
 {
 private:
-    std::vector<configuration_descriptor_imp *> config_desc_vec;                       // Store a list of CONFIGURATION descriptor objects
+    std::map<uint16_t, configuration_descriptor_imp *> config_desc_map;                // Store a map of CONFIGURATION descriptor objects
     struct jdksavdecc_aem_command_acquire_entity_response aem_cmd_acquire_entity_resp; // Store the response received after sending a ACQUIRE_ENTITY command.
     struct jdksavdecc_aem_command_lock_entity_response aem_cmd_lock_entity_resp;       // Store the response received after sending a LOCK_ENTITY command.
     struct jdksavdecc_aem_command_reboot_response aem_cmd_reboot_resp;


### PR DESCRIPTION
- entity_descriptor_imp : config_desc_vec -> config_desc_map 
- READ_DESCRIPTOR  : discard responses with sequence ids not found in the inflight vector (avoiding unnecessary background descriptor discovery)
- error logging changes