### PR TITLE
Fix segfaults on timeout and invalid audio unit index

### DIFF
--- a/controller/app/cmdline/src/cmd_line.cpp
+++ b/controller/app/cmdline/src/cmd_line.cpp
@@ -3097,7 +3097,7 @@ int cmd_line::cmd_show_connections(int total_matched, std::vector<cli_argument *
         {
             avdecc_lib::stream_input_descriptor * instream = in_descriptor->get_stream_input_desc_by_index(in_stream_index);
             avdecc_lib::stream_input_get_rx_state_response * stream_input_resp_ref = instream->get_stream_input_get_rx_state_response();
-            if (!stream_input_resp_ref->get_rx_state_connection_count())
+            if (!stream_input_resp_ref || !stream_input_resp_ref->get_rx_state_connection_count())
             {
                 delete stream_input_resp_ref;
                 continue;
@@ -3118,7 +3118,8 @@ int cmd_line::cmd_show_connections(int total_matched, std::vector<cli_argument *
                     avdecc_lib::stream_input_get_rx_state_response * stream_input_resp_ref = instream->get_stream_input_get_rx_state_response();
                     avdecc_lib::stream_output_descriptor * outstream = out_descriptor->get_stream_output_desc_by_index(out_stream_index);
                     avdecc_lib::stream_output_get_tx_state_response * stream_output_resp_ref = outstream->get_stream_output_get_tx_state_response();
-                    if (!stream_output_resp_ref->get_tx_state_connection_count() ||
+                    if (!stream_output_resp_ref || !stream_input_resp_ref ||
+                        !stream_output_resp_ref->get_tx_state_connection_count() ||
                         (stream_input_resp_ref->get_rx_state_stream_id() != stream_output_resp_ref->get_tx_state_stream_id()))
                     {
                         delete stream_input_resp_ref;

--- a/controller/app/cmdline/src/cmd_line.cpp
+++ b/controller/app/cmdline/src/cmd_line.cpp
@@ -4496,9 +4496,12 @@ int cmd_line::cmd_set_sampling_rate(int total_matched, std::vector<cli_argument 
 
     if (desc_type_value == avdecc_lib::AEM_DESC_AUDIO_UNIT)
     {
+        avdecc_lib::audio_unit_descriptor * audio_unit_desc_ref = configuration->get_audio_unit_desc_by_index(desc_index);
+        if (!audio_unit_desc_ref)
+            return 0;
         intptr_t cmd_notification_id = get_next_notification_id();
         sys->set_wait_for_next_cmd((void *)cmd_notification_id);
-        avdecc_lib::audio_unit_descriptor * audio_unit_desc_ref = configuration->get_audio_unit_desc_by_index(desc_index);
+
         audio_unit_desc_ref->send_set_sampling_rate_cmd((void *)cmd_notification_id, new_sampling_rate);
         int status = sys->get_last_resp_status();
 
@@ -4542,9 +4545,12 @@ int cmd_line::cmd_get_sampling_rate(int total_matched, std::vector<cli_argument 
 
     if (desc_type_value == avdecc_lib::AEM_DESC_AUDIO_UNIT)
     {
+        avdecc_lib::audio_unit_descriptor * audio_unit_desc_ref = configuration->get_audio_unit_desc_by_index(desc_index);
+        if (!audio_unit_desc_ref)
+            return 0;
         intptr_t cmd_notification_id = get_next_notification_id();
         sys->set_wait_for_next_cmd((void *)cmd_notification_id);
-        avdecc_lib::audio_unit_descriptor * audio_unit_desc_ref = configuration->get_audio_unit_desc_by_index(desc_index);
+
         audio_unit_desc_ref->send_get_sampling_rate_cmd((void *)cmd_notification_id);
         int status = sys->get_last_resp_status();
 


### PR DESCRIPTION
Fix segfaults on commands
a) show connections -> on timeout of GET_RX_STATE_COMMAND
b) get sampling_rate AUDIO_UNIT 3 -> on non existing index