### PR TITLE
Absolute submodule URL.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "jdksavdecc-c"]
 	path = jdksavdecc-c
-	url = ../../jdkoftinoff/jdksavdecc-c.git
+	url = https://github.com/jdkoftinoff/jdksavdecc-c.git


### PR DESCRIPTION
Forking into a non-Github environment breaks the old submodule
configuration. Use an absolute URL to make forkers happy. :smile: 